### PR TITLE
docs(contributing): updating contributing guide

### DIFF
--- a/pages/docs/contributing.mdx
+++ b/pages/docs/contributing.mdx
@@ -16,12 +16,11 @@ in all of your interactions with the project and our community.
 
 ## Getting started
 
-Please create a new branch from an up to date `master` on your fork. (Note:
-urgent hotfixes should be branched off the latest stable release rather than
-`master`)
+Please create a new branch from an up to date `main` on your fork. (Note: urgent
+hotfixes should be branched off the latest stable release rather than `main`)
 
-- Fork the Chakra UI repository on Github
-- Clone your fork to your local machine
+- Fork the Chakra UI repository on GitHub
+- Clone your fork on your local machine
   `git clone git@github.com:<yourname>/chakra-ui.git`
 - Create a branch `git checkout -b my-feature-branch`
 - Make your changes, lint, then push to GitHub with
@@ -40,16 +39,19 @@ git checkout -b my-feature-branch
 
 ## Docs contribution
 
-Chakra UI uses Gatsby for its documentation website. Thank you in advance and
-cheers for contributing to our documentation! We created a simple command to run
-it.
+Chakra UI uses Next.js for its documentation website. Thank you in advance and
+cheers for contributing to our documentation! To get started:
 
-```sh
-npm run docs:start
-```
+- Fork the [docsite repo](https://github.com/chakra-ui/chakra-ui-docs) on GitHub
+- Clone your fork on your local machine
+  `git clone git@github.com:<yourname>/chakra-ui-docs.git`
+- Create a branch `git checkout -b my-feature-branch`
+- Make your changes, lint, then push to GitHub with
+  `git push --set-upstream origin my-feature-branch`.
+- Visit GitHub and make your pull request.
 
-You can now access the documentation site locally. Changes to the docs will hot
-reload the site.
+To access the documentation site locally, simply run `npm run dev` or `yarn dev`
+and visit `localhost:3000`. Changes to the docs will hot reload the site.
 
 ### Documentation Goals
 
@@ -84,10 +86,6 @@ hit during heavy local docs development if the server is frequently restarted.
 
 Creating a GitHub token and storing it as the `GITHUB_TOKEN` environment
 variable allows the user to avoid the limit.
-
-## Code contribution
-
-TODO
 
 ## Code of Conduct
 


### PR DESCRIPTION
Closes #281 

## 📝 Description

The Contributing guide was outdated and wasn't refreshed since we've moved the docsite into its own repo.

## ⛳️ Current behavior (updates)

The Contributing guide has old and outdated steps.

## 🚀 New behavior

The Contributing guide is refreshed and explains how to get started with contributing on both the Chakra UI and docsite repos.

## 💣 Is this a breaking change (Yes/No):

No