### PR TITLE
fix(docs): Fix pagination order in hooks docs

### DIFF
--- a/configs/docs-sidebar.json
+++ b/configs/docs-sidebar.json
@@ -422,12 +422,12 @@
               "path": "/docs/hooks/use-clipboard"
             },
             {
-              "title": "useControllable",
-              "path": "/docs/hooks/use-controllable"
-            },
-            {
               "title": "useConst",
               "path": "/docs/hooks/use-const"
+            },
+            {
+              "title": "useControllable",
+              "path": "/docs/hooks/use-controllable"
             },
             {
               "title": "useDisclosure",


### PR DESCRIPTION


## 📝 Description

Fixes the order of Pagination for the hooks docs. Specifically the order of `useConst` and its previous and next order in its sibling pages.

## ⛳️ Current behavior (updates)

There is a disorder of navigation on the pages and skips back an extra page on the siblings of `useConst`/`useControllable`

## 🚀 New behavior

Pagination works as expected.


## 💣 Is this a breaking change (Yes/No):
No


