### PR TITLE
docs(breadcrumb): add section for separator in last item

### DIFF
--- a/pages/docs/navigation/breadcrumb.mdx
+++ b/pages/docs/navigation/breadcrumb.mdx
@@ -100,12 +100,12 @@ icon.
 </Breadcrumb>
 ```
 
-### Using a separator as last item
+### Using a separator in last item
 
-If you want to have a `BreadcrumbSeparator` as last item of the `Breadcrumb`
-you have different ways to achieve it. But to avoid the *'React does not 
-recognize the `isLastChild` prop on a DOM element.'* error you can not simply
-add the separator directly in the `Breadcrumb`.
+If you want to have a `BreadcrumbSeparator` in the last item of the 
+`Breadcrumb` you have different ways to achieve it. But to avoid the *'React 
+does not recognize the `isLastChild` prop on a DOM element.'* error you can not 
+simply add the separator directly in the `Breadcrumb`.
 
 The clean way to achieve it is to put the separator in the last
 `BreadcrumbItem`. Feel free to also inspect the example below with the browsers 

--- a/pages/docs/navigation/breadcrumb.mdx
+++ b/pages/docs/navigation/breadcrumb.mdx
@@ -100,6 +100,55 @@ icon.
 </Breadcrumb>
 ```
 
+### Using a separator as last item
+
+If you want to have a `BreadcrumbSeparator` as last item of the `Breadcrumb`
+you have different ways to achieve it. But to avoid the *'React does not 
+recognize the `isLastChild` prop on a DOM element.'* error you can not simply
+add the separator directly in the `Breadcrumb`.
+
+The clean way to achieve it is to put the separator in the last
+`BreadcrumbItem`. Feel free to also inspect the example below with the browsers 
+dev tools.
+
+```jsx
+<Box>
+  <Breadcrumb>
+    <BreadcrumbItem>
+      <BreadcrumbLink href="">Page 1</BreadcrumbLink>
+    </BreadcrumbItem>
+    <BreadcrumbItem>
+      <BreadcrumbLink href="">Page 2</BreadcrumbLink>
+    </BreadcrumbItem>
+    {/* this will generate a span in the ol HTML tag which causes the error: */}
+    {/* <BreadcrumbSeparator /> */}
+  </Breadcrumb>
+
+  {/* preferred solution: */}
+  <Breadcrumb pt="3">
+    <BreadcrumbItem>
+      <BreadcrumbLink href="">Page 1</BreadcrumbLink>
+    </BreadcrumbItem>
+    {/* this creates the exact same HTML as for page 1 */}
+    <BreadcrumbItem>
+      <BreadcrumbLink href="">Page 2</BreadcrumbLink>
+      <BreadcrumbSeparator />
+    </BreadcrumbItem>
+  </Breadcrumb>
+
+  <Breadcrumb pt="3">
+    <BreadcrumbItem>
+      <BreadcrumbLink href="">Page 1</BreadcrumbLink>
+    </BreadcrumbItem>
+    <BreadcrumbItem>
+      <BreadcrumbLink href="">Page 2</BreadcrumbLink>
+    </BreadcrumbItem>
+      {/* this works too, but creates an additional empty li HTML tag */}
+    <BreadcrumbItem />
+  </Breadcrumb>
+</Box>
+```
+
 ## Composition
 
 Breadcrumb composes [Box](/docs/layout/box) so you can pass all `Box` props to


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #138

## 📝 Description

Added a section for having a BreadcrumbSeparator on the last item of the Breadcrumb component.

## ⛳️ Current behavior (updates)

No information for using the separator as last Breadcrumb item.

## 🚀 New behavior

New section for using the separator as last Breadcrumb item. Also creation of clean HTML was taken into account.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

Thanks to @primos63 for the informations in https://github.com/chakra-ui/chakra-ui-docs/issues/138#issuecomment-990724557