### PR TITLE
docs: faq and section for tooltip around disabled button

### DIFF
--- a/pages/docs/overlay/tooltip.mdx
+++ b/pages/docs/overlay/tooltip.mdx
@@ -102,6 +102,52 @@ cursor out of the element.
 </Tooltip>
 ```
 
+### Tooltip around disabled Button
+
+By default the `Tooltip` is not shown when it is around a disabled `Button`.
+
+```jsx
+<Tooltip hasArrow label='You can not see me'>
+  <Button isDisabled>Button</Button>
+</Tooltip>
+```
+
+To show the `Tooltip` on a disabled `Button` you need to give the `Tooltip` the
+`shouldWrapChildren` prop. This means that the `Button` is surrounded by a span 
+on which the `Tooltip` is pinned. 
+You could simply add a margin to the `Tooltip` to have it more or less 'pinned' 
+on the `Button` again.
+
+```jsx
+<Tooltip hasArrow label='You can see me' shouldWrapChildren mt='3'>
+  <Button isDisabled>Button</Button>
+</Tooltip>
+```
+
+> The `borderRadius` of `Buttons` with the `shouldWrapChildren` prop within 
+> a `ButtonGroup` with the `isAttached` prop will break. 
+> A workaround could be to pass the specific `borderRadius` depending on the
+> `isDisabled` prop of the `Button`.
+
+```jsx
+<ButtonGroup colorScheme="teal" isAttached>
+  <Tooltip label="works">
+    <Button>1</Button>
+  </Tooltip>
+
+  <Tooltip label="messes up border radius" shouldWrapChildren>
+    <Button isDisabled>2</Button>
+  </Tooltip>
+
+  <Tooltip label="this could be a workaround" shouldWrapChildren>
+    <Button isDisabled borderRadius='0'>3</Button>
+  </Tooltip>
+
+  <Button>4</Button>
+</ButtonGroup>
+```
+
+
 ## Placement
 
 Using the `placement` prop you can adjust where your tooltip will be displayed.

--- a/pages/docs/overlay/tooltip.mdx
+++ b/pages/docs/overlay/tooltip.mdx
@@ -112,11 +112,10 @@ By default the `Tooltip` is not shown when it is around a disabled `Button`.
 </Tooltip>
 ```
 
-To show the `Tooltip` on a disabled `Button` you need to give the `Tooltip` the
+To show the `Tooltip` on a disabled `Button` you need to provide the 
 `shouldWrapChildren` prop. This means that the `Button` is surrounded by a span 
-on which the `Tooltip` is pinned. 
-You could simply add a margin to the `Tooltip` to have it more or less 'pinned' 
-on the `Button` again.
+on which the `Tooltip` is pinned. You could simply add a margin to the `Tooltip` 
+to have it more or less 'pinned' on the `Button` again.
 
 ```jsx
 <Tooltip hasArrow label='You can see me' shouldWrapChildren mt='3'>
@@ -124,8 +123,9 @@ on the `Button` again.
 </Tooltip>
 ```
 
-> The `borderRadius` of `Buttons` with the `shouldWrapChildren` prop within 
-> a `ButtonGroup` with the `isAttached` prop will break. 
+> There's a case where the `borderRadius` of a button breaks when the button 
+> is in a `ButtonGroup` that has the `isAttached` prop set, and the tooltip 
+> has the `shouldWrapChildren` prop set.
 > A workaround could be to pass the specific `borderRadius` depending on the
 > `isDisabled` prop of the `Button`.
 

--- a/pages/faqs/index.mdx
+++ b/pages/faqs/index.mdx
@@ -12,8 +12,9 @@ own custom datepicker with Chakra UI and either `react-datepicker` or `dayzed`.
 
 ## Tooltip does not work around disabled Button
 
-In case you have wrapped a `Tooltip` around a disabled `Button` and you want that 
-the `Tooltip` still shows up you need to provide it the `shouldWrapChildren` prop.
+In case you have wrapped a `Tooltip` around a disabled `Button` and you still 
+want to show the `Tooltip`, you need to provide the `shouldWrapChildren` prop to 
+the `Tooltip`.
 
-Please be aware that this prop will break the `borderRadius` of the `Buttons` 
-within a `ButtonGroup` because it wraps a span around the disabled `Button`.
+Please be aware that this prop will break the `borderRadius` of the buttons 
+within a `ButtonGroup` because it wraps a span around the disabled buttons.

--- a/pages/faqs/index.mdx
+++ b/pages/faqs/index.mdx
@@ -9,3 +9,11 @@ description:
 
 No, currently we don't provide a datepicker component. We recommend building your
 own custom datepicker with Chakra UI and either `react-datepicker` or `dayzed`.
+
+## Tooltip does not work around disabled Button
+
+In case you have wrapped a `Tooltip` around a disabled `Button` and you want that 
+the `Tooltip` still shows up you need to provide it the `shouldWrapChildren` prop.
+
+Please be aware that this prop will break the `borderRadius` of the `Buttons` 
+within a `ButtonGroup` because it wraps a span around the disabled `Button`.


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #302 

## 📝 Description

Add an entry on the faq page and a section on the Tooltip page for Tooltips around disabled Buttons.

## ⛳️ Current behavior (updates)

No informations about Tooltips around disabled Buttons.

## 🚀 New behavior

Informations on faq page and a section on the Tooltip page.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

Thanks for asking/reporting and the codesandboxes to @DeeeeLAN on https://github.com/chakra-ui/chakra-ui/issues/5528 and @raulrpearson on https://github.com/chakra-ui/chakra-ui/issues/2849. :rocket: 