### PR TITLE
Typo in typescript code

### DIFF
--- a/pages/guides/integrations/with-framer.mdx
+++ b/pages/guides/integrations/with-framer.mdx
@@ -74,7 +74,7 @@ import React from 'react'
 import { Box, BoxProps } from '@chakra-ui/layout'
 import { motion } from 'framer-motion'
 
-export const MotionBox = motion < BoxProps > Box
+export const MotionBox = motion<BoxProps>(Box)
 
 function Example() {
   return (


### PR DESCRIPTION
Also, in codesandbox edit link, this snippet 

```jsx
type Merge<P, T> = Omit<P, keyof T> & T;

type MotionBoxProps = Merge<HTMLChakraProps<"div">, HTMLMotionProps<"div">>;

export const MotionBox: React.FC<MotionBoxProps> = motion(chakra.div);
```

can be commented out (if the below snippet generate Typescript error, _see P/S_) and replaced by

```jsx
export const MotionBox = motion<BoxProps>(Box);
```

---
P/S: Example error using the replaced snippet

```jsx
export const TextMotion = motion<TextProps>(Text);

<TextMotion
  fontSize="2xl"
  fontWeight="semibold"
  fontFamily="cursive"
  w="100%"
  borderBottom="1px solid white"
  initial={{ x: 1000 }}
  animate={{ x: 0 }}
  transition={{ duration: 5 }} // <-- Error here
>
    Pizza Join
</TextMotion>

/*
Type '{ duration: number; }' is not assignable to type '(ResponsiveValue<Transition<string & {}>> & Transition) | undefined'.
  Type '{ duration: number; }' is not assignable to type 'undefined'.
*/
```

which will be fixed using the original snippet

```jsx
type Merge<P, T> = Omit<P, keyof T> & T;
type TextMotionProps = Merge<TextProps, HTMLMotionProps<"p">>;
export const TextMotionNoError: React.FC<TextMotionProps> = motion(Text);
```