### PR TITLE
Clarify the useClipboard timeout parameter

### DIFF
--- a/pages/docs/hooks/use-clipboard.mdx
+++ b/pages/docs/hooks/use-clipboard.mdx
@@ -11,20 +11,20 @@ description:
 
 The `useClipboard` hook takes the following arguments:
 
-| Name               | Type                 | Required | Description                                                                                                |
-| ------------------ | -------------------- | -------- | ---------------------------------------------------------------------------------------------------------- |
-| `text`             | `string`             | `true`   | The text or value that is to be copied.                                                                    |
-| `optionsOrTimeout` | `number` or `object` | `false`  | The timeout as a `number` or an `object` containing 2 properties: `timeout` and `format` for the MIME type |
+| Name               | Type                 | Required | Description                                                                                                                                                                      |
+| ------------------ | -------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `text`             | `string`             | `true`   | The text or value that is to be copied.                                                                                                                                          |
+| `optionsOrTimeout` | `number` or `object` | `false`  | The timeout as a `number` or an `object` containing 2 properties: `timeout` and `format` for the MIME type. The timeout is measured in milliseconds and has a default of 1500ms. |
 
 ## Return value
 
 The `useClipboard` hook returns an object with the following fields:
 
-| Name        | Type       | Default | Description                              |
-| ----------- | ---------- | ------- | ---------------------------------------- |
-| `value`     | `string`   |         | The copied value.                        |
-| `onCopy`    | `function` |         | Callback function to copy content.       |
-| `hasCopied` | `boolean`  | `false` | If `true`, the content has been copied . |
+| Name        | Type       | Default | Description                                                                                                                                                                       |
+| ----------- | ---------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `value`     | `string`   |         | The copied value.                                                                                                                                                                 |
+| `onCopy`    | `function` |         | Callback function to copy content.                                                                                                                                                |
+| `hasCopied` | `boolean`  | `false` | If `true`, the content has been copied within the last `timeout` milliseconds. That is, it is set to true right after `onCopy` is called, and `false` after `timeout` has passed. |
 
 ## Import
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

The useClipboard documentation wasn't super clear, so I added information about defaults & units. I'm not particular about the language used, but it would be nice to have the default timeout of 1500ms specified!

## ⛳️ Current behavior (updates)

The `optionsOrTimeout` parameter is confusing.

## 🚀 New behavior

Adds more details about `optionsOrTimeout`.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Perhaps it would be even better if `optionsOrTimeout` was replaced with two parameters in the code, `options` and `timeout`. Then each idea is its own discrete unit that can be understood without reference to the other, reducing mental load.
