### PR TITLE
fix(style-props): add content property and example to style-props page

### DIFF
--- a/pages/docs/styled-system/features/style-props.mdx
+++ b/pages/docs/styled-system/features/style-props.mdx
@@ -577,6 +577,14 @@ import { Button } from "@chakra-ui/react"
   >
   </Box>
 </Box>
+
+// add ::before pseudo element
+<Box
+  _before={{ content: '"🙂"', display: 'inline-block', me: '5px'} // Note: the content value need an extra set of quotes!
+>
+A pseudo element
+</Box>
+
 ```
 
 | Prop                    | CSS Property                                                                                                                                                                               | Theme Field |
@@ -650,6 +658,7 @@ following props:
 | ----------------- | ------------------ | ----------- |
 | `animation`       | `animation`        | none        |
 | `appearance`      | `appearance`       | none        |
+| `content`         | `content`          | none        |
 | `transform`       | `transform`        | none        |
 | `transformOrigin` | `transform-origin` | none        |
 | `visibility`      | `visibility`       | none        |

--- a/pages/docs/styled-system/features/style-props.mdx
+++ b/pages/docs/styled-system/features/style-props.mdx
@@ -579,10 +579,11 @@ import { Button } from "@chakra-ui/react"
 </Box>
 
 // add ::before pseudo element
+// Note: the content value needs an extra set of quotes!
 <Box
-  _before={{ content: '"🙂"', display: 'inline-block', me: '5px'} // Note: the content value need an extra set of quotes!
+  _before={{ content: '"🙂"', display: 'inline-block', mr: '5px' }}
 >
-A pseudo element
+  A pseudo element
 </Box>
 
 ```


### PR DESCRIPTION
Closes # https://github.com/chakra-ui/chakra-ui/issues/561

## 📝 Description

- add missing `content` property & example for `::before` example with extra note about quotes

## ⛳️ Current behavior (updates)

- content prop is missing and no clear example for its usage

## 🚀 New behavior

- add missing `content` property & example for `::before` example with extra note about quotes

## 💣 Is this a breaking change (Yes/No):

no

## 📝 Additional Information
