### PR TITLE
docs: fix typo in "ranging"

### DIFF
--- a/pages/docs/comparison.mdx
+++ b/pages/docs/comparison.mdx
@@ -140,7 +140,7 @@ Typography.
 
 ### Theming and Customizing
 
-Ant Design has a long list of default variables that can be modified rangining
+Ant Design has a long list of default variables that can be modified ranging
 from colors, paddings, margins, animations, shadows, borders, screen sizes,
 dimensions some being generic and some specific to UI components. Customization
 beyond modifying these existing variables is not recommended in order to respect


### PR DESCRIPTION
## 📝 Description

Fixes a small typo in the docs: "rangining" should read "ranging"
