### PR TITLE
fix: add text "view theme source" button

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,13 @@
 {
   "name": "@chakra-ui/docs",
   "version": "2.1.6",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/chakra-ui/chakra-ui-docs"
+  },
+  "bugs": {
+    "url": "https://github.com/chakra-ui/chakra-ui-docs/issues"
+  },
   "scripts": {
     "dev": "next",
     "build": "next build",

--- a/pages/docs/typography/text.mdx
+++ b/pages/docs/typography/text.mdx
@@ -8,6 +8,7 @@ description: Text is the used to render text and paragraphs within an interface.
 It renders a `<p>` tag by default.
 
 <ComponentLinks
+  theme={{ componentName: 'text' }}
   github={{ package: 'layout' }}
   npm={{ package: '@chakra-ui/layout' }}
 />


### PR DESCRIPTION
## 📝 Description

- [x] Adds missing "view theme source" button to Text documentation
- [x] adds package.json meta 

## ⛳️ Current behavior (updates)

![Bildschirmfoto 2022-02-25 um 10 38 14](https://user-images.githubusercontent.com/2707029/155692169-592b1644-92a0-49c6-97b4-ccffed94e90d.png)


## 🚀 New behavior
- adds "view theme source" button

<img width="800" alt="Bildschirmfoto 2022-02-25 um 10 37 50" src="https://user-images.githubusercontent.com/2707029/155692219-ba6e4eb2-80bd-4583-bc20-fb7ef4251576.png">

- adds repo meta info to package.json - so you can jump to the repo via `npm repo`

## 💣 Is this a breaking change (Yes/No):

NO

## 📝 Additional Information
