### PR TITLE
docs(i18n): fixed i18n flickering + commented out the language switcher component

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,5 +88,8 @@
         "imagemin-jpegtran": "7.0.0",
         "next-compose-plugins": "^2.2.1",
         "ts-node": "9.1.1"
+    },
+    "engines": {
+        "node": ">=14"
     }
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,4 +1,4 @@
-import { useTranslation } from 'react-i18next';
+import { t } from 'utils/i18n';
 import {
   Box,
   BoxProps,
@@ -112,7 +112,6 @@ interface HomePageProps {
 }
 
 const HomePage = ({ members, sponsors, githubStars }: HomePageProps) => {
-  const { t } = useTranslation();
   return (
     <>
       <SEO

--- a/pages/team.tsx
+++ b/pages/team.tsx
@@ -19,9 +19,9 @@ import PageTransition from 'components/page-transition';
 import SEO from 'components/seo';
 import fs from 'fs';
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
 import { IoIosGlobe, IoLogoGithub, IoLogoTwitter } from 'react-icons/io';
 import { Contributor, Member as IMember } from 'src/types/github';
+import { t } from 'utils/i18n';
 
 function SocialLink({ icon, href }) {
   return (
@@ -86,7 +86,6 @@ interface TeamProps {
 }
 
 function Team({ members, contributors }: TeamProps) {
-  const { t } = useTranslation();
   const memberLogins = members.map(({ login }) => login);
   const contributorsWithoutTeam = contributors.filter(
     ({ login }) => !memberLogins.includes(login)

--- a/src/components/language-switcher.tsx
+++ b/src/components/language-switcher.tsx
@@ -40,10 +40,13 @@ const LanguageSwitcher = ({ withLabel }: Props) => {
     });
   };
 
-  if (!process.env.ENABLE_LANGUAGE_SWITCHER) {
-    return <></>;
-  }
+  // if (!process.env.ENABLE_LANGUAGE_SWITCHER) {
+  //   return <></>;
+  // }
 
+  return <></>;
+
+  /* TODO: uncomment the following block when another language gets added
   const selectedLanguage = i18n.language
     ? locales.locales.find((loc) => loc.startsWith(i18n.language))
     : locales.defaultLocale;
@@ -70,6 +73,7 @@ const LanguageSwitcher = ({ withLabel }: Props) => {
       </MenuList>
     </Menu>
   );
+  */
 };
 
 export default LanguageSwitcher;

--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -1,0 +1,7 @@
+import { get } from 'lodash';
+import uiJson from '../../i18n/ui.json';
+
+export function t(str: string) {
+  // TODO: load the locale appropriate ui.json file
+  return get(uiJson, str);
+}


### PR DESCRIPTION
Closes #17

## 📝 Description

This PR removes on-demand loading of i18n strings, therefore it fixes the localized string flickering. A better i18n implementation should be worked out in future.

## ⛳️ Current behavior (updates)

Homepage title (and more strings in team page) flicker before i18n loads the strings in memory.

## 🚀 New behavior

No flickering

## 💣 Is this a breaking change (Yes/No):

No