### PR TITLE
Revert "doc: mention color "mode" function in the doc"

### DIFF
--- a/pages/docs/theming/customize-theme.mdx
+++ b/pages/docs/theming/customize-theme.mdx
@@ -25,7 +25,6 @@ brand colors, here's what you'll do:
 ```jsx live=false
 // 1. Import `extendTheme`
 import { extendTheme } from "@chakra-ui/react"
-import { mode } from '@chakra-ui/theme-tools'
 
 // 2. Call `extendTheme` and pass your custom values
 const theme = extendTheme({
@@ -35,7 +34,6 @@ const theme = extendTheme({
       // ...
       900: "#1a202c",
     },
-    primary: mode('black', 'pink.400') // for light and dark color mode
   },
 })
 


### PR DESCRIPTION
I am sorry, but this is not working as expected.
The `mode()` utility function is not meant to be used in the color section, because it expects only static values. 
I'll come back with a better contribution and example, sorry about that.

Reverts chakra-ui/chakra-ui-docs#140