### PR TITLE
docs: clarify when initialFocusRef can be used on Popover

### DIFF
--- a/pages/docs/overlay/popover.mdx
+++ b/pages/docs/overlay/popover.mdx
@@ -99,6 +99,7 @@ portal, wrap the `PopoverContent` in a `Portal`
 
 By default, focus is to sent to `PopoverContent` when it opens. Pass the
 `initialFocusRef` prop to send focus to a specific element instead.
+> Focusing a child element only works for popovers with a `click` trigger, not `hover`.
 
 ```jsx
 function WalkthroughPopover() {


### PR DESCRIPTION
## 📝 Description

Our team was trying to get a button to focus in a Popover with a `hover` trigger. We would've saved a bunch of time if we found this comment earlier: https://github.com/chakra-ui/chakra-ui/issues/3820#issuecomment-820535397
Therefore I thought it could be helpful to clarify that in the Popover documentation

## ⛳️ Current behavior (updates)

This PR adds a note to the Popover documentation (see below)

<img width="810" alt="Screen Shot 2022-01-20 at 9 35 27 PM" src="https://user-images.githubusercontent.com/4600967/150456242-c8093375-0db9-427e-b225-4405cb980b58.png">


## 🚀 New behavior

n/a

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
