### PR TITLE
doc: mention color "mode" function in the doc

### DIFF
--- a/pages/docs/theming/customize-theme.mdx
+++ b/pages/docs/theming/customize-theme.mdx
@@ -25,6 +25,7 @@ brand colors, here's what you'll do:
 ```jsx live=false
 // 1. Import `extendTheme`
 import { extendTheme } from "@chakra-ui/react"
+import { mode } from '@chakra-ui/theme-tools'
 
 // 2. Call `extendTheme` and pass your custom values
 const theme = extendTheme({
@@ -34,6 +35,7 @@ const theme = extendTheme({
       // ...
       900: "#1a202c",
     },
+    primary: mode('black', 'pink.400') // for light and dark color mode
   },
 })
 


### PR DESCRIPTION
# Possible doc improvement

## 📝 Description

I had difficulties to find a way to define in the theme a color that changes depending on the color mode.
This is handy so I don't need to handle it inside of each component (with `useColorModeValue`).
I don't know if I am missing something else from the documentation, but I wish I would have found sooner the mention of the function `mode` from `@chakra-ui/theme-tools`.
