### PR TITLE
fix: add latest chakra version used in docs to version picker

### DIFF
--- a/src/components/version-switcher.tsx
+++ b/src/components/version-switcher.tsx
@@ -1,13 +1,15 @@
-import { useState } from 'react';
 import { Select, SelectProps, useColorModeValue } from '@chakra-ui/react';
 import { useRouter } from 'next/router';
+import packageJSON from 'package.json';
 
 function VersionSwitcher(props: SelectProps) {
   const router = useRouter();
-  const [chakraVersion] = useState<string>('1.x.x');
 
   const versions = [
-    { label: `v${chakraVersion}`, url: 'https://chakra-ui.com' },
+    {
+      label: `v${packageJSON.dependencies['@chakra-ui/react']}`,
+      url: 'https://chakra-ui.com',
+    },
     { label: 'v0.8.x', url: 'https://v0.chakra-ui.com' },
   ];
 


### PR DESCRIPTION
Closes #18 

## 📝 Description

Added the latest chakra version used in docs to the version picker dropdown.

## ⛳️ Current behavior (updates)

The current chakra version shows v1.x.x. 

## 🚀 New behavior

The dropdown now shows the latest version of chakra ui installed in the docs repo as default.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
- 