### PR TITLE
docs: add backdrop style section for modals

### DIFF
--- a/pages/docs/overlay/modal.mdx
+++ b/pages/docs/overlay/modal.mdx
@@ -446,6 +446,72 @@ there are certain situations where you might not want the modal to trap focus.
 
 To prevent focus trapping, pass `trapFocus` and set its value to `false`.
 
+### Styling the backdrop
+
+In the case you want to keep the users focus on the modal you can use the
+`backdropFilter` property. To do this you can add one or multiple filters and
+change the `bg` property, which is per default set to `blackAlpha.600`.
+
+Another approach is to use e.g. the `backdropBlur` or other similar defined
+properties. To do so you need to set the `backdropFilter` to `auto`.
+
+> Please be aware that not every browser supports the
+> [backdrop-filter](https://caniuse.com/css-backdrop-filter) CSS property.
+
+The `filter` property will have no effect on the background because the Modal is
+rendered within a `Portal`. This mean you can only style components within the
+Modal by using this property.
+
+```jsx
+function BackdropExample() {
+  const { isOpen, onOpen, onClose } = useDisclosure()
+  const [firstOverlay, setFirstOverlay] = React.useState(true)
+
+  const handleOnClick = (isFirst) => {
+    onOpen()
+    setFirstOverlay(isFirst)
+  }
+
+  const OverlayOne = () => (
+    <ModalOverlay
+      bg='blackAlpha.300'
+      backdropFilter='blur(10px) hue-rotate(90deg)'
+    />
+  )
+
+  const OverlayTwo = () => (
+    <ModalOverlay
+      bg='none'
+      backdropFilter='auto'
+      backdropInvert='80%'
+      backdropBlur='2px'
+    />
+  )
+
+  return (
+    <>
+      <Button onClick={() => handleOnClick(true)}>Use Overlay one</Button>
+      <Button ml='4' onClick={() => handleOnClick(false)}>
+        Use Overlay two
+      </Button>
+      <Modal isCentered isOpen={isOpen} onClose={onClose}>
+        {firstOverlay ? <OverlayOne /> : <OverlayTwo />}
+        <ModalContent>
+          <ModalHeader>Modal Title</ModalHeader>
+          <ModalCloseButton />
+          <ModalBody>
+            <Lorem count={1} />
+          </ModalBody>
+          <ModalFooter>
+            <Button onClick={onClose}>Close</Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </>
+  )
+}
+```
+
 ## Accessibility
 
 ### Keyboard and Focus Management

--- a/pages/docs/overlay/modal.mdx
+++ b/pages/docs/overlay/modal.mdx
@@ -448,15 +448,15 @@ To prevent focus trapping, pass `trapFocus` and set its value to `false`.
 
 ### Styling the backdrop
 
-In the case you want to keep the users focus on the modal you can use the
-`backdropFilter` property. To do this you can add one or multiple filters and
-change the `bg` property, which is per default set to `blackAlpha.600`.
-
-Another approach is to use e.g. the `backdropBlur` or other similar defined
-properties. To do so you need to set the `backdropFilter` to `auto`.
+The backdrop's background by default is set to `blackAlpha.600`, but if you want
+to achieve a different style you can also use the backdrop style props, like
+`backdropBlur`, `backdropBrightness`, `backdropContrast`, `backdropHueRotate`,
+`backdropInvert`, and `backdropSaturate`. To use these style props, you'd have
+to set the `backdropFilter` prop to `auto`.
 
 > Please be aware that not every browser supports the
-> [backdrop-filter](https://caniuse.com/css-backdrop-filter) CSS property.
+> [backdrop-filter](https://caniuse.com/css-backdrop-filter) CSS property, the
+> example below included.
 
 The `filter` property will have no effect on the background because the Modal is
 rendered within a `Portal`. This mean you can only style components within the
@@ -465,12 +465,7 @@ Modal by using this property.
 ```jsx
 function BackdropExample() {
   const { isOpen, onOpen, onClose } = useDisclosure()
-  const [firstOverlay, setFirstOverlay] = React.useState(true)
-
-  const handleOnClick = (isFirst) => {
-    onOpen()
-    setFirstOverlay(isFirst)
-  }
+  const [overlay, setOverlay] = React.useState()
 
   const OverlayOne = () => (
     <ModalOverlay
@@ -490,17 +485,30 @@ function BackdropExample() {
 
   return (
     <>
-      <Button onClick={() => handleOnClick(true)}>Use Overlay one</Button>
-      <Button ml='4' onClick={() => handleOnClick(false)}>
+      <Button
+        onClick={() => {
+          setOverlay(<OverlayOne />)
+          onOpen()
+        }}
+      >
+        Use Overlay one
+      </Button>
+      <Button
+        ml='4'
+        onClick={() => {
+          setOverlay(<OverlayTwo />)
+          onOpen()
+        }}
+      >
         Use Overlay two
       </Button>
       <Modal isCentered isOpen={isOpen} onClose={onClose}>
-        {firstOverlay ? <OverlayOne /> : <OverlayTwo />}
+        {overlay}
         <ModalContent>
           <ModalHeader>Modal Title</ModalHeader>
           <ModalCloseButton />
           <ModalBody>
-            <Lorem count={1} />
+            <Text>Custom backdrop filters!</Text>
           </ModalBody>
           <ModalFooter>
             <Button onClick={onClose}>Close</Button>

--- a/pages/docs/overlay/modal.mdx
+++ b/pages/docs/overlay/modal.mdx
@@ -464,9 +464,6 @@ Modal by using this property.
 
 ```jsx
 function BackdropExample() {
-  const { isOpen, onOpen, onClose } = useDisclosure()
-  const [overlay, setOverlay] = React.useState()
-
   const OverlayOne = () => (
     <ModalOverlay
       bg='blackAlpha.300'
@@ -482,6 +479,9 @@ function BackdropExample() {
       backdropBlur='2px'
     />
   )
+
+  const { isOpen, onOpen, onClose } = useDisclosure()
+  const [overlay, setOverlay] = React.useState(<OverlayOne />)
 
   return (
     <>


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #307 

## 📝 Description

Adding a section for styling the backdrop on modals.

## ⛳️ Current behavior (updates)

No information about and examples for styling the backdrop.

## 🚀 New behavior

Information about styling the backdrop with two editable examples.
Hint for browser compatibility.

Example 1 with blur and hue-rotate filters in the backdropFilter property:
![image](https://user-images.githubusercontent.com/44474134/153964630-b1ab29a0-a0aa-40e2-a500-bc64d29b24e0.png)

Example 2 with invert and blur filters in separated props and the backdropFilter set to 'auto':
![image](https://user-images.githubusercontent.com/44474134/153964658-380a71e1-03fd-408d-a85f-e1656951cf0c.png)


## 💣 Is this a breaking change (Yes/No):
No.

## 📝 Additional Information
