### PR TITLE
Fix Homepage Headline Color

### DIFF
--- a/i18n/ui.json
+++ b/i18n/ui.json
@@ -1,6 +1,7 @@
 {
   "homepage": {
-    "title": "Create accessible React apps with speed",
+    "title1": "Create accessible React apps",
+    "title2": "with speed",
     "message": "Chakra UI is a simple, modular and accessible component library that gives you the building blocks you need to build your React applications.",
     "seo": {
       "title": "Chakra UI - A simple, modular and accessible component library that gives you the building blocks you need to build your React applications.",

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -134,13 +134,13 @@ const HomePage = ({ members, sponsors, githubStars }: HomePageProps) => {
                 mb='16px'
                 lineHeight='1.2'
               > 
-                {t('homepage.title').split(" ").slice(0,-2).join(" ")}
+                {t('homepage.title1')}
                 <Box
                   as="span"
                   color={useColorModeValue("teal.500", "teal.300")}
                 >
                   {" "}
-                {t('homepage.title').split(" ").slice(-2).join(" ")}
+                {t('homepage.title2')}
                 </Box>
               </chakra.h1>
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -133,8 +133,15 @@ const HomePage = ({ members, sponsors, githubStars }: HomePageProps) => {
                 fontWeight='extrabold'
                 mb='16px'
                 lineHeight='1.2'
-              >
-                {t('homepage.title')}
+              > 
+                {t('homepage.title').split(" ").slice(0,-2).join(" ")}
+                <Box
+                  as="span"
+                  color={useColorModeValue("teal.500", "teal.300")}
+                >
+                  {" "}
+                {t('homepage.title').split(" ").slice(-2).join(" ")}
+                </Box>
               </chakra.h1>
 
               <Text


### PR DESCRIPTION
This PR fixes #19 

Changes the `with speed` text in `homepage.title` to `teal` color.