### PR TITLE
(docs) `role` prop for Icon no longer has a default

### DIFF
--- a/pages/docs/media-and-icons/icon.mdx
+++ b/pages/docs/media-and-icons/icon.mdx
@@ -207,7 +207,7 @@ When `children` is not provided, the `Icon` component renders a fallback icon.
 | `boxSize`   | `string`              | `1em`          | The size (width and height) of the icon.                                             |
 | `color`     | `string`              | `currentColor` | The color of the icon.                                                               |
 | `focusable` | `boolean`             | `false`        | Denotes that the icon is not an interactive element, and only used for presentation. |
-| `role`      | `presentation`, `img` | `presentation` | The html role of the icon.                                                           |
+| `role`      | `presentation`, `img` |                | The html role of the icon.                                                           |
 | `children`  | `React.ReactNode`     |                | The Path or Group of the icon                                                        |
 
 ## `createIcon` options


### PR DESCRIPTION
Closes #70

## 📝 Description

It seems like this prop stopped receiving `presentation` as a default, as per https://github.com/chakra-ui/chakra-ui/pull/1349 and https://github.com/chakra-ui/chakra-ui/issues/1197

## ⛳️ Current behavior (updates)

Update the documented default value for the `role` prop
