### PR TITLE
docs: remove duplicate objectPosition prop definition

### DIFF
--- a/pages/docs/features/style-props.mdx
+++ b/pages/docs/features/style-props.mdx
@@ -522,7 +522,6 @@ following props:
 | `transition`      | `transition`       | none        |
 | `objectFit`       | `object-fit`       | none        |
 | `objectPosition`  | `object-position`  | none        |
-| `objectPosition`  | `object-position`  | none        |
 | `float`           | `float`            | none        |
 | `fill`            | `fill`             | `colors`    |
 | `stroke`          | `stroke`           | `colors`    |


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # NA

## 📝 Description

Removes duplicate style prop definition for `objectPosition`. 

## ⛳️ Current behavior (updates)

Currently, under the style props documentation, there is a duplicate definition for `objectPosition`. 

## 🚀 New behavior

This pull request removes the duplicate definition for `objectPosition` from the style props documentation.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

NA
