### PR TITLE
docs(link): Added "Usage with Next.js" section

### DIFF
--- a/pages/docs/navigation/link.mdx
+++ b/pages/docs/navigation/link.mdx
@@ -63,6 +63,21 @@ Reach's `Link`.
 </Link>
 ```
 
+## Usage with Next.js
+
+To use the `Link` with Next.js, all you need to do is to wrap `Link` with
+Next.js `Link` component and pass the `passHref` prop. `passHref` Forces Next.js
+`Link` to send the `href` property to its child.
+
+```jsx live=false
+// 1. import NextLink from "next/link"
+
+// 2. Then use it like this
+<NextLink href='/home' passHref>
+  <Link>Home</Link>
+</NextLink>
+```
+
 ## Props
 
 The Link component composes the `Box` component.


### PR DESCRIPTION
## 📝 Description

Added "Usage with Next.js" section, Using Next.js Link with Chakra-UI link is not the same as using it with Reach Router or React Router.

## ⛳️ Current behavior (updates)

There is no official docs about how to use Next.js Link with Chakra-UI link.

## 🚀 New behavior

Added a section about how to use Next.js Link with Chakra-UI Link.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
