### PR TITLE
fix: remix icon color and overlapping bgColor in framework link in dark mode

### DIFF
--- a/src/components/framework-link.tsx
+++ b/src/components/framework-link.tsx
@@ -21,7 +21,7 @@ const FrameworkLink = (props) => {
   return (
     <Link passHref href={href}>
       <ChakraLink textDecoration='none' _hover={{ textDecoration: 'none' }}>
-        <Box boxShadow='md' bg='white' borderRadius='lg' pt='4'>
+        <Box boxShadow='md' bg='white' borderRadius='xl' pt='4'>
           {children}
 
           <Center

--- a/src/components/framework-svg.tsx
+++ b/src/components/framework-svg.tsx
@@ -99,7 +99,7 @@ export const RemixSvg = ({ ...props }) => {
       role='img'
       width='1em'
       height='1em'
-      fill='currentColor'
+      fill='#000'
       {...props}
     >
       <title id='remix-run-logo-title'>Remix Logo</title>


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #359

## 📝 Description

Sets the color of the Remix SVG to black and fixes the overlapping of FrameworkLinks bgColor in the bottom corners in dark mode.

## ⛳️ Current behavior (updates)

- invisible color of Remix SVG due to fill set to currentColor
- overlapping pixels of the bgColor in the bottom corners

![image](https://user-images.githubusercontent.com/44474134/155846225-e8f359bf-404e-44a9-8385-506f646a32f9.png)


## 🚀 New behavior

- color of Remix SVG is set to black, similar to the Next.js SVG
- no white bgColor visible in the bottom corners by increasing the borderRadius

![image](https://user-images.githubusercontent.com/44474134/155846264-388af3b0-41e1-4a6c-94f5-1772202a14a0.png)


## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
