### PR TITLE
Fix Checkbox Doc Example On Mobile Layout

### DIFF
--- a/pages/docs/form/checkbox.mdx
+++ b/pages/docs/form/checkbox.mdx
@@ -39,7 +39,7 @@ Basic usage of `Checkbox`.
 ### Disabled Checkbox
 
 ```jsx
-<Stack spacing={10} direction='row'>
+<Stack spacing={5} direction='row'>
   <Checkbox isDisabled>Checkbox</Checkbox>
   <Checkbox isDisabled defaultIsChecked>
     Checkbox
@@ -53,7 +53,7 @@ You can override the color scheme of the `Checkbox` to any color key specified
 in `theme.colors`.
 
 ```jsx
-<Stack spacing={10} direction='row'>
+<Stack spacing={5} direction='row'>
   <Checkbox colorScheme='red' defaultIsChecked>
     Checkbox
   </Checkbox>

--- a/pages/docs/form/checkbox.mdx
+++ b/pages/docs/form/checkbox.mdx
@@ -69,7 +69,7 @@ Pass the `size` prop to change the size of the `Checkbox`. Values can be either
 `sm`, `md` or `lg`.
 
 ```jsx
-<HStack spacing={10} direction='row'>
+<Stack spacing={[1, 5]} direction={['column', 'row']}>
   <Checkbox size='sm' colorScheme='red'>
     Checkbox
   </Checkbox>
@@ -79,7 +79,7 @@ Pass the `size` prop to change the size of the `Checkbox`. Values can be either
   <Checkbox size='lg' colorScheme='orange' defaultIsChecked>
     Checkbox
   </Checkbox>
-</HStack>
+</Stack>
 ```
 
 ### Invalid Checkbox

--- a/pages/docs/form/checkbox.mdx
+++ b/pages/docs/form/checkbox.mdx
@@ -185,11 +185,11 @@ shared styling props.
 
 ```jsx
 <CheckboxGroup colorScheme='green' defaultValue={['naruto', 'kakashi']}>
-  <HStack>
+  <Stack spacing={[1, 5]} direction={['column', 'row']}>
     <Checkbox value='naruto'>Naruto</Checkbox>
     <Checkbox value='sasuke'>Sasuke</Checkbox>
     <Checkbox value='kakashi'>kakashi</Checkbox>
-  </HStack>
+  </Stack>
 </CheckboxGroup>
 ```
 

--- a/src/components/props-table.tsx
+++ b/src/components/props-table.tsx
@@ -58,7 +58,7 @@ Remove the use of <PropsTable of="${of}" /> for this component in the docs.`,
   }
 
   return (
-    <Stack spacing='10' my='10'>
+    <Stack overflowX='auto' spacing='10' my='10'>
       {propList.map((prop) => (
         <chakra.div
           key={prop.name}


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #142 <!-- Github issue # here -->

## 📝 Description

Update one of the Checkbox examples, within Checkbox documentation page, to prevent it from overflowing container on mobile, and thus, prevent the bug.

_Before_

![chakra-ui-checkbox-bug-1](https://user-images.githubusercontent.com/23528307/147117681-12739ed8-1fe6-4316-8036-df5e567569a2.PNG)

_After (current)_

![chakra-ui-checkbox-bug-2](https://user-images.githubusercontent.com/23528307/147117730-4dc0ad32-56d6-42b2-b571-db940c29eb20.PNG)

## ⛳️ Current behavior (updates)

* Checkbox example breaks out of container in documentation page, at smaller view ports

## 🚀 New behavior

* Checkbox example no longer breaks out of container in documentation page, at smaller view ports
  * Example still uses row layout, whenever there is space, but then switches to column whenever there is no space

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

* Tested on Edge, Firefox, and Chrome