### PR TITLE
fix: Use GridItem instead of Box

### DIFF
--- a/pages/docs/layout/grid.mdx
+++ b/pages/docs/layout/grid.mdx
@@ -33,11 +33,11 @@ applying a `gap` or space between the grid items.
 
 ```jsx
 <Grid templateColumns='repeat(5, 1fr)' gap={6}>
-  <Box w='100%' h='10' bg='blue.500' />
-  <Box w='100%' h='10' bg='blue.500' />
-  <Box w='100%' h='10' bg='blue.500' />
-  <Box w='100%' h='10' bg='blue.500' />
-  <Box w='100%' h='10' bg='blue.500' />
+  <GridItem w='100%' h='10' bg='blue.500' />
+  <GridItem w='100%' h='10' bg='blue.500' />
+  <GridItem w='100%' h='10' bg='blue.500' />
+  <GridItem w='100%' h='10' bg='blue.500' />
+  <GridItem w='100%' h='10' bg='blue.500' />
 </Grid>
 ```
 


### PR DESCRIPTION
We do not import Box at the beginning of this page. So I think, we should use GridItem instead.

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

Use GridItem composent instead of Box

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):

No
## 📝 Additional Information
