### PR TITLE
docs: fix code block language identifiers, cleanup imports in examples

### DIFF
--- a/pages/changelog/content.mdx
+++ b/pages/changelog/content.mdx
@@ -130,7 +130,7 @@ experience.
 Semantic tokens provide the ability to create css variables which can change
 with a CSS condition.
 
-```tsx live=false
+```jsx live=false
 import { ChakraProvider, extendTheme } from '@chakra-ui/react'
 
 const customTheme = extendTheme({
@@ -146,7 +146,7 @@ const App = () => (
 )
 ```
 
-```tsx live=false
+```jsx live=false
 import { ChakraProvider, extendTheme } from '@chakra-ui/react'
 
 const customTheme = extendTheme({
@@ -173,7 +173,7 @@ const App = () => (
 )
 ```
 
-```tsx live=false
+```jsx live=false
 import { extendTheme } from '@chakra-ui/react'
 
 const theme = extendTheme({
@@ -215,7 +215,7 @@ const theme = extendTheme({
 Semantic tokens provide the ability to create css variables which can change
 with a CSS condition.
 
-```tsx live=false
+```jsx live=false
 import { ChakraProvider, extendTheme } from '@chakra-ui/react'
 
 const customTheme = extendTheme({
@@ -231,7 +231,7 @@ const App = () => (
 )
 ```
 
-```tsx live=false
+```jsx live=false
 import { ChakraProvider, extendTheme } from '@chakra-ui/react'
 
 const customTheme = extendTheme({
@@ -258,7 +258,7 @@ const App = () => (
 )
 ```
 
-```tsx live=false
+```jsx live=false
 import { extendTheme } from '@chakra-ui/react'
 
 const theme = extendTheme({
@@ -323,7 +323,7 @@ Here's a table of the theme parts and entrypoints
 Semantic tokens provide the ability to create css variables which can change
 with a CSS condition.
 
-```tsx live=false
+```jsx live=false
 import { ChakraProvider, extendTheme } from '@chakra-ui/react'
 
 const customTheme = extendTheme({
@@ -339,7 +339,7 @@ const App = () => (
 )
 ```
 
-```tsx live=false
+```jsx live=false
 import { ChakraProvider, extendTheme } from '@chakra-ui/react'
 
 const customTheme = extendTheme({
@@ -366,7 +366,7 @@ const App = () => (
 )
 ```
 
-```tsx live=false
+```jsx live=false
 import { extendTheme } from '@chakra-ui/react'
 
 const theme = extendTheme({
@@ -568,7 +568,7 @@ Here's a full list of properties:
 chakra-cli tokens --strict-component-types
 ```
 
-```tsx live=false
+```jsx live=false
 // before
 <Button variant="abc" />
 // valid type but variant is not available in the theme
@@ -587,7 +587,7 @@ chakra-cli tokens --strict-component-types
 chakra-cli tokens --strict-component-types
 ```
 
-```tsx live=false
+```jsx live=false
 // before
 <Button variant="abc" />
 // valid type but variant is not available in the theme
@@ -1292,7 +1292,7 @@ $width.reference // => 'var(--slider-width)'
 
 Create a component anatomy
 
-```jsx live=false
+```tsx live=false
 import { anatomy }  from "@chakra-ui/theme-tools"
 import type { PartsStyle } from "@chakra-ui/theme-tools"
 
@@ -2561,7 +2561,7 @@ Update text align attribute to use end instead of right for RTL.
 - Introducing a generic TypeScript type `ChakraTheme` to improve the
   `extendTheme` function even further.
 
-```jsx live=false
+```tsx live=false
 import { extendTheme } from '@chakra-ui/react'
 
 export const customTheme = extendTheme({

--- a/pages/docs/features/chakra-factory.mdx
+++ b/pages/docs/features/chakra-factory.mdx
@@ -109,7 +109,7 @@ Another example that combines the default `shouldForwardProp` from Chakra UI
 with custom logic.
 
 ```jsx live=false
-import { shouldForwardProp } from '@chakra-ui/react'
+import { chakra, shouldForwardProp } from '@chakra-ui/react'
 
 const Div = chakra('div', {
   shouldForwardProp: (prop) => {
@@ -129,7 +129,7 @@ package.
 
 ```jsx live=false
 import isValidHTMLProp from '@emotion/is-prop-valid'
-import { shouldForwardProp } from '@chakra-ui/react'
+import { chakra, shouldForwardProp } from '@chakra-ui/react'
 
 const Div = chakra('div', {
   shouldForwardProp: (prop) => {

--- a/pages/docs/features/color-mode.mdx
+++ b/pages/docs/features/color-mode.mdx
@@ -58,11 +58,11 @@ export default theme
 For typescript, you need to explicitly describe the theme config type as
 `ThemeConfig` object.
 
-```jsx live=false
+```tsx live=false
 // theme.ts
 
 // 1. import `extendTheme` function
-import { extendTheme, ThemeConfig } from '@chakra-ui/react'
+import { extendTheme, type ThemeConfig } from '@chakra-ui/react'
 
 // 2. Add your color mode config
 const config: ThemeConfig = {

--- a/pages/docs/features/semantic-tokens.mdx
+++ b/pages/docs/features/semantic-tokens.mdx
@@ -79,7 +79,7 @@ const App = () => (
 
 ## Theme Example
 
-```tsx live=false
+```jsx live=false
 import { extendTheme } from '@chakra-ui/react'
 
 const theme = extendTheme({

--- a/pages/docs/hooks/use-prefers-reduced-motion.mdx
+++ b/pages/docs/hooks/use-prefers-reduced-motion.mdx
@@ -27,12 +27,7 @@ user prefers reduced motion.
 ## Usage
 
 ```jsx live=false
-import {
-  Image,
-  ImageProps,
-  keyframes,
-  usePrefersReducedMotion,
-} from '@chakra-ui/react'
+import { Image, keyframes, usePrefersReducedMotion } from '@chakra-ui/react'
 import logo from './logo.svg'
 
 const spin = keyframes`

--- a/pages/docs/theming/component-style.mdx
+++ b/pages/docs/theming/component-style.mdx
@@ -83,7 +83,7 @@ below.
 
 Here's a contrived implementation of the design:
 
-```jsx live=false
+```tsx live=false
 import type { ComponentStyleConfig } from '@chakra-ui/theme'
 
 // You can also use the more specific type for
@@ -321,7 +321,7 @@ export default {
 For example, here's what the style configurations for a custom menu component
 looks like:
 
-```jsx live=false
+```tsx live=false
 import type { ComponentStyleConfig } from '@chakra-ui/theme'
 
 // You can also use the more specific type for

--- a/pages/guides/as-prop.mdx
+++ b/pages/guides/as-prop.mdx
@@ -22,7 +22,7 @@ const Card = (props: BoxProps) => (
 and you need to consume this component in a way that works with the `as` prop,
 like this:
 
-```tsx live=false
+```jsx live=false
 const Usage = () => <Card as='button'>This is a card</Card>
 ```
 
@@ -80,7 +80,7 @@ Chakra enabled component.
 What you need to do is to call the `chakra` function and pass it any element or
 component type.
 
-```tsx live=false
+```jsx live=false
 import { chakra } from '@chakra-ui/react'
 
 const Card = chakra('div', {

--- a/pages/guides/integrations/with-framer.mdx
+++ b/pages/guides/integrations/with-framer.mdx
@@ -69,9 +69,8 @@ function Example() {
 
 For TypeScript users, here's what you need to do:
 
-```jsx live=false
-import React from 'react'
-import { Box, BoxProps } from '@chakra-ui/layout'
+```tsx live=false
+import { Box, type BoxProps } from '@chakra-ui/layout'
 import { motion } from 'framer-motion'
 
 export const MotionBox = motion<BoxProps>(Box)

--- a/pages/guides/integrations/with-hook-form.mdx
+++ b/pages/guides/integrations/with-hook-form.mdx
@@ -10,7 +10,6 @@ and the [React Hook Form](https://react-hook-form.com) form library:
 
 ```jsx live=false
 import { useForm } from 'react-hook-form'
-import React from 'react'
 import {
   FormErrorMessage,
   FormLabel,


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes -> no current issue

## 📝 Description

Fixes for wrong language identifiers on code blocks for examples (only searched for jsx and tsx).
Also some small cleanups for the imports in the regarding examples.

## ⛳️ Current behavior (updates)

Code block language identifier for jsx and tsx are inaccurate.

## 🚀 New behavior

Code block language identifier for jsx and tsx are accurate.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Thanks @aaarichter for finding that issue on https://github.com/chakra-ui/chakra-ui-docs/pull/295