### PR TITLE
docs(guides): update framer-motion to v5

### DIFF
--- a/pages/docs/getting-started.mdx
+++ b/pages/docs/getting-started.mdx
@@ -28,11 +28,11 @@ Inside your React project directory, install Chakra UI by running either of the
 following:
 
 ```bash
-npm i @chakra-ui/react @emotion/react@^11 @emotion/styled@^11 framer-motion@^4
+npm i @chakra-ui/react @emotion/react@^11 @emotion/styled@^11 framer-motion@^5
 ```
 
 ```bash
-yarn add @chakra-ui/react @emotion/react@^11 @emotion/styled@^11 framer-motion@^4
+yarn add @chakra-ui/react @emotion/react@^11 @emotion/styled@^11 framer-motion@^5
 ```
 
 ### Set up Provider

--- a/pages/guides/getting-started/cra-guide.mdx
+++ b/pages/guides/getting-started/cra-guide.mdx
@@ -11,11 +11,11 @@ Inside your CRA project directory, install Chakra UI by running either of the
 following:
 
 ```bash
-npm i @chakra-ui/react @emotion/react@^11 @emotion/styled@^11 framer-motion@^4
+npm i @chakra-ui/react @emotion/react@^11 @emotion/styled@^11 framer-motion@^5
 ```
 
 ```bash
-yarn add @chakra-ui/react @emotion/react@^11 @emotion/styled@^11 framer-motion@^4
+yarn add @chakra-ui/react @emotion/react@^11 @emotion/styled@^11 framer-motion@^5
 ```
 
 #### 2. Provider Setup

--- a/pages/guides/getting-started/nextjs-guide.mdx
+++ b/pages/guides/getting-started/nextjs-guide.mdx
@@ -27,11 +27,11 @@ author: estheragbaje
 In your `nextjs` project, install Chakra UI by running either of the following:
 
 ```bash
-npm i @chakra-ui/react @emotion/react@^11 @emotion/styled@^11 framer-motion@^4
+npm i @chakra-ui/react @emotion/react@^11 @emotion/styled@^11 framer-motion@^5
 ```
 
 ```bash
-yarn add @chakra-ui/react @emotion/react@^11 @emotion/styled@^11 framer-motion@^4
+yarn add @chakra-ui/react @emotion/react@^11 @emotion/styled@^11 framer-motion@^5
 ```
 
 #### 2. Provider Setup

--- a/pages/guides/getting-started/redwoodjs-guide.mdx
+++ b/pages/guides/getting-started/redwoodjs-guide.mdx
@@ -11,11 +11,11 @@ Inside your `Redwoodjs` project , cd into `web`, then, install Chakra UI by
 running either of the following:
 
 ```bash
-npm i @chakra-ui/react @emotion/react@^11 @emotion/styled@^11 framer-motion@^4
+npm i @chakra-ui/react @emotion/react@^11 @emotion/styled@^11 framer-motion@^5
 ```
 
 ```bash
-yarn add @chakra-ui/react @emotion/react@^11 @emotion/styled@^11 framer-motion@^4
+yarn add @chakra-ui/react @emotion/react@^11 @emotion/styled@^11 framer-motion@^5
 ```
 
 #### 2. Provider Setup

--- a/pages/guides/getting-started/remix-guide.mdx
+++ b/pages/guides/getting-started/remix-guide.mdx
@@ -14,11 +14,11 @@ Inside your `Remix` project root directory, install Chakra UI by running either
 of the following:
 
 ```bash
-npm i @chakra-ui/react @emotion/react@^11 @emotion/styled@^11 framer-motion@^4
+npm i @chakra-ui/react @emotion/react@^11 @emotion/styled@^11 framer-motion@^5
 ```
 
 ```bash
-yarn add @chakra-ui/react @emotion/react@^11 @emotion/styled@^11 framer-motion@^4
+yarn add @chakra-ui/react @emotion/react@^11 @emotion/styled@^11 framer-motion@^5
 ```
 
 > 🚨 Right now `yarn` is not officially supported in Remix projects, so use it

--- a/pages/guides/with-nextjs.mdx
+++ b/pages/guides/with-nextjs.mdx
@@ -24,9 +24,9 @@ yarn create next-app my-project
 To get started, install the core Chakra UI package :
 
 ```zsh
-npm i @chakra-ui/react @emotion/react@^11 @emotion/styled@^11 framer-motion@^4
+npm i @chakra-ui/react @emotion/react@^11 @emotion/styled@^11 framer-motion@^5
 # or
-yarn add @chakra-ui/react @emotion/react@^11 @emotion/styled@^11 framer-motion@^4
+yarn add @chakra-ui/react @emotion/react@^11 @emotion/styled@^11 framer-motion@^5
 ```
 
 After installation, you'll need to add Chakra providers


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

This PR updates `framer-motion@^4` to `framer-motion@^5`

## ⛳️ Current behavior (updates)

https://chakra-ui.com/docs/getting-started uses `framer-motion@^4` but https://github.com/chakra-ui/chakra-ui/#installing-chakra-ui uses `framer-motion@^5`.

```
npm i @chakra-ui/react @emotion/react@^11 @emotion/styled@^11 framer-motion@^4

yarn add @chakra-ui/react @emotion/react@^11 @emotion/styled@^11 framer-motion@^4
```

## 🚀 New behavior

Both https://chakra-ui.com/docs/getting-started and https://github.com/chakra-ui/chakra-ui/#installing-chakra-ui use `framer-motion@^5`.

```
npm i @chakra-ui/react @emotion/react@^11 @emotion/styled@^11 framer-motion@^5

yarn add @chakra-ui/react @emotion/react@^11 @emotion/styled@^11 framer-motion@^5
```

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->
No.

## 📝 Additional Information
https://chakra-ui.com/docs/getting-started