### PR TITLE
bugfix: active sidebar link

### DIFF
--- a/src/components/sidebar/sidebar-link.tsx
+++ b/src/components/sidebar/sidebar-link.tsx
@@ -40,7 +40,7 @@ const SidebarLink = (props: SidebarLinkProps) => {
   const { href, icon, children, ...rest } = props
 
   const { asPath } = useRouter()
-  const isActive = asPath === href
+  const isActive = asPath.includes(href)
 
   return (
     <chakra.div


### PR DESCRIPTION
## 📝 Description

When entering a section in a doc from searching (or from a URL), the sidebar link is not highlighted.
For instance, enter this url: https://chakra-ui.com/docs/form/button#button-variants

## ⛳️ Current behavior (updates)

The Button sidebar link is not highlighted

## 🚀 New behavior

The Button sidebar link is highlighted

## 💣 Is this a breaking change (Yes/No): No


## 📝 Additional Information
