### PR TITLE
fix: improved handling for empty search results

### DIFF
--- a/src/components/omni-search.tsx
+++ b/src/components/omni-search.tsx
@@ -183,6 +183,10 @@ function OmniSearch() {
           break
         }
         case 'Enter': {
+          if (results?.length <= 0) {
+            break
+          }
+
           modal.onClose()
           router.push(results[active].url)
           break


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #348 

## 📝 Description

This adds a check if the results of the search are empty. If so then the 'Enter' event doesn't do anything. If not then it behaves as before.

## ⛳️ Current behavior (updates)

When search results are empty an error is thrown because we try to look something up in an empty array.

## 🚀 New behavior

Checks if the results array is empty before looking up the page to redirect to. Ignore the lookup if the array is empty.

## 💣 Is this a breaking change (Yes/No):

No
