### PR TITLE
docs/add component of the week video to components

### DIFF
--- a/i18n/ui.json
+++ b/i18n/ui.json
@@ -143,7 +143,8 @@
       "component-links": {
         "view-source": "View source",
         "view-storybook": "View storybook",
-        "view-theme-source": "View theme source"
+        "view-theme-source": "View theme source",
+        "view-video": "Watch video"
       }
     },
     "algolia-search": {

--- a/pages/docs/disclosure/tabs.mdx
+++ b/pages/docs/disclosure/tabs.mdx
@@ -16,6 +16,7 @@ attributes described in the
   theme={{ componentName: 'tabs' }}
   github={{ package: 'tabs' }}
   npm={{ package: '@chakra-ui/tabs' }}
+  video={{ url: 'https://youtu.be/hSVhhOamFaI' }}
 />
 
 <carbon-ad></carbon-ad>

--- a/pages/docs/form/input.mdx
+++ b/pages/docs/form/input.mdx
@@ -13,6 +13,7 @@ field.
   theme={{ componentName: 'input' }}
   github={{ package: 'input' }}
   npm={{ package: '@chakra-ui/input' }}
+  video={{ url: 'https://youtu.be/4y86kDy3Z2E' }}
 />
 
 <carbon-ad></carbon-ad>

--- a/pages/docs/form/range-slider.mdx
+++ b/pages/docs/form/range-slider.mdx
@@ -16,6 +16,7 @@ a user to set the minimum and maximum price.
   theme={{ componentName: 'slider' }}
   github={{ package: 'slider' }}
   npm={{ package: '@chakra-ui/slider' }}
+  video={{ url: 'https://youtu.be/yt0F8srvg_Q' }}
 />
 
 <carbon-ad></carbon-ad>

--- a/pages/docs/layout/simple-grid.mdx
+++ b/pages/docs/layout/simple-grid.mdx
@@ -13,6 +13,7 @@ anything CSS grid.
 <ComponentLinks
   github={{ package: 'layout' }}
   npm={{ package: '@chakra-ui/layout' }}
+  video={{ url: 'https://youtu.be/uyJNBGBI5sI' }}
 />
 
 <carbon-ad></carbon-ad>

--- a/pages/docs/layout/stack.mdx
+++ b/pages/docs/layout/stack.mdx
@@ -15,6 +15,7 @@ to add spacing between its children.
 <ComponentLinks
   github={{ package: 'layout' }}
   npm={{ package: '@chakra-ui/layout' }}
+  video={{ url: 'https://youtu.be/6Az4Yd6f8RA' }}
 />
 
 <carbon-ad></carbon-ad>

--- a/pages/docs/overlay/menu.mdx
+++ b/pages/docs/overlay/menu.mdx
@@ -14,6 +14,7 @@ An accessible dropdown menu for the common dropdown menu button design pattern.
   theme={{ componentName: 'menu' }}
   github={{ package: 'menu' }}
   npm={{ package: '@chakra-ui/menu' }}
+  video={{ url: 'https://youtu.be/Q-AMFseuFrk' }}
 />
 
 <carbon-ad></carbon-ad>

--- a/src/components/mdx-components/component-links.tsx
+++ b/src/components/mdx-components/component-links.tsx
@@ -9,7 +9,7 @@ import {
   LinkProps,
   WrapItem,
 } from '@chakra-ui/react'
-import { FaNpm, FaGithub } from 'react-icons/fa'
+import { FaNpm, FaGithub, FaYoutube } from 'react-icons/fa'
 import StorybookIcon from '../storybook-icon'
 import { t } from 'utils/i18n'
 
@@ -55,9 +55,10 @@ export type ComponentLinksProps = {
   github?: { url?: string; package?: string }
   npm?: { package: string }
   storybook?: { url: string }
+  video?: { url: string }
 }
 function ComponentLinks(props: ComponentLinksProps) {
-  const { theme, github, npm, storybook, ...rest } = props
+  const { theme, github, npm, storybook, video, ...rest } = props
   const iconColor = useColorModeValue('gray.600', 'inherit')
 
   const githubRepoUrl = 'https://github.com/chakra-ui/chakra-ui'
@@ -103,6 +104,19 @@ function ComponentLinks(props: ComponentLinksProps) {
     </WrapItem>
   )
 
+  const videoLink = video?.url && (
+    <WrapItem>
+      <ComponentLink
+        url={video.url}
+        icon={FaYoutube}
+        iconSize='1.2rem'
+        iconColor='red.500'
+      >
+        {t('component.mdx-components.component-links.view-video')}
+      </ComponentLink>
+    </WrapItem>
+  )
+
   const themeComponentLink = theme && (
     <WrapItem>
       <ComponentLink
@@ -122,6 +136,7 @@ function ComponentLinks(props: ComponentLinksProps) {
       {themeComponentLink}
       {npmLink}
       {storybookLink}
+      {videoLink}
     </Wrap>
   )
 }


### PR DESCRIPTION
Closes #21 

## 📝 Description

Added component of the week video to each component page

## ⛳️ Current behavior (updates)

There was no video link for components, so I've added it in

## 🚀 New behavior

Users can now watch COTW video from component pages

## 💣 Is this a breaking change (Yes/No):

No


