### PR TITLE
docs(FormControl): an example of FormErrorMessage and some descriptions 

### DIFF
--- a/pages/docs/form/form-control.mdx
+++ b/pages/docs/form/form-control.mdx
@@ -22,6 +22,17 @@ forms.
 
 ## Import
 
+Chakra UI export 4 components for Form Control:
+
+- **`FormControl`**: The wrapper that provides context and functionality for all
+  children.
+- **`FormLabel`**: The label of a form section. The usage is similar to
+  [html label](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label).
+- **`FormHelperText`**: The message that tells users more detail things about
+  the form section.
+- **`FormErrorMessage`**: The message that shows up when an error occurs and
+  tells users how to make it right.
+
 ```js
 import {
   FormControl,
@@ -56,6 +67,38 @@ import {
   </RadioGroup>
   <FormHelperText>Select only if you're a fan.</FormHelperText>
 </FormControl>
+```
+
+### Error message
+
+`FormErrorMessage` will only show up when the property `isInvalid` in
+`FormControl` is true.
+
+```jsx
+function errorMessageExample() {
+  const [input, setInput] = useState('')
+
+  const handleInputChange = (e) => setInput(e.target.value)
+
+  const isError = input === ''
+
+  return (
+    <FormControl isInvalid={isError}>
+      <FormLabel htmlFor='email'>Tell me how you love chakra-ui 💛</FormLabel>
+      <Input
+        id='email'
+        type='email'
+        value={input}
+        isError={isError}
+        onChange={handleInputChange}
+      />
+      <FormErrorMessage>Please enter some text.</FormErrorMessage>
+      {!isError && (
+        <FormHelperText>We'll never share this secret.</FormHelperText>
+      )}
+    </FormControl>
+  )
+}
 ```
 
 ### Making a field required

--- a/pages/docs/form/form-control.mdx
+++ b/pages/docs/form/form-control.mdx
@@ -28,10 +28,9 @@ Chakra UI export 4 components for Form Control:
   children.
 - **`FormLabel`**: The label of a form section. The usage is similar to
   [html label](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label).
-- **`FormHelperText`**: The message that tells users more detail things about
-  the form section.
-- **`FormErrorMessage`**: The message that shows up when an error occurs and
-  tells users how to make it right.
+- **`FormHelperText`**: The message that tells users more details about the form
+  section.
+- **`FormErrorMessage`**: The message that shows up when an error occurs.
 
 ```js
 import {
@@ -84,17 +83,19 @@ function errorMessageExample() {
 
   return (
     <FormControl isInvalid={isError}>
-      <FormLabel htmlFor='email'>Tell me how you love chakra-ui 💛</FormLabel>
+      <FormLabel htmlFor='email'>Email</FormLabel>
       <Input
         id='email'
         type='email'
         value={input}
-        isError={isError}
         onChange={handleInputChange}
       />
-      <FormErrorMessage>Please enter some text.</FormErrorMessage>
-      {!isError && (
-        <FormHelperText>We'll never share this secret.</FormHelperText>
+      {!isError ? (
+        <FormHelperText>
+          Enter the email you'd like to receive the newsletter on.
+        </FormHelperText>
+      ) : (
+        <FormErrorMessage>Email is required.</FormErrorMessage>
       )}
     </FormControl>
   )


### PR DESCRIPTION

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #73 

## 📝 Description

- A simple example for showing the use case of `FromErrorMessage`
- Descriptions about 4 components exporting from `form-control`

## ⛳️ Current behavior (updates)

Lack detail descriptions and sample usages about `FormErrorMessage` and `FormHelperText`. 

## 🚀 New behavior

#### Add descriptions for components 

![截圖 2021-12-20 下午2 31 49](https://user-images.githubusercontent.com/57777349/146722497-b646b79c-f9b9-465c-9578-a6d0406cd6cc.png)

### Example with `FormErrorMessage` showing (triggerred by `isInvalid`)

![截圖 2021-12-20 下午2 39 51](https://user-images.githubusercontent.com/57777349/146723035-0b630f80-0f74-490c-be97-2a8f2e6724b4.png)

###  Example with `FormErrorMessage` hidden

![截圖 2021-12-20 下午2 39 41](https://user-images.githubusercontent.com/57777349/146723031-8c6bb095-5b6a-44f5-a4e6-31ef820d9b6f.png)



## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

No

## 📝 Additional Information
