### PR TITLE
Ensure float label recipe behaves independently from label length

### DIFF
--- a/pages/docs/components/recipes/floating-labels.mdx
+++ b/pages/docs/components/recipes/floating-labels.mdx
@@ -33,7 +33,7 @@ Below is the gist to achieve floating labels.
   Box,
 } from '@chakra-ui/react'
 const activeLabelStyles = {
-  transform: 'scale(0.85) translateY(-24px) translateX(-10px)',
+  transform: 'scale(0.85) translateY(-24px)',
 }
 export const theme = extendTheme({
   components: {
@@ -60,6 +60,7 @@ export const theme = extendTheme({
               mx: 3,
               px: 1,
               my: 2,
+              transformOrigin: 'left top'
             },
           },
         },


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #379 

## 📝 Description

The given recipe for floating labels behaved differently based on the floating label length.

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

Using transformOrigin the floating label will always positioned the same.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
