### PR TITLE
feat: scroll sidebar when coming from overview

### DIFF
--- a/src/components/features-overview.tsx
+++ b/src/components/features-overview.tsx
@@ -106,7 +106,11 @@ export const FeaturesOverview = () => {
   return (
     <SimpleGrid mt='12' minChildWidth='15.625rem' spacing='8'>
       {features.map((feature) => (
-        <Link key={feature.title} passHref href={feature.routes[0].path}>
+        <Link
+          key={feature.title}
+          passHref
+          href={`${feature.routes[0].path}?scroll=true`}
+        >
           <Feature icon={icons[feature.title] ?? null} title={feature.title}>
             {feature.summarize
               ? `${feature.routes.length} ${changeFeatureText(feature.path)}`

--- a/src/components/sidebar/sidebar-link.tsx
+++ b/src/components/sidebar/sidebar-link.tsx
@@ -42,11 +42,11 @@ const SidebarLink = ({ href, children, ...rest }: SidebarLinkProps) => {
 
   const isActive = asPath.split('?')[0] === href
 
-  const link = useRef<HTMLAnchorElement>(null)
+  const link = useRef<HTMLAnchorElement>()
 
   useEffect(() => {
     if (isActive && query.scroll === 'true') {
-      link.current.scrollIntoView(true)
+      link.current.scrollIntoView({ block: 'center' })
     }
   }, [isActive, query])
 

--- a/src/components/sidebar/sidebar-link.tsx
+++ b/src/components/sidebar/sidebar-link.tsx
@@ -1,7 +1,7 @@
 import { PropsOf, chakra, useColorModeValue } from '@chakra-ui/react'
 import NextLink from 'next/link'
 import { useRouter } from 'next/router'
-import { forwardRef, Ref } from 'react'
+import { forwardRef, Ref, useEffect, useRef } from 'react'
 
 const StyledLink = forwardRef(function StyledLink(
   props: PropsOf<typeof chakra.a> & { isActive?: boolean },
@@ -38,8 +38,17 @@ type SidebarLinkProps = PropsOf<typeof chakra.div> & {
 }
 
 const SidebarLink = ({ href, children, ...rest }: SidebarLinkProps) => {
-  const { asPath } = useRouter()
-  const isActive = asPath === href
+  const { asPath, query } = useRouter()
+
+  const isActive = asPath.split('?')[0] === href
+
+  const link = useRef<HTMLAnchorElement>(null)
+
+  useEffect(() => {
+    if (isActive && query.scroll === 'true') {
+      link.current.scrollIntoView(true)
+    }
+  }, [isActive, query])
 
   return (
     <chakra.div
@@ -50,7 +59,9 @@ const SidebarLink = ({ href, children, ...rest }: SidebarLinkProps) => {
       {...rest}
     >
       <NextLink href={href} passHref>
-        <StyledLink isActive={isActive}>{children}</StyledLink>
+        <StyledLink isActive={isActive} ref={link}>
+          {children}
+        </StyledLink>
       </NextLink>
     </chakra.div>
   )


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #395 

## 📝 Description

This adds a scroll the sidebar when the user comes from the component / styled-system overviews. Like this the user sees where he actually is on the sidebard. The scroll event is not triggered when the user uses the sidebar normally.

## ⛳️ Current behavior (updates)

Sidebar is not scrolling as described in the issue. Kinda confusing for the user.

## 🚀 New behavior

Sidebar now scrolls.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
I chose to trigger the scroll event with a flag in the url as it only has to be triggered conditionally and from outside of the actual component where the event is triggered.