### PR TITLE
feat(homepage): Automate npm downloads and discord guild member count

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -42,7 +42,9 @@ import type { Member, Sponsor } from 'src/types/github'
 import { getAllContributors } from 'utils/get-all-contributors'
 import { getAllMembers } from 'utils/get-all-members'
 import { getAllSponsors } from 'utils/get-all-sponsors'
+import { getDiscordMembers } from 'utils/get-discord-members'
 import { getGithubStars } from 'utils/get-github-stars'
+import { getNpmDownloads } from 'utils/get-npm-downloads'
 import { t } from 'utils/i18n'
 
 const Feature = ({ title, icon, children, ...props }) => {
@@ -105,13 +107,21 @@ const StatBox = (props: StatBoxProps) => {
 interface HomePageProps {
   members: Member[]
   githubStars: string
+  npmDownloads: string
+  discordMembers: string
   sponsors: {
     companies: Sponsor[]
     individuals: Sponsor[]
   }
 }
 
-const HomePage = ({ members, sponsors, githubStars }: HomePageProps) => {
+const HomePage = ({
+  members,
+  sponsors,
+  githubStars,
+  npmDownloads,
+  discordMembers,
+}: HomePageProps) => {
   return (
     <>
       <SEO
@@ -371,7 +381,7 @@ const HomePage = ({ members, sponsors, githubStars }: HomePageProps) => {
             >
               <StatBox
                 icon={FiDownload}
-                title='813K'
+                title={npmDownloads}
                 description={t('homepage.growing-section.downloads-per-month')}
               />
               <StatBox
@@ -386,7 +396,7 @@ const HomePage = ({ members, sponsors, githubStars }: HomePageProps) => {
               />
               <StatBox
                 icon={FaDiscord}
-                title='5.1K'
+                title={discordMembers}
                 description={t('homepage.growing-section.discord-members')}
               />
             </SimpleGrid>
@@ -652,17 +662,28 @@ const HomePage = ({ members, sponsors, githubStars }: HomePageProps) => {
 }
 
 export async function getStaticProps() {
-  const { prettyCount } = await getGithubStars()
+  const [
+    { prettyCount: githubStars },
+    { prettyCount: npmDownloads },
+    { prettyCount: discordMembers },
+  ] = await Promise.all([
+    getGithubStars(),
+    getNpmDownloads(),
+    getDiscordMembers(),
+  ])
+
   const contributors = getAllContributors()
   const members = getAllMembers()
   const sponsors = getAllSponsors()
 
   return {
     props: {
-      githubStars: prettyCount,
+      githubStars,
       members,
       contributors,
       sponsors,
+      discordMembers,
+      npmDownloads,
     },
   }
 }

--- a/src/utils/get-discord-members.ts
+++ b/src/utils/get-discord-members.ts
@@ -1,0 +1,22 @@
+import { numberFormatter } from './number-formatter'
+
+// https://discord.com/api/v9/guilds/660863154703695893/widget.json
+// https://discord.com/api/v9/invites/hup7J23V?with_counts=true
+export async function getDiscordMembers() {
+  let count = 5_100 // Fallback if there's any error
+
+  try {
+    const data = await fetch(
+      'https://discord.com/api/v9/invites/hup7J23V?with_counts=true',
+    ).then((res) => res.json())
+
+    count = data.approximate_member_count
+  } catch (error) {
+    console.log('Failed to get discord members count: ', error.toString())
+  }
+
+  return {
+    count,
+    prettyCount: numberFormatter.format(count),
+  }
+}

--- a/src/utils/get-github-stars.ts
+++ b/src/utils/get-github-stars.ts
@@ -1,11 +1,7 @@
 import { Octokit } from '@octokit/rest'
+import { numberFormatter } from './number-formatter'
 
 const octokit = new Octokit({ auth: process.env.GITHUB_TOKEN })
-
-const formatter = Intl.NumberFormat('en', {
-  notation: 'compact',
-  maximumFractionDigits: 1,
-})
 
 // "https://api.npms.io/v2/package/@chakra-ui%2Freact"
 export async function getGithubStars() {
@@ -24,6 +20,6 @@ export async function getGithubStars() {
 
   return {
     count,
-    prettyCount: formatter.format(count),
+    prettyCount: numberFormatter.format(count),
   }
 }

--- a/src/utils/get-npm-downloads.ts
+++ b/src/utils/get-npm-downloads.ts
@@ -1,0 +1,20 @@
+import { numberFormatter } from './number-formatter'
+
+export async function getNpmDownloads() {
+  let count = 817_000 // Fallback if there's any error
+
+  try {
+    const data = await fetch(
+      'https://api.npmjs.org/downloads/point/last-month/@chakra-ui/react',
+    ).then((res) => res.json())
+
+    count = data.downloads
+  } catch (error) {
+    console.log('Failed to get npm downloads: ', error.toString())
+  }
+
+  return {
+    count,
+    prettyCount: numberFormatter.format(count),
+  }
+}

--- a/src/utils/number-formatter.ts
+++ b/src/utils/number-formatter.ts
@@ -1,0 +1,4 @@
+export const numberFormatter = Intl.NumberFormat('en', {
+  notation: 'compact',
+  maximumFractionDigits: 1,
+})


### PR DESCRIPTION
Closes #98 

## 📝 Description

Need to automate the npm downloads and discord guild member count.

## ⛳️ Current behavior (updates)

Currently, the npm downloads and discord guild member count is hardcoded which is really not efficient.

## 🚀 New behavior

After this PR merged, it will be automated at build time by fetching to some specific API endpoints.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

None