### PR TITLE
chore: Remove depreciated deployment target in next.config.js

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -9,6 +9,5 @@ module.exports = withContentlayer()({
     domains: ['img.youtube.com', 'avatars.githubusercontent.com'],
   },
   productionBrowserSourceMaps: true,
-  target: 'serverless',
   redirects: require('./next-redirect'),
 })


### PR DESCRIPTION
## 📝 Description

Removes the `target` entry in `next.config.js` as it is [deprecated](https://nextjs.org/docs/messages/deprecated-target-config).

## ⛳️ Current behavior (updates)

Warnings appear in builds and development:

```
warn  - The `target` config is deprecated and will be removed in a future version.
See more info here https://nextjs.org/docs/messages/deprecated-target-config
```

## 🚀 New behavior

Warning no longer logged.

## 💣 Is this a breaking change (Yes/No):

No
