### PR TITLE
docs(numberinput): added NumberInputField size hint.

### DIFF
--- a/pages/docs/components/form/number-input.mdx
+++ b/pages/docs/components/form/number-input.mdx
@@ -7,8 +7,9 @@ description:
   controls for incrementing or decrementing numeric values.
 ---
 
-The `NumberInput` component is similar to the [Input](/docs/components/form/input)
-component, but it has controls for incrementing or decrementing numeric values.
+The `NumberInput` component is similar to the
+[Input](/docs/components/form/input) component, but it has controls for
+incrementing or decrementing numeric values.
 
 <ComponentLinks
   theme={{ componentName: 'number-input' }}
@@ -364,7 +365,9 @@ NumberInput composes `Flex` with some additional props listed below.
 
 ### NumberInputField Props
 
-`NumberInput` composes `Input` so you can pass all `Input` props.
+`NumberInputField` composes `Input` so you can pass all `Input` props. If you
+want to change the size, pass the `size` prop to the `NumberInput` component
+instead, as [demonstrated above](#changing-the-size-of-the-input).
 
 ### NumberInputStepper Props
 


### PR DESCRIPTION
Closes #402 

## 📝 Description

Adding a short hint in the `NumberInputField` Props section about changing the size.

## ⛳️ Current behavior (updates)

The current documentation says that the `NumberInputField` composes `Input` so we can pass all `Input` props. This means that if we want to change the size we can set the `size` prop to the `NumberInputField` component, which is wrong in this case. To change the size we need to pass the `size` prop to the `NumberInput` component instead.

## 🚀 New behavior

I've added an additional hint in the "NumberInputField Props" section at the bottom regarding the size.

## 💣 Is this a breaking change (Yes/No):

No