### PR TITLE
docs(style-props): remove fractional code example

### DIFF
--- a/pages/docs/features/style-props.mdx
+++ b/pages/docs/features/style-props.mdx
@@ -151,9 +151,6 @@ import { Box } from "@chakra-ui/react"
 // use theme sizing
 <Box boxSize="sm" />
 
-// width `50%`
-<Box w={1/2} />
-
 // width `256px`
 <Box w={256} />
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that add new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

So this PR removes the misleading example of using fractional values for layout sizes which should be converted into percentage values.

## ⛳️ Current behavior (updates)
When following the style-props docs, it is shown that using the following `<Box w={1/2} />` will give you a `50%` width, but in fact, you get the value representation of `var(--chakra-sizes-0\.5)` which is `0.125rem`.
This has been reported in the following issues: chakra-ui/chakra-ui#3396 chakra-ui/chakra-ui#3777 chakra-ui/chakra-ui#3673

## 🚀 New behavior

See https://github.com/chakra-ui/chakra-ui/issues/3396#issuecomment-790407805

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->
