### PR TITLE
docs: remove global styles community examples section

### DIFF
--- a/pages/docs/features/global-styles.mdx
+++ b/pages/docs/features/global-styles.mdx
@@ -115,10 +115,3 @@ const theme = {
 
 // 3. That's it! Your app will now read and use the global styles
 ```
-
-## Community examples
-
-To help you better understand this concept, here are links to community projects
-that use custom global styles.
-
-- [Gatsby Starter i18n](https://git.habd.as/comfusion/gatsby-starter-i18n-react-i18next/src/branch/master/src/utils/theme.tsx)


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #369 

## 📝 Description

Remove the whole community example section of the global styles page because the only link within is broken.

## ⛳️ Current behavior (updates)

Constains only one link, which is broken.

## 🚀 New behavior

Remove the whole section.

## 💣 Is this a breaking change (Yes/No):

No.
