### PR TITLE
enhancemenet: enable source map in production mode

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -8,6 +8,7 @@ module.exports = withContentlayer()({
   images: {
     domains: ['img.youtube.com', 'avatars.githubusercontent.com'],
   },
+  productionBrowserSourceMaps: true,
   target: 'serverless',
   redirects: require('./next-redirect'),
 })


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #103 

## 📝 Description

Enable source map in production mode 

## 🚀 New behavior

Allow users to see the original code.

According to the nextjs doc, there are two caveats if we turn on `productionBrowserSourceMaps` 

- Increase building time when we run `next build`
- Increase memory usage when we're running `next build`

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information


