### PR TITLE
Remove MenuIcon, MenuCommand from import as it is only used inside chakra-ui source code

### DIFF
--- a/pages/docs/overlay/menu.mdx
+++ b/pages/docs/overlay/menu.mdx
@@ -42,8 +42,6 @@ import {
   MenuItemOption,
   MenuGroup,
   MenuOptionGroup,
-  MenuIcon,
-  MenuCommand,
   MenuDivider,
 } from '@chakra-ui/react'
 ```


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #166

## 📝 Description

> Remove MenuIcon, MenuCommand from import

## 💣 Is this a breaking change (Yes/No): 

> No
