### PR TITLE
Fix installation step

### DIFF
--- a/pages/guides/getting-started/nextjs-guide.mdx
+++ b/pages/guides/getting-started/nextjs-guide.mdx
@@ -27,11 +27,11 @@ author: estheragbaje
 In your `nextjs` project, install Chakra UI by running either of the following:
 
 ```bash
-npm i @chakra-ui/react @emotion/react@^11 @emotion/styled@^11 framer-motion@^6
+npm i @chakra-ui/react @emotion/react @emotion/styled framer-motion
 ```
 
 ```bash
-yarn add @chakra-ui/react @emotion/react@^11 @emotion/styled@^11 framer-motion@^6
+yarn add @chakra-ui/react @emotion/react @emotion/styled framer-motion
 ```
 
 #### 2. Provider Setup


### PR DESCRIPTION
Currently, following the instructions as written results in `no matches found: @emotion/react@^11`.