### PR TITLE
chore: update numbers in the growing section

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -371,7 +371,7 @@ const HomePage = ({ members, sponsors, githubStars }: HomePageProps) => {
             >
               <StatBox
                 icon={FiDownload}
-                title='488K'
+                title='813K'
                 description={t('homepage.growing-section.downloads-per-month')}
               />
               <StatBox
@@ -386,7 +386,7 @@ const HomePage = ({ members, sponsors, githubStars }: HomePageProps) => {
               />
               <StatBox
                 icon={FaDiscord}
-                title='2.9K'
+                title='5.1K'
                 description={t('homepage.growing-section.discord-members')}
               />
             </SimpleGrid>


### PR DESCRIPTION
## 📝 Description

Updated the numbers in the growing section to match new values.

## ⛳️ Current behavior (updates)

Homepage growing section was still showing 488k monthly downloads and 2.9k discord members

## 🚀 New behavior

Homepage growing section is showing 813k monthly downloads and 5.1k discords members

## 💣 Is this a breaking change (Yes/No):

No
