### PR TITLE
Fixed broken links for the image component

### DIFF
--- a/pages/docs/media-and-icons/image.mdx
+++ b/pages/docs/media-and-icons/image.mdx
@@ -28,7 +28,7 @@ import { Image } from '@chakra-ui/react'
 
 ```jsx
 <Box boxSize='sm'>
-  <Image src='https://bit.ly/sage-adebayo' alt='Segun Adebayo' />
+  <Image src='https://bit.ly/dan-abramov' alt='Dan Abramov' />
 </Box>
 ```
 
@@ -41,8 +41,8 @@ The size of the image can be adjusted using the `boxSize` prop.
   <Image
     boxSize='100px'
     objectFit='cover'
-    src='https://bit.ly/sage-adebayo'
-    alt='Segun Adebayo'
+    src='https://bit.ly/dan-abramov'
+    alt='Dan Abramov'
   />
   <Image
     boxSize='150px'
@@ -60,8 +60,8 @@ The size of the image can be adjusted using the `boxSize` prop.
 <Image
   borderRadius='full'
   boxSize='150px'
-  src='https://bit.ly/sage-adebayo'
-  alt='Segun Adebayo'
+  src='https://bit.ly/dan-abramov'
+  alt='Dan Abramov'
 />
 ```
 


### PR DESCRIPTION
## 📝 Description

Fixed broken links for the image component in the [documentation](https://chakra-ui.com/docs/media-and-icons/image)

## ⛳️ Current behavior (updates)

'https://bit.ly/sage-adebayo' link is broken

## 🚀 New behavior

Replaced 'https://bit.ly/sage-adebayo' link with 'https://bit.ly/dan-abramov' as the former link is broken.

Fixed [documentation page](https://chakra-ui-docs-git-fork-6aravind-docs-fix-links-chakra-ui.vercel.app/docs/media-and-icons/image)

## 💣 Is this a breaking change (Yes/No):

No