### PR TITLE
docs(popover): omit enabled prop, resolves #183

### DIFF
--- a/pages/docs/overlay/popover.mdx
+++ b/pages/docs/overlay/popover.mdx
@@ -504,7 +504,7 @@ happen when the component is displayed.
 
 ### Popover Props
 
-<PropsTable of='Popover' />
+<PropsTable of='Popover' omit={['enabled']} />
 
 ### Other Props
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #183

## 📝 Description

Removes the `enabled` prop from Popover documentation

## ⛳️ Current behavior (updates)

`enabled` prop is shown in Popover documentation but is omitted from types as per https://github.com/chakra-ui/chakra-ui/issues/5155#issuecomment-984784300


## 🚀 New behavior

`enabled` prop is no longer shown in Popover documentation

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information