### PR TITLE
docs: fix missing children in theming example

### DIFF
--- a/pages/docs/theming/component-style.mdx
+++ b/pages/docs/theming/component-style.mdx
@@ -224,7 +224,7 @@ function Card(props) {
   const styles = useStyleConfig('Card', { variant })
 
   // Pass the computed styles into the `__css` prop
-  return <Box __css={styles} {...rest} />
+  return <Box __css={styles} {...rest} >{children}</Box>
 }
 ```
 

--- a/pages/docs/theming/component-style.mdx
+++ b/pages/docs/theming/component-style.mdx
@@ -219,12 +219,12 @@ passed, the `defaultProps` defined in the style config will be used.
 import { Box, useStyleConfig } from '@chakra-ui/react'
 
 function Card(props) {
-  const { variant, children, ...rest } = props
+  const { variant, ...rest } = props
 
   const styles = useStyleConfig('Card', { variant })
 
   // Pass the computed styles into the `__css` prop
-  return <Box __css={styles} {...rest} >{children}</Box>
+  return <Box __css={styles} {...rest} />
 }
 ```
 


### PR DESCRIPTION
## 📝 Description

Adds `{children}`to theming example @ https://chakra-ui.com/docs/theming/component-style#return-value

## ⛳️ Current behavior (updates)

Theming example destructs `children` in line 222 but doesn't return it

## 🚀 New behavior

removes destructed `children` from theming example props

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
