### PR TITLE
docs(scripts): fixed showcase script GitHub URL destructuring

### DIFF
--- a/scripts/get-showcase-data.ts
+++ b/scripts/get-showcase-data.ts
@@ -178,7 +178,14 @@ const parseRepoData = async (context: string[]): Promise<IShowcase> => {
         )
         continue
       }
-      const { owner, repo } = parseGithubUrl(link)
+      const parsedUrl = parseGithubUrl(link)
+
+      if (!parsedUrl) {
+        console.error('ERROR', link);
+        continue;
+      }
+
+      const { owner, repo } = parsedUrl;
 
       let url = ''
 


### PR DESCRIPTION
## 📝 Description

Skipped script execution if GitHub URL is not a repo URL.

## ⛳️ Current behavior (updates)

The Daily script crashes with `TypeError: Cannot read property 'owner' of undefined`.

## 🚀 New behavior

All good now.

## 💣 Is this a breaking change (Yes/No):

No