### PR TITLE
fix: sponsor logos objectFit property

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -600,10 +600,8 @@ const HomePage = ({
                       src={i.image}
                       alt={i.name}
                       loading='lazy'
-                      rounded='full'
                       width={40}
                       height={40}
-                      objectFit='cover'
                     />
                   </WrapItem>
                 ))}

--- a/src/components/chakra-next-image.tsx
+++ b/src/components/chakra-next-image.tsx
@@ -51,7 +51,7 @@ const ChakraNextImage = (props: ImageProps & FlexProps) => {
         quality={quality}
         height={height}
         placeholder='blur'
-        objectFit='cover'
+        objectFit='contain'
         blurDataURL={`data:image/svg+xml;base64,${toBase64(
           shimmer(+width, +height),
         )}`}


### PR DESCRIPTION
Closes #239 

## 📝 Description

Fix logo image's objectFit property.

## ⛳️ Current behavior (updates)

![image](https://user-images.githubusercontent.com/47717492/150693069-111a0dad-42d0-4ac5-ae75-5068f81ab392.png)


## 🚀 New behavior

Updates the `objectFit` property from `cover` to `contain`.

![image](https://user-images.githubusercontent.com/47717492/150693093-2f9ccc3d-a3a2-4d61-b905-90ce4eb7f784.png)


## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
