### PR TITLE
fix(docs): fixed MDX targeting in docs

### DIFF
--- a/pages/docs/[[...slug]].tsx
+++ b/pages/docs/[[...slug]].tsx
@@ -25,6 +25,6 @@ export const getStaticProps: GetStaticProps = async (ctx) => {
   const params = Array.isArray(ctx.params.slug)
     ? ctx.params.slug
     : [ctx.params.slug]
-  const doc = allDocs.find((doc) => doc._id.includes(params.join('/')))
+  const doc = allDocs.find((doc) => doc._id.endsWith(`${params.join('/')}.mdx`))
   return { props: { doc } }
 }

--- a/pages/guides/[[...slug]].tsx
+++ b/pages/guides/[[...slug]].tsx
@@ -25,6 +25,8 @@ export const getStaticProps: GetStaticProps = async (ctx) => {
   const params = Array.isArray(ctx.params.slug)
     ? ctx.params.slug
     : [ctx.params.slug]
-  const guide = allGuides.find((guide) => guide._id.includes(params.join('/')))
+  const guide = allGuides.find((guide) =>
+    guide._id.endsWith(`${params.join('/')}.mdx`),
+  )
   return { props: { guide } }
 }


### PR DESCRIPTION
Closes #68 

## 📝 Description

The `Link` doc page wasn't being targeted correctly, so the `LinkOverlay` page was rendered instead. Instead of `.includes`, I've replaced the query with `endsWith`, and then added an `.mdx`. This way the `Link` doc page gets rendered correctly. I also checked every other page in the documentation. No issues there.

## ⛳️ Current behavior (updates)

`Link` docpage doesn't get rendered

## 🚀 New behavior

All good 👍 

## 💣 Is this a breaking change (Yes/No):

No