### PR TITLE
Docs/correct navigation of pages

### DIFF
--- a/configs/docs-sidebar.json
+++ b/configs/docs-sidebar.json
@@ -182,17 +182,17 @@
               "path": "/docs/form/radio"
             },
             {
+              "new": true,
+              "title": "Range Slider",
+              "path": "/docs/form/range-slider"
+            },
+            {
               "title": "Select",
               "path": "/docs/form/select"
             },
             {
               "title": "Slider",
               "path": "/docs/form/slider"
-            },
-            {
-              "new": true,
-              "title": "Range Slider",
-              "path": "/docs/form/range-slider"
             },
             {
               "title": "Switch",

--- a/pages/docs/getting-started.mdx
+++ b/pages/docs/getting-started.mdx
@@ -18,7 +18,7 @@ for you to get up and running with Chakra UI.
 
 ## Direct integrations
 
-If you're working without any of the frameworks above, you can install Chakra UI using the
+If you're working without any of the frameworks above, install Chakra UI using the
 steps below
 
 ### Installation


### PR DESCRIPTION
Closes #20 

## 📝 Description

> Add a brief description

## ⛳️ Current behavior (updates)

The navigation was from Radio > Select and then Slider > Range Slider

## 🚀 New behavior

Pages route correctly from Radio > Range Slider and Slider > Switch

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
