### PR TITLE
docs(slider): Add SliderMarks example

### DIFF
--- a/pages/docs/form/slider.mdx
+++ b/pages/docs/form/slider.mdx
@@ -186,7 +186,6 @@ function SliderThumbWithTooltip() {
         bg='teal.500'
         color='white'
         placement='top'
-        closeOnClick={false}
         isOpen={showTooltip}
         label={`${sliderValue}%`}
       >

--- a/pages/docs/form/slider.mdx
+++ b/pages/docs/form/slider.mdx
@@ -22,13 +22,15 @@ or applying image filters.
 
 ## Import
 
-Chakra UI export 4 components for Slider:
+Chakra UI export 5 components for Slider:
 
 - **`Slider`**: The wrapper that provides context and functionality for all
   children.
 - **`SliderTrack`**: The empty part of the slider that shows the track.
 - **`SliderFilledTrack`**: The filled part of the slider.
 - **`SliderThumb`**: The handle that's used to change the slider value.
+- **`SliderMark`**: The label or mark that shows names for specific slider
+  values
 
 ```js
 import {
@@ -36,6 +38,7 @@ import {
   SliderTrack,
   SliderFilledTrack,
   SliderThumb,
+  SliderMark,
 } from '@chakra-ui/react'
 ```
 
@@ -109,6 +112,86 @@ accomplished using the `step` prop.
   </SliderTrack>
   <SliderThumb boxSize={6} />
 </Slider>
+```
+
+### Slider with custom labels and marks
+
+You can have custom labels and marks by using `SliderMark` component
+
+```jsx
+function SliderMarkExample() {
+  const [sliderValue, setSliderValue] = useState(50)
+  return (
+    <Slider aria-label='slider-ex-6' onChange={(val) => setSliderValue(val)}>
+      <SliderMark value={25} mt='1' ml='-2.5' fontSize='sm'>
+        25%
+      </SliderMark>
+      <SliderMark value={50} mt='1' ml='-2.5' fontSize='sm'>
+        50%
+      </SliderMark>
+      <SliderMark value={75} mt='1' ml='-2.5' fontSize='sm'>
+        75%
+      </SliderMark>
+      <SliderMark
+        value={sliderValue}
+        textAlign='center'
+        bg='blue.500'
+        color='white'
+        mt='-10'
+        ml='-5'
+        w='12'
+      >
+        {sliderValue}%
+      </SliderMark>
+      <SliderTrack>
+        <SliderFilledTrack />
+      </SliderTrack>
+      <SliderThumb />
+    </Slider>
+  )
+}
+```
+
+And you can also use `Tooltip` with `SliderThumb`
+
+```jsx
+function SliderThumbWithTooltip() {
+  const [sliderValue, setSliderValue] = React.useState(5)
+  return (
+    <Slider
+      id='slider'
+      defaultValue={5}
+      min={0}
+      max={100}
+      colorScheme='blue'
+      onChange={(v) => setSliderValue(v)}
+    >
+      <SliderMark value={25} mt='1' ml='-2.5' fontSize='sm'>
+        25%
+      </SliderMark>
+      <SliderMark value={50} mt='1' ml='-2.5' fontSize='sm'>
+        50%
+      </SliderMark>
+      <SliderMark value={75} mt='1' ml='-2.5' fontSize='sm'>
+        75%
+      </SliderMark>
+      <SliderTrack>
+        <SliderFilledTrack />
+      </SliderTrack>
+      <Tooltip
+        hasArrow
+        bg='red.600'
+        placement='top'
+        gutter='10'
+        closeOnClick={false}
+        isOpen
+        label={`${sliderValue}`}
+      >
+        <SliderThumb />
+      </Tooltip>
+    </Slider>
+  )
+}
 ```
 
 ### Getting the final value when dragging the slider

--- a/pages/docs/form/slider.mdx
+++ b/pages/docs/form/slider.mdx
@@ -157,14 +157,17 @@ And you can also use `Tooltip` with `SliderThumb`
 ```jsx
 function SliderThumbWithTooltip() {
   const [sliderValue, setSliderValue] = React.useState(5)
+  const [showTooltip, setShowTooltip] = React.useState(false)
   return (
     <Slider
       id='slider'
       defaultValue={5}
       min={0}
       max={100}
-      colorScheme='blue'
+      colorScheme='teal'
       onChange={(v) => setSliderValue(v)}
+      onMouseEnter={() => setShowTooltip(true)}
+      onMouseLeave={() => setShowTooltip(false)}
     >
       <SliderMark value={25} mt='1' ml='-2.5' fontSize='sm'>
         25%
@@ -180,12 +183,12 @@ function SliderThumbWithTooltip() {
       </SliderTrack>
       <Tooltip
         hasArrow
-        bg='red.600'
+        bg='teal.500'
+        color='white'
         placement='top'
-        gutter='10'
         closeOnClick={false}
-        isOpen
-        label={`${sliderValue}`}
+        isOpen={showTooltip}
+        label={`${sliderValue}%`}
       >
         <SliderThumb />
       </Tooltip>


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #78 

## 📝 Description

Add 2 example to show how to add a mark on `SliderThumb`

- With `SliderMark`
- With `Tooltip`

## ⛳️ Current behavior (updates)

No example for adding marks on thumb

## 🚀 New behavior

- With `SliderMarks`
- 
![截圖 2021-12-20 下午1 21 51](https://user-images.githubusercontent.com/57777349/146715794-18c71298-d7e8-4c2e-98cf-43f3dd276348.png)

- With `Tooltip`
- 
![截圖 2021-12-20 下午1 21 57](https://user-images.githubusercontent.com/57777349/146715818-0fb63b3b-35cc-4d65-88f9-c3e9b0dc970b.png)


## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
