### PR TITLE
docs(checkbox): Replace deprecated defaultIsChecked attribute

### DIFF
--- a/pages/docs/form/checkbox.mdx
+++ b/pages/docs/form/checkbox.mdx
@@ -33,7 +33,7 @@ import { Checkbox, CheckboxGroup } from '@chakra-ui/react'
 Basic usage of `Checkbox`.
 
 ```jsx
-<Checkbox defaultIsChecked>Checkbox</Checkbox>
+<Checkbox defaultChecked>Checkbox</Checkbox>
 ```
 
 ### Disabled Checkbox
@@ -41,7 +41,7 @@ Basic usage of `Checkbox`.
 ```jsx
 <Stack spacing={5} direction='row'>
   <Checkbox isDisabled>Checkbox</Checkbox>
-  <Checkbox isDisabled defaultIsChecked>
+  <Checkbox isDisabled defaultChecked>
     Checkbox
   </Checkbox>
 </Stack>
@@ -54,10 +54,10 @@ in `theme.colors`.
 
 ```jsx
 <Stack spacing={5} direction='row'>
-  <Checkbox colorScheme='red' defaultIsChecked>
+  <Checkbox colorScheme='red' defaultChecked>
     Checkbox
   </Checkbox>
-  <Checkbox colorScheme='green' defaultIsChecked>
+  <Checkbox colorScheme='green' defaultChecked>
     Checkbox
   </Checkbox>
 </Stack>
@@ -73,10 +73,10 @@ Pass the `size` prop to change the size of the `Checkbox`. Values can be either
   <Checkbox size='sm' colorScheme='red'>
     Checkbox
   </Checkbox>
-  <Checkbox size='md' colorScheme='green' defaultIsChecked>
+  <Checkbox size='md' colorScheme='green' defaultChecked>
     Checkbox
   </Checkbox>
-  <Checkbox size='lg' colorScheme='orange' defaultIsChecked>
+  <Checkbox size='lg' colorScheme='orange' defaultChecked>
     Checkbox
   </Checkbox>
 </Stack>


### PR DESCRIPTION
## 📝 Description

The `defaultIsChecked` attribute is now marked deprecated and replaced with `defaultChecked` - the documented component examples should reflect this.

## ⛳️ Current behavior

`defaultisChecked` usage remains throughout:
https://chakra-ui.com/docs/form/checkbox


## 🚀 New behavior

Examples now use the supported attribute instead.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Nil