### PR TITLE
docs: remove flags from language switcher and add a generic language …

### DIFF
--- a/src/components/language-switcher.tsx
+++ b/src/components/language-switcher.tsx
@@ -1,8 +1,8 @@
-import getUnicodeFlagIcon from 'country-flag-icons/unicode';
 import { useTranslation } from 'react-i18next';
 import locales from '../../i18n/locales';
 import {
   chakra,
+  Box,
   Menu,
   MenuItem,
   MenuButton,
@@ -13,6 +13,7 @@ import {
   useColorModeValue as mode,
 } from '@chakra-ui/react';
 import { useRouter } from 'next/router';
+import { MdLanguage } from 'react-icons/md';
 import { ChevronDownIcon } from '@chakra-ui/icons';
 
 type Props = {
@@ -54,9 +55,7 @@ const LanguageSwitcher = ({ withLabel }: Props) => {
   return (
     <Menu>
       <MenuButton as={Button} variant='ghost' rightIcon={<ChevronDownIcon />}>
-        {selectedLanguage
-          ? getUnicodeFlagIcon(selectedLanguage.split('-')[1])
-          : getUnicodeFlagIcon('US')}
+        <Box as={MdLanguage} display='inline' fontSize='1.25rem' />
         {withLabel && (
           <chakra.span ml={2}>
             {locales.localeNames[selectedLanguage]}
@@ -66,7 +65,6 @@ const LanguageSwitcher = ({ withLabel }: Props) => {
       <MenuList color={mode('gray.800', 'white')}>
         {locales.locales.map((locale) => (
           <MenuItem key={locale} onClick={() => changeLanguage(locale)}>
-            {getUnicodeFlagIcon(locale.split('-')[1])}
             <Text ml={2}>{locales.localeNames[locale]}</Text>
           </MenuItem>
         ))}


### PR DESCRIPTION
Closes #35 

## 📝 Description

Replace flag icons in `LanguageSwitcher` component with a generic language icon. 

## ⛳️ Current behavior (updates)

> **With Label**

![before_with-label](https://user-images.githubusercontent.com/57777349/141080104-3a45dadc-bbfe-448d-87b9-5aa72553e3d4.png)

> **Without Label* 

![before_without-label](https://user-images.githubusercontent.com/57777349/141080164-07587eab-d468-411d-8dc0-cc0b82238a36.png)


## 🚀 New behavior

> **With Label**

![after_with-label](https://user-images.githubusercontent.com/57777349/141080220-cfcf6f95-09da-4005-96b1-93536bcbd266.png)

> **Without Label* 

![after_without-label](https://user-images.githubusercontent.com/57777349/141080239-f344dff4-6774-4412-84cb-673c059c9117.png)

## 💣 Is this a breaking change (Yes/No):

No
