### PR TITLE
docs: add portal hints for overlay components

### DIFF
--- a/pages/docs/overlay/alert-dialog.mdx
+++ b/pages/docs/overlay/alert-dialog.mdx
@@ -8,7 +8,9 @@ description:
 ---
 
 `AlertDialog` component is used to interrupt the user with a mandatory
-confirmation or action.
+confirmation or action. 
+It is rendered within a `portal` which mean u can not set e.g. a `filter` 
+with blur for the rest of your application.
 
 <ComponentLinks
   github={{ package: 'modal' }}

--- a/pages/docs/overlay/drawer.mdx
+++ b/pages/docs/overlay/drawer.mdx
@@ -11,6 +11,8 @@ description:
 The `Drawer` component is a panel that slides out from the edge of the screen.
 It can be useful when you need users to complete a task or view some details
 without leaving the current page.
+It is rendered within a `portal` which mean u can not set e.g. a `filter` 
+with blur for the rest of your application.
 
 <ComponentLinks
   theme={{ componentName: 'drawer' }}

--- a/pages/docs/overlay/menu.mdx
+++ b/pages/docs/overlay/menu.mdx
@@ -219,6 +219,8 @@ the component is displayed.
 
 To render menus in a portal, import the `Portal` component and wrap the
 `MenuList` within the `Portal`.
+This means u can not set e.g. a `filter` with blur for the rest of your 
+application.
 
 ```jsx
 <Menu>

--- a/pages/docs/overlay/modal.mdx
+++ b/pages/docs/overlay/modal.mdx
@@ -10,6 +10,8 @@ description:
 A dialog is a window overlaid on either the primary window or another dialog
 window. Content behind a modal dialog is **inert**, meaning that users cannot
 interact with it.
+It is rendered within a `portal` which mean u can not set e.g. a `filter` 
+with blur for the rest of your application.
 
 <ComponentLinks
   theme={{ componentName: 'modal' }}

--- a/pages/docs/overlay/popover.mdx
+++ b/pages/docs/overlay/popover.mdx
@@ -71,7 +71,9 @@ is critical for accessiblity.
 ## Rendering the Popover in a Portal
 
 By default, the Popover doesn't render in a Portal. To make them display in a
-portal, wrap the `PopoverContent` in a `Portal`
+portal, wrap the `PopoverContent` in a `Portal`.
+This means u can not set e.g. a `filter` with blur for the rest of your 
+application.
 
 > You might need to **Inspect Element** to see this in action. Notice that
 > `PopoverContent` is rendered as a child of `<body>`


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes -> no current issue

## 📝 Description

When you try to blur the background on opening e.g. a modal it will not work because the modal will be rendered in a portal. The only thing that can be blurred from this point is the modal itself or the children, which is obviously not the idea behind it.

## ⛳️ Current behavior (updates)

No direct hint that the overlay components are rendered within a Portal (only via props).

## 🚀 New behavior

Direct hint that the overlay components are rendered within a Portal.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
To be 100% correct the information needs also be on the Tooltip Page. But I hope that nobody come to the idea to try this. :laughing: 

I resolved this at work by adding a BlurContext which contains only a bool state hook so that I can use the bool in my pagelayout component. I am not happy with that solution and open for suggestions. 
I also considered the docs of https://github.com/chakra-ui/chakra-ui-docs/pull/263.