### PR TITLE
docs(responsive-styles): fixed example typo

### DIFF
--- a/pages/docs/features/responsive-styles.mdx
+++ b/pages/docs/features/responsive-styles.mdx
@@ -155,13 +155,13 @@ It'll generate a CSS that looks like this
   width: 100%;
 }
 
-@media screen and (min-width: 40em) {
+@media screen and (min-width: 30em) {
   .Box {
     width: 50%;
   }
 }
 
-@media screen and (min-width: 52em) {
+@media screen and (min-width: 48em) {
   .Box {
     width: 25%;
   }


### PR DESCRIPTION
Closes #219 

## 📝 Description

The "Under the Hood" example in the Responsive Styles page has wrong values.

## ⛳️ Current behavior (updates)

The example shows `40em` and `52em` for the `sm` and `md` breakpoints.

## 🚀 New behavior

The example shows `30em` and `48em` for the `sm` and `md` breakpoints.

## 💣 Is this a breaking change (Yes/No):

No