### PR TITLE
fix(homepage): discord member NaN

### DIFF
--- a/src/utils/get-discord-members.ts
+++ b/src/utils/get-discord-members.ts
@@ -1,13 +1,11 @@
 import { numberFormatter } from './number-formatter'
 
-// https://discord.com/api/v9/guilds/660863154703695893/widget.json
-// https://discord.com/api/v9/invites/hup7J23V?with_counts=true
 export async function getDiscordMembers() {
   let count = 5_100 // Fallback if there's any error
 
   try {
     const data = await fetch(
-      'https://discord.com/api/v9/invites/hup7J23V?with_counts=true',
+      'https://discord.com/api/v9/invites/chakra-ui?with_counts=true',
     ).then((res) => res.json())
 
     count = data.approximate_member_count


### PR DESCRIPTION
## 📝 Description

Previously I'm trying to automate the discord member count by creating a request to the discord invite url with the invite id (I guess), and It just temporary, when it gets expired, the response return undefined, and parsed by number formatter and it give us NaN.

## ⛳️ Current behavior (updates)

I've updated the invites link to use `chakra-ui`.

## 🚀 New behavior

This should fix below behaviour

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Here's the screenshot

<img width="1031" alt="Screenshot 2021-12-18 at 22 30 45" src="https://user-images.githubusercontent.com/70800415/146646526-b620e92d-b999-4375-a439-c95ac1e92344.png">

