### PR TITLE
fix: size of 'your company' box

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -51,6 +51,8 @@ import SandpackEmbed from 'components/sandpack-embed'
 import { App, Index } from 'configs/sandpack-contents/homepage/files'
 import ShowcaseSection from 'components/showcase/showcase-section'
 
+const openCollectiveLink = 'https://opencollective.com/chakra-ui'
+
 const Feature = ({ title, icon, children, ...props }) => {
   return (
     <Box
@@ -259,18 +261,26 @@ const HomePage = ({
                     </Link>
                   </WrapItem>
                 ))}
-              <Box
-                p='4'
-                border='1px dashed'
-                borderColor={useColorModeValue('teal.200', 'teal.500')}
-                bg={useColorModeValue('teal.50', 'whiteAlpha.200')}
-                rounded='md'
-              >
-                <Box as='span' mr='1' role='img'>
-                  💖
-                </Box>{' '}
-                {t('homepage.your-company')}
-              </Box>
+              <WrapItem>
+                <Button
+                  as='a'
+                  w='40'
+                  h='16'
+                  href={`${openCollectiveLink}/contribute`}
+                  rel='noopener'
+                  target='_blank'
+                  border='1px dashed'
+                  borderColor={useColorModeValue('teal.200', 'teal.500')}
+                  bg={useColorModeValue('teal.50', 'whiteAlpha.200')}
+                  _hover={{ bg: useColorModeValue('teal.100', 'whiteAlpha.300') }}
+                  rounded='md'
+                >
+                  <Box as='span' mr='1' role='img'>
+                    💖
+                  </Box>{' '}
+                  {t('homepage.your-company')}
+                </Button>
+              </WrapItem>
             </Wrap>
           </Container>
         </Box>
@@ -504,7 +514,7 @@ const HomePage = ({
                   as='a'
                   minW='7rem'
                   colorScheme='teal'
-                  href='https://opencollective.com/chakra-ui'
+                  href={openCollectiveLink}
                   rel='noopener'
                   target='_blank'
                 >


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes -> no current issue

## 📝 Description

The 'Your company' Box on the 'supported and backed by' section has a different width and height than the company link list items. The placeholder is also a div in an unordered list.

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

- Box has wrong width and height, which resulted in an alignment issue of the hole unordered list.
- div inside the unordered list

![image](https://user-images.githubusercontent.com/44474134/153691418-ad0fb76b-a99d-497d-9b96-5dd542996bad.png)


## 🚀 New behavior

- alignment of list items in the unordered list is fixed
- only list items in the unordered list 
- 'Your company' is now a link to the [membership plans](https://opencollective.com/chakra-ui/contribute), should be much easier to find for companies now. :money_with_wings: 

![image](https://user-images.githubusercontent.com/44474134/153691762-e1338dd2-bda7-4a1c-9dad-ec3ec2891c16.png)

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
