### PR TITLE
fix: Grid example closing tags

### DIFF
--- a/pages/changelog/content.mdx
+++ b/pages/changelog/content.mdx
@@ -812,9 +812,9 @@ template area.
 
 ```jsx live=false
 <Grid templateAreas='"one two three"'>
-   <GridItem area='one'>one</Grid>
-   <GridItem area='two'>two</Grid>
-   <GridItem area='three'>three</Grid>
+   <GridItem area='one'>one</GridItem>
+   <GridItem area='two'>two</GridItem>
+   <GridItem area='three'>three</GridItem>
 </Grid>
 ```
 


### PR DESCRIPTION
## 📝 Description

Currently, there is an error in the grid example, as a result of incorrect closing tags

## ⛳️ Current behavior (updates)
Grid has incorrect closing tags

## 🚀 New behavior
Grid closing tags are now correct

## 💣 Is this a breaking change (Yes/No):

No
