### PR TITLE
docs(scripts): fixed commit showcase bug

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -67,7 +67,7 @@ jobs:
           git add public/showcases
           git diff --staged --quiet || git commit -m "chore(showcase-preview-images): $GITHUB_SHA"
 
-          git add config/showcase.json
+          git add configs/showcase.json
           git diff --staged --quiet || git commit -m "chore(showcase.json)): $GITHUB_SHA"
 
       - name: Create Pull Request


### PR DESCRIPTION
## 📝 Description

The `commit showcase.json` GitHub action has a typo and cannot commit the `showcase.json` file.

## ⛳️ Current behavior (updates)

The GitHub Daily action fails because there is no `config/showcase.json` file.

## 🚀 New behavior

I changed the targeting to `configs/showcase.json`.

## 💣 Is this a breaking change (Yes/No):

No