### PR TITLE
docs(icon): remove view theme source button from icon docs

### DIFF
--- a/pages/docs/media-and-icons/icon.mdx
+++ b/pages/docs/media-and-icons/icon.mdx
@@ -16,7 +16,6 @@ Chakra provides multiple ways to use icons in your project:
 > clickable icon, use the [IconButton](/docs/form/icon-button) instead.
 
 <ComponentLinks
-  theme={{ componentName: 'icon' }}
   github={{ package: 'icon' }}
   npm={{ package: '@chakra-ui/icon' }}
 />


### PR DESCRIPTION


Closes #178 

## 📝 Description

> The doc page for Icon contains the View theme source button, but there is no theme source for Icon. Clicking on the button produces a 404 page, so removed `View theme source` button from icon docs.

## ⛳️ Current behavior (updates)

> Currently, when you click `View theme source` button on icon docs, users land on 404 page

## 🚀 New behavior

> As there is no theme source for icon, we removed the corresponding button from docs

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information

Screenshot:

<img width="1419" alt="Screen Shot 2022-01-05 at 10 51 03 PM" src="https://user-images.githubusercontent.com/8125473/148326059-c55df7cd-a257-42dc-aab9-945c9050c122.png">

