### PR TITLE
docs(tabs): fix the Tabs example to work properly and without type errors

### DIFF
--- a/pages/docs/disclosure/tabs.mdx
+++ b/pages/docs/disclosure/tabs.mdx
@@ -399,23 +399,21 @@ to pass state internally. Your custom `Tab` component must use
 
 ```jsx
 function CustomTabs() {
-
   const CustomTab = React.forwardRef((props, ref) => {
     // 1. Reuse the `useTab` hook
     const tabProps = useTab({ ...props, ref })
     const isSelected = !!tabProps['aria-selected']
 
     // 2. Hook into the Tabs `size`, `variant`, props
-    const styles = useMultiStyleConfig("Tabs", tabProps);
-
+    const styles = useMultiStyleConfig('Tabs', tabProps)
 
     return (
-      <Box __css={styles.tab} {...tabProps}>
+      <Button __css={styles.tab} {...tabProps}>
         <Box as='span' mr='2'>
           {isSelected ? '😎' : '😐'}
         </Box>
         {tabProps.children}
-      </Box>
+      </Button>
     )
   })
 

--- a/pages/docs/disclosure/tabs.mdx
+++ b/pages/docs/disclosure/tabs.mdx
@@ -399,24 +399,23 @@ to pass state internally. Your custom `Tab` component must use
 
 ```jsx
 function CustomTabs() {
-  // 1. Reuse the styles for the Tab
-  const StyledTab = chakra('button', { themeKey: 'Tabs.Tab' })
 
   const CustomTab = React.forwardRef((props, ref) => {
-    // 2. Reuse the `useTab` hook
+    // 1. Reuse the `useTab` hook
     const tabProps = useTab({ ...props, ref })
     const isSelected = !!tabProps['aria-selected']
 
-    // 3. Hook into the Tabs `size`, `variant`, props
-    const styles = useStyles()
+    // 2. Hook into the Tabs `size`, `variant`, props
+    const styles = useMultiStyleConfig("Tabs", tabProps);
+
 
     return (
-      <StyledTab __css={styles.tab} {...tabProps}>
+      <Box __css={styles.tab} {...tabProps}>
         <Box as='span' mr='2'>
           {isSelected ? '😎' : '😐'}
         </Box>
         {tabProps.children}
-      </StyledTab>
+      </Box>
     )
   })
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #76 

## 📝 Description
Modified the example for custom Tabs and removed the broken parts. Replaced them with the useMultiStylesConfig API.

## ⛳️ Current behavior (updates)

Type errors when using the factory with themeKey the example.

## 🚀 New behavior

No more type errors and example working as expected when pasting.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
-