### PR TITLE
Remove inconsiderate language from FAQ

### DIFF
--- a/pages/faqs/index.mdx
+++ b/pages/faqs/index.mdx
@@ -7,5 +7,5 @@ description:
 
 ## Is there a Datepicker in Chakra UI?
 
-No, currently we don't provide a datepicker component. You can easily build your
-own custom Datepicker with Chakra UI and `react-datepicker` or `dayzed`.
+No, currently we don't provide a datepicker component. We recommend building your
+own custom datepicker with Chakra UI and either `react-datepicker` or `dayzed`.


### PR DESCRIPTION
Rewords the FAQ to remove the word "easily", which can be taken as condescending.