### PR TITLE
fix(changelog): fixed changelog search meta url

### DIFF
--- a/configs/search-meta.json
+++ b/configs/search-meta.json
@@ -1,72 +1,72 @@
 [
   {
     "content": "Changelog",
-    "id": "e3513fd5-6fbd-4bdc-bfa6-c1d4165c2ebf",
+    "id": "2c4fb665-2d13-484e-8e5b-d519e33f2e36",
     "type": "lvl1",
-    "url": "/changelog/content",
+    "url": "/changelog/",
     "hierarchy": { "lvl1": "Changelog" }
   },
   {
     "content": "28-02-2022",
-    "id": "44f4fead-ae86-4eb0-aaa5-959b79ac5248",
+    "id": "cd580089-2c78-4e87-b3e8-ac55d24420c6",
     "type": "lvl2",
-    "url": "/changelog/content#28-02-2022",
+    "url": "/changelog/#28-02-2022",
     "hierarchy": { "lvl1": "Changelog", "lvl2": "28-02-2022", "lvl3": null }
   },
   {
     "content": "20-02-2022",
-    "id": "ec8e6449-11eb-4d4e-a878-21fad0b054bd",
+    "id": "fdb301f0-5571-4964-b819-6f9dab6495ce",
     "type": "lvl2",
-    "url": "/changelog/content#20-02-2022",
+    "url": "/changelog/#20-02-2022",
     "hierarchy": { "lvl1": "Changelog", "lvl2": "20-02-2022", "lvl3": null }
   },
   {
     "content": "20-02-2022",
-    "id": "1e617641-91a6-4b30-a72c-4e3ea7fc09b8",
+    "id": "fe093462-d597-4c96-af84-04b648299224",
     "type": "lvl2",
-    "url": "/changelog/content#20-02-2022-1",
+    "url": "/changelog/#20-02-2022-1",
     "hierarchy": { "lvl1": "Changelog", "lvl2": "20-02-2022", "lvl3": null }
   },
   {
     "content": "05-02-2022",
-    "id": "612d64b2-f6e9-40d2-b733-31143b292d23",
+    "id": "b71b827a-51a6-43b7-85f8-c8beb98dfa1d",
     "type": "lvl2",
-    "url": "/changelog/content#05-02-2022",
+    "url": "/changelog/#05-02-2022",
     "hierarchy": { "lvl1": "Changelog", "lvl2": "05-02-2022", "lvl3": null }
   },
   {
     "content": "05-02-2022",
-    "id": "305bb1e3-e14c-4f7d-8445-bc2fd84d25a3",
+    "id": "89d099b7-086e-4679-ac49-949792995d34",
     "type": "lvl2",
-    "url": "/changelog/content#05-02-2022-1",
+    "url": "/changelog/#05-02-2022-1",
     "hierarchy": { "lvl1": "Changelog", "lvl2": "05-02-2022", "lvl3": null }
   },
   {
     "content": "26-01-2022",
-    "id": "67b105b2-0d47-4b25-9998-effccde922fa",
+    "id": "cd986e48-e1da-45aa-819e-08405acc654a",
     "type": "lvl2",
-    "url": "/changelog/content#26-01-2022",
+    "url": "/changelog/#26-01-2022",
     "hierarchy": { "lvl1": "Changelog", "lvl2": "26-01-2022", "lvl3": null }
   },
   {
     "content": "25-01-2022",
-    "id": "fa07cb7b-56d7-42df-aabd-850a137ea92e",
+    "id": "f87e8d75-d4a7-4ed5-b3c7-5fd0ef32c0ed",
     "type": "lvl2",
-    "url": "/changelog/content#25-01-2022",
+    "url": "/changelog/#25-01-2022",
     "hierarchy": { "lvl1": "Changelog", "lvl2": "25-01-2022", "lvl3": null }
   },
   {
     "content": "06-01-2022",
-    "id": "a2a15e21-45df-47fb-a7c4-aa761ea9e0a5",
+    "id": "73d110df-8aec-4341-b581-fb530c02b26d",
     "type": "lvl2",
-    "url": "/changelog/content#06-01-2022",
+    "url": "/changelog/#06-01-2022",
     "hierarchy": { "lvl1": "Changelog", "lvl2": "06-01-2022", "lvl3": null }
   },
   {
     "content": "Add support for `area` prop on `GridItem`",
-    "id": "610bec27-1b4a-401c-9e71-c7ff6df5eee6",
+    "id": "fd76ff21-b89c-48c9-9cc2-0f350f356817",
     "type": "lvl3",
-    "url": "/changelog/content#add-support-for-area-prop-on-griditem",
+    "url": "/changelog/#add-support-for-area-prop-on-griditem",
     "hierarchy": {
       "lvl1": "Changelog",
       "lvl2": "06-01-2022",
@@ -75,16 +75,16 @@
   },
   {
     "content": "02-01-2022",
-    "id": "aa0ac0d4-f8ba-4ee4-8996-62effda57493",
+    "id": "1b613a55-19a4-46a0-87c8-704c669b6499",
     "type": "lvl2",
-    "url": "/changelog/content#02-01-2022",
+    "url": "/changelog/#02-01-2022",
     "hierarchy": { "lvl1": "Changelog", "lvl2": "02-01-2022", "lvl3": null }
   },
   {
     "content": "Add support peer pseudo style props",
-    "id": "e189d5e4-e222-4bc7-8e76-b213fcd954a1",
+    "id": "f4a489e1-ed0a-4873-bfab-1dfd64cc5948",
     "type": "lvl3",
-    "url": "/changelog/content#add-support-peer-pseudo-style-props",
+    "url": "/changelog/#add-support-peer-pseudo-style-props",
     "hierarchy": {
       "lvl1": "Changelog",
       "lvl2": "02-01-2022",
@@ -93,9 +93,9 @@
   },
   {
     "content": "New style props",
-    "id": "916d7670-88c0-4ac2-a1ae-dc9b5d51e71e",
+    "id": "2e7c0eb4-4497-4140-b7a2-1f07ced8980a",
     "type": "lvl3",
-    "url": "/changelog/content#new-style-props",
+    "url": "/changelog/#new-style-props",
     "hierarchy": {
       "lvl1": "Changelog",
       "lvl2": "Add support peer pseudo style props",
@@ -104,294 +104,294 @@
   },
   {
     "content": "09-12-2021",
-    "id": "faa16b4e-04f5-4cec-97f9-e8c19bb6b5f7",
+    "id": "d88f0b72-3653-431d-8a0f-9172b8c7c0f6",
     "type": "lvl2",
-    "url": "/changelog/content#09-12-2021",
+    "url": "/changelog/#09-12-2021",
     "hierarchy": { "lvl1": "Changelog", "lvl2": "09-12-2021", "lvl3": null }
   },
   {
     "content": "17-11-2021",
-    "id": "6d3310b8-13cb-4578-a503-e31176151f62",
+    "id": "5e434c64-7a6f-4986-94a7-93f3f2498860",
     "type": "lvl2",
-    "url": "/changelog/content#17-11-2021",
+    "url": "/changelog/#17-11-2021",
     "hierarchy": { "lvl1": "Changelog", "lvl2": "17-11-2021", "lvl3": null }
   },
   {
     "content": "12-11-2021",
-    "id": "34771a91-5271-4a97-8e31-daf1758923f6",
+    "id": "3747bd54-31bd-4542-b520-73069266a07f",
     "type": "lvl2",
-    "url": "/changelog/content#12-11-2021",
+    "url": "/changelog/#12-11-2021",
     "hierarchy": { "lvl1": "Changelog", "lvl2": "12-11-2021", "lvl3": null }
   },
   {
     "content": "09-11-2021",
-    "id": "ffeeb5ff-9c99-4246-ab74-86be6239703e",
+    "id": "7e2d9380-5a22-4b3d-9acf-a0cb6699b6c1",
     "type": "lvl2",
-    "url": "/changelog/content#09-11-2021",
+    "url": "/changelog/#09-11-2021",
     "hierarchy": { "lvl1": "Changelog", "lvl2": "09-11-2021", "lvl3": null }
   },
   {
     "content": "03-11-2021",
-    "id": "3a33c8eb-e196-401a-9cd1-03309a3457de",
+    "id": "1dc4976f-1920-43f8-be90-afab6d76936b",
     "type": "lvl2",
-    "url": "/changelog/content#03-11-2021",
+    "url": "/changelog/#03-11-2021",
     "hierarchy": { "lvl1": "Changelog", "lvl2": "03-11-2021", "lvl3": null }
   },
   {
     "content": "31-10-2021",
-    "id": "3920c719-0745-4890-8dfa-c1ca6b38a02e",
+    "id": "8bc0e0ea-0ebd-4884-9b6c-39a587fe3e5f",
     "type": "lvl2",
-    "url": "/changelog/content#31-10-2021",
+    "url": "/changelog/#31-10-2021",
     "hierarchy": { "lvl1": "Changelog", "lvl2": "31-10-2021", "lvl3": null }
   },
   {
     "content": "14-10-2021",
-    "id": "271760fb-7f4d-49c2-a94c-c5af8e38f0e5",
+    "id": "a849dc02-b703-4a91-bae0-fac78d20259c",
     "type": "lvl2",
-    "url": "/changelog/content#14-10-2021",
+    "url": "/changelog/#14-10-2021",
     "hierarchy": { "lvl1": "Changelog", "lvl2": "14-10-2021", "lvl3": null }
   },
   {
     "content": "05-10-2021",
-    "id": "928483a1-6456-44ac-8828-f37df7fa2453",
+    "id": "bc07fe93-5df0-48c5-8c66-4648df7967a0",
     "type": "lvl2",
-    "url": "/changelog/content#05-10-2021",
+    "url": "/changelog/#05-10-2021",
     "hierarchy": { "lvl1": "Changelog", "lvl2": "05-10-2021", "lvl3": null }
   },
   {
     "content": "20-09-2021",
-    "id": "77675514-89f3-4ad9-b1ae-7c903d38e099",
+    "id": "b787276f-c10f-4d1c-808a-cb9dc37a6458",
     "type": "lvl2",
-    "url": "/changelog/content#20-09-2021",
+    "url": "/changelog/#20-09-2021",
     "hierarchy": { "lvl1": "Changelog", "lvl2": "20-09-2021", "lvl3": null }
   },
   {
     "content": "29-08-2021",
-    "id": "cd16efe0-e1aa-4bc0-8e4a-727f4c866709",
+    "id": "4b39db46-6e3a-4b0d-94ad-f81367a82ba5",
     "type": "lvl2",
-    "url": "/changelog/content#29-08-2021",
+    "url": "/changelog/#29-08-2021",
     "hierarchy": { "lvl1": "Changelog", "lvl2": "29-08-2021", "lvl3": null }
   },
   {
     "content": "09-08-2021",
-    "id": "866071ff-001d-44a0-8165-0ab1bef4ae03",
+    "id": "afe92811-e2ce-4149-b104-c62960e2ce8c",
     "type": "lvl2",
-    "url": "/changelog/content#09-08-2021",
+    "url": "/changelog/#09-08-2021",
     "hierarchy": { "lvl1": "Changelog", "lvl2": "09-08-2021", "lvl3": null }
   },
   {
     "content": "08-07-2021",
-    "id": "aba2ff3a-fca4-445d-a852-3ee83e490390",
+    "id": "9110c669-3430-4338-a5bb-663a0ccff947",
     "type": "lvl2",
-    "url": "/changelog/content#08-07-2021",
+    "url": "/changelog/#08-07-2021",
     "hierarchy": { "lvl1": "Changelog", "lvl2": "08-07-2021", "lvl3": null }
   },
   {
     "content": "16-06-2021",
-    "id": "c753f94a-2efc-459f-bf7f-9b2edd7a4007",
+    "id": "d9b573c8-9334-44f8-919e-457a26d52d81",
     "type": "lvl2",
-    "url": "/changelog/content#16-06-2021",
+    "url": "/changelog/#16-06-2021",
     "hierarchy": { "lvl1": "Changelog", "lvl2": "16-06-2021", "lvl3": null }
   },
   {
     "content": "26-05-2021",
-    "id": "615fdaf6-7a87-4cdf-91cb-f552f65d93c4",
+    "id": "254b58d7-c07b-47d6-a1df-c13540fa3ffe",
     "type": "lvl2",
-    "url": "/changelog/content#26-05-2021",
+    "url": "/changelog/#26-05-2021",
     "hierarchy": { "lvl1": "Changelog", "lvl2": "26-05-2021", "lvl3": null }
   },
   {
     "content": "17-05-2021",
-    "id": "9266ec50-b842-4799-9112-6fd2c25d05f0",
+    "id": "2e4339b0-dca3-451c-9a42-6652130b0397",
     "type": "lvl2",
-    "url": "/changelog/content#17-05-2021",
+    "url": "/changelog/#17-05-2021",
     "hierarchy": { "lvl1": "Changelog", "lvl2": "17-05-2021", "lvl3": null }
   },
   {
     "content": "04-05-2021",
-    "id": "29d91c54-209c-46af-a63f-2958b6e78bbc",
+    "id": "dd42fdff-36a8-441d-af9d-ef388c7f3949",
     "type": "lvl2",
-    "url": "/changelog/content#04-05-2021",
+    "url": "/changelog/#04-05-2021",
     "hierarchy": { "lvl1": "Changelog", "lvl2": "04-05-2021", "lvl3": null }
   },
   {
     "content": "23-04-2021",
-    "id": "f880e74a-9637-4f37-bbbd-28b896109d42",
+    "id": "c2100d07-8fc5-4096-baeb-4374c437258a",
     "type": "lvl2",
-    "url": "/changelog/content#23-04-2021",
+    "url": "/changelog/#23-04-2021",
     "hierarchy": { "lvl1": "Changelog", "lvl2": "23-04-2021", "lvl3": null }
   },
   {
     "content": "19-04-2021",
-    "id": "3632ef80-cbab-4839-a10b-bbe8e1f0f105",
+    "id": "d48c9534-a91b-4e4b-9b5c-7df5451f09ee",
     "type": "lvl2",
-    "url": "/changelog/content#19-04-2021",
+    "url": "/changelog/#19-04-2021",
     "hierarchy": { "lvl1": "Changelog", "lvl2": "19-04-2021", "lvl3": null }
   },
   {
     "content": "13-04-2021",
-    "id": "d055c351-5b6d-4618-ba20-8ff6f01162b8",
+    "id": "e3c0d4f9-d45b-446c-9620-b580d4544d82",
     "type": "lvl2",
-    "url": "/changelog/content#13-04-2021",
+    "url": "/changelog/#13-04-2021",
     "hierarchy": { "lvl1": "Changelog", "lvl2": "13-04-2021", "lvl3": null }
   },
   {
     "content": "07-04-2021",
-    "id": "1fb62938-9654-4e0c-8dbd-2ababa5f6401",
+    "id": "ea6ec626-ed3c-4aaf-9a30-d011dd6862bf",
     "type": "lvl2",
-    "url": "/changelog/content#07-04-2021",
+    "url": "/changelog/#07-04-2021",
     "hierarchy": { "lvl1": "Changelog", "lvl2": "07-04-2021", "lvl3": null }
   },
   {
     "content": "30-03-2021",
-    "id": "ec132d68-9721-4154-a2d1-7db848130bf5",
+    "id": "945e4bf5-f420-4005-a28d-b9f7d76c6362",
     "type": "lvl2",
-    "url": "/changelog/content#30-03-2021",
+    "url": "/changelog/#30-03-2021",
     "hierarchy": { "lvl1": "Changelog", "lvl2": "30-03-2021", "lvl3": null }
   },
   {
     "content": "21-03-2021",
-    "id": "96609c99-b266-425a-9be6-86b9537cdbb8",
+    "id": "dea3377a-c7b2-4538-82ba-6cbfe80357c6",
     "type": "lvl2",
-    "url": "/changelog/content#21-03-2021",
+    "url": "/changelog/#21-03-2021",
     "hierarchy": { "lvl1": "Changelog", "lvl2": "21-03-2021", "lvl3": null }
   },
   {
     "content": "20-03-2021",
-    "id": "d5fd61be-9af5-42d7-83c3-b203d61636e9",
+    "id": "ae896b67-94e9-4443-9a9d-783e89b0c8ab",
     "type": "lvl2",
-    "url": "/changelog/content#20-03-2021",
+    "url": "/changelog/#20-03-2021",
     "hierarchy": { "lvl1": "Changelog", "lvl2": "20-03-2021", "lvl3": null }
   },
   {
     "content": "05-03-2021",
-    "id": "d6ac77df-f7ff-4d6c-8d5c-45254ce36392",
+    "id": "dfd6d7cc-2407-4ddc-88bd-7ae73e03f291",
     "type": "lvl2",
-    "url": "/changelog/content#05-03-2021",
+    "url": "/changelog/#05-03-2021",
     "hierarchy": { "lvl1": "Changelog", "lvl2": "05-03-2021", "lvl3": null }
   },
   {
     "content": "13-02-2021",
-    "id": "74b67a42-6c36-4709-af3f-5c954affee92",
+    "id": "64153445-41ce-4911-80f6-942aba6b90e5",
     "type": "lvl2",
-    "url": "/changelog/content#13-02-2021",
+    "url": "/changelog/#13-02-2021",
     "hierarchy": { "lvl1": "Changelog", "lvl2": "13-02-2021", "lvl3": null }
   },
   {
     "content": "06-02-2021",
-    "id": "7a194b84-f2a5-43b3-aae4-2f550f0be4e7",
+    "id": "f526c84a-a71c-4f25-8ab0-d3da271a8a75",
     "type": "lvl2",
-    "url": "/changelog/content#06-02-2021",
+    "url": "/changelog/#06-02-2021",
     "hierarchy": { "lvl1": "Changelog", "lvl2": "06-02-2021", "lvl3": null }
   },
   {
     "content": "31-01-2021",
-    "id": "6eef58bf-3088-4aa4-8bc2-44980337f425",
+    "id": "a6916979-af9e-47fb-91ca-d1d8debe7a46",
     "type": "lvl2",
-    "url": "/changelog/content#31-01-2021",
+    "url": "/changelog/#31-01-2021",
     "hierarchy": { "lvl1": "Changelog", "lvl2": "31-01-2021", "lvl3": null }
   },
   {
     "content": "31-01-2021",
-    "id": "8e2ababd-b959-4125-a1f5-9b1284a29ba9",
+    "id": "62bc2480-114b-4d22-9660-7113b9798a0d",
     "type": "lvl2",
-    "url": "/changelog/content#31-01-2021-1",
+    "url": "/changelog/#31-01-2021-1",
     "hierarchy": { "lvl1": "Changelog", "lvl2": "31-01-2021", "lvl3": null }
   },
   {
     "content": "24-01-2021",
-    "id": "32997479-d2b4-4390-a23b-dfcde4cab353",
+    "id": "7551b312-741d-4fb9-9704-7c11d1e887a0",
     "type": "lvl2",
-    "url": "/changelog/content#24-01-2021",
+    "url": "/changelog/#24-01-2021",
     "hierarchy": { "lvl1": "Changelog", "lvl2": "24-01-2021", "lvl3": null }
   },
   {
     "content": "17-01-2021",
-    "id": "59045520-862b-44f3-804e-3c548674e7ae",
+    "id": "406025c9-5b94-4e84-8f55-f256c9f2b4e5",
     "type": "lvl2",
-    "url": "/changelog/content#17-01-2021",
+    "url": "/changelog/#17-01-2021",
     "hierarchy": { "lvl1": "Changelog", "lvl2": "17-01-2021", "lvl3": null }
   },
   {
     "content": "11-01-2021",
-    "id": "52452646-a36e-493f-ac41-c18128a4c425",
+    "id": "3390dc07-ff9c-425b-b2dc-22348394da06",
     "type": "lvl2",
-    "url": "/changelog/content#11-01-2021",
+    "url": "/changelog/#11-01-2021",
     "hierarchy": { "lvl1": "Changelog", "lvl2": "11-01-2021", "lvl3": null }
   },
   {
     "content": "10-01-2021",
-    "id": "f4b3bba7-aa67-40dd-9e67-83ed7856f518",
+    "id": "761acf60-f623-4486-a93e-6219f866c956",
     "type": "lvl2",
-    "url": "/changelog/content#10-01-2021",
+    "url": "/changelog/#10-01-2021",
     "hierarchy": { "lvl1": "Changelog", "lvl2": "10-01-2021", "lvl3": null }
   },
   {
     "content": "03-01-2021",
-    "id": "d0f396de-7871-46af-9b80-8d046ab857c8",
+    "id": "6de66478-16bf-4d4d-a11e-d8fc8c9c0018",
     "type": "lvl2",
-    "url": "/changelog/content#03-01-2021",
+    "url": "/changelog/#03-01-2021",
     "hierarchy": { "lvl1": "Changelog", "lvl2": "03-01-2021", "lvl3": null }
   },
   {
     "content": "28-12-2020",
-    "id": "9493d339-f2e1-4b73-ad15-82adcfc471de",
+    "id": "6676e3e8-4b27-4b31-b82c-c0ef1e95738e",
     "type": "lvl2",
-    "url": "/changelog/content#28-12-2020",
+    "url": "/changelog/#28-12-2020",
     "hierarchy": { "lvl1": "Changelog", "lvl2": "28-12-2020", "lvl3": null }
   },
   {
     "content": "18-12-2020",
-    "id": "3bbe967e-d513-4551-8dd8-009b739f8449",
+    "id": "5250078f-4769-41ef-ad24-2020db596dde",
     "type": "lvl2",
-    "url": "/changelog/content#18-12-2020",
+    "url": "/changelog/#18-12-2020",
     "hierarchy": { "lvl1": "Changelog", "lvl2": "18-12-2020", "lvl3": null }
   },
   {
     "content": "08-12-2020",
-    "id": "89f01f83-ecec-4eea-82ba-2e9226a76e3f",
+    "id": "61d648a9-cd08-473a-b9e1-e879e24e4ca7",
     "type": "lvl2",
-    "url": "/changelog/content#08-12-2020",
+    "url": "/changelog/#08-12-2020",
     "hierarchy": { "lvl1": "Changelog", "lvl2": "08-12-2020", "lvl3": null }
   },
   {
     "content": "03-12-2020",
-    "id": "743541ad-ab5c-4f62-8718-f50760219a4e",
+    "id": "9e087156-fb2a-458c-81f0-0d83d37749d5",
     "type": "lvl2",
-    "url": "/changelog/content#03-12-2020",
+    "url": "/changelog/#03-12-2020",
     "hierarchy": { "lvl1": "Changelog", "lvl2": "03-12-2020", "lvl3": null }
   },
   {
     "content": "Badge",
-    "id": "ca599a0b-ab23-406c-a73f-4de9a2cba1af",
+    "id": "91a1bc7d-5d8b-4f13-a157-1f634086cafb",
     "type": "lvl1",
     "url": "/docs/components/data-display/badge",
     "hierarchy": { "lvl1": "Badge" }
   },
   {
     "content": "Import",
-    "id": "019f9646-a1c4-435b-b656-da6aeb43a394",
+    "id": "eff76990-0c57-4441-9809-660d1fb4471c",
     "type": "lvl2",
     "url": "/docs/components/data-display/badge#import",
     "hierarchy": { "lvl1": "Badge", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Usage",
-    "id": "4caf559e-2fa6-404d-9f77-f82233c69b17",
+    "id": "8c529e7f-ebcf-4c61-a41e-35e32321d2a6",
     "type": "lvl2",
     "url": "/docs/components/data-display/badge#usage",
     "hierarchy": { "lvl1": "Badge", "lvl2": "Usage", "lvl3": null }
   },
   {
     "content": "Badge Color",
-    "id": "9dbaf2ca-30b9-440a-a9dc-33f2851c4642",
+    "id": "f07f3182-35f5-427c-976a-bdb3daa06797",
     "type": "lvl3",
     "url": "/docs/components/data-display/badge#badge-color",
     "hierarchy": { "lvl1": "Badge", "lvl2": "Usage", "lvl3": "Badge Color" }
   },
   {
     "content": "Badge Variants",
-    "id": "e700e576-e521-48a7-8f43-4ca3f38b5917",
+    "id": "6b7769e4-2a43-4e8f-b8ec-52b6301bbcd3",
     "type": "lvl3",
     "url": "/docs/components/data-display/badge#badge-variants",
     "hierarchy": {
@@ -402,77 +402,77 @@
   },
   {
     "content": "Composition",
-    "id": "5821f99e-4677-4510-800b-5dd6c8b2ff04",
+    "id": "5519de80-8969-4bb0-b873-6015d8815d51",
     "type": "lvl2",
     "url": "/docs/components/data-display/badge#composition",
     "hierarchy": { "lvl1": "Badge", "lvl2": "Composition", "lvl3": null }
   },
   {
     "content": "Props",
-    "id": "5a808ae0-de5a-4c41-8899-e1feb286ebc3",
+    "id": "cd29dbe0-2cfd-4374-9018-f17f740726b6",
     "type": "lvl2",
     "url": "/docs/components/data-display/badge#props",
     "hierarchy": { "lvl1": "Badge", "lvl2": "Props", "lvl3": null }
   },
   {
     "content": "Code",
-    "id": "2ca07ae9-c2cf-42b7-b625-d1cb6a181af8",
+    "id": "07563dfe-a025-44e8-a749-b3aa2b86e025",
     "type": "lvl1",
     "url": "/docs/components/data-display/code",
     "hierarchy": { "lvl1": "Code" }
   },
   {
     "content": "Import",
-    "id": "195b0083-343e-49b0-b480-7f807ff016df",
+    "id": "96a986fe-b771-41f3-976d-bf755455c274",
     "type": "lvl2",
     "url": "/docs/components/data-display/code#import",
     "hierarchy": { "lvl1": "Code", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Usage",
-    "id": "49223283-7dfd-4807-80a9-9ef2f99b2b2b",
+    "id": "11ee5311-314c-4f66-ae5e-775212a32237",
     "type": "lvl2",
     "url": "/docs/components/data-display/code#usage",
     "hierarchy": { "lvl1": "Code", "lvl2": "Usage", "lvl3": null }
   },
   {
     "content": "Colors",
-    "id": "e707b3d6-d56d-4fd0-9b77-01681d231551",
+    "id": "96eaa0f6-ed1b-41a9-8484-95cdf159eaad",
     "type": "lvl3",
     "url": "/docs/components/data-display/code#colors",
     "hierarchy": { "lvl1": "Code", "lvl2": "Usage", "lvl3": "Colors" }
   },
   {
     "content": "Props",
-    "id": "6bfd56bf-197c-4eaf-9039-6e261233527b",
+    "id": "895de081-e85b-4bfd-ba89-6711f0e33ce7",
     "type": "lvl2",
     "url": "/docs/components/data-display/code#props",
     "hierarchy": { "lvl1": "Code", "lvl2": "Props", "lvl3": null }
   },
   {
     "content": "Divider",
-    "id": "926f62ed-21f6-4598-a66b-195dd9cfea70",
+    "id": "bbfa2692-5ba7-4105-a2a3-d4135a3c948e",
     "type": "lvl1",
     "url": "/docs/components/data-display/divider",
     "hierarchy": { "lvl1": "Divider" }
   },
   {
     "content": "Import",
-    "id": "a23d5592-17f2-4811-8014-a40bd36411f5",
+    "id": "f2f0d997-6ec3-49b9-8c3c-13d2c35ce4a1",
     "type": "lvl2",
     "url": "/docs/components/data-display/divider#import",
     "hierarchy": { "lvl1": "Divider", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Usage",
-    "id": "0cb0a5e2-821a-4bb1-87bc-1a347dc8b666",
+    "id": "46af3ece-f8e5-4ca3-ba3b-8913ec06fcb1",
     "type": "lvl2",
     "url": "/docs/components/data-display/divider#usage",
     "hierarchy": { "lvl1": "Divider", "lvl2": "Usage", "lvl3": null }
   },
   {
     "content": "Divider Orientation",
-    "id": "013dfaed-bc92-4f59-af10-faf4b3f1f4eb",
+    "id": "a82062a3-e4dd-429f-844a-e26b3e4bc993",
     "type": "lvl3",
     "url": "/docs/components/data-display/divider#divider-orientation",
     "hierarchy": {
@@ -483,77 +483,77 @@
   },
   {
     "content": "Composition",
-    "id": "4251e35f-e929-4c95-b6c8-714d167120d6",
+    "id": "fca3147a-12eb-4de7-8353-e119a277f8d7",
     "type": "lvl2",
     "url": "/docs/components/data-display/divider#composition",
     "hierarchy": { "lvl1": "Divider", "lvl2": "Composition", "lvl3": null }
   },
   {
     "content": "Props",
-    "id": "10e65ee9-d5d4-486e-9ead-5954d57ed0b8",
+    "id": "c15b8c2a-31e6-4b50-9fda-babc607a7af0",
     "type": "lvl2",
     "url": "/docs/components/data-display/divider#props",
     "hierarchy": { "lvl1": "Divider", "lvl2": "Props", "lvl3": null }
   },
   {
     "content": "Keyboard Key",
-    "id": "28ef6c3a-6b1b-4960-a1f8-8f6d0a7deb40",
+    "id": "125d41ae-0b7c-4d05-8bfb-b5da4d2ca599",
     "type": "lvl1",
     "url": "/docs/components/data-display/kbd",
     "hierarchy": { "lvl1": "Keyboard Key" }
   },
   {
     "content": "Import",
-    "id": "412de2e7-7f64-4ecc-bdc2-b03d5bb1fba9",
+    "id": "d0efcd23-53a2-41ca-b6f3-6933e2ed734b",
     "type": "lvl2",
     "url": "/docs/components/data-display/kbd#import",
     "hierarchy": { "lvl1": "Keyboard Key", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Guideline",
-    "id": "98cdd1d4-8793-4318-96e0-88f51c95ec2d",
+    "id": "29aaa588-7425-4e24-b31d-f56948f72e9e",
     "type": "lvl2",
     "url": "/docs/components/data-display/kbd#guideline",
     "hierarchy": { "lvl1": "Keyboard Key", "lvl2": "Guideline", "lvl3": null }
   },
   {
     "content": "Modifier",
-    "id": "0a72055c-e514-4d60-992a-6576c0055f83",
+    "id": "06a92db4-4cee-4ea6-8fa8-f864e9a05a77",
     "type": "lvl2",
     "url": "/docs/components/data-display/kbd#modifier",
     "hierarchy": { "lvl1": "Keyboard Key", "lvl2": "Modifier", "lvl3": null }
   },
   {
     "content": "List",
-    "id": "16f8efb3-3002-4d2b-b15b-d91dd694e97f",
+    "id": "952fc468-1410-44df-8785-6edf3fb083f7",
     "type": "lvl1",
     "url": "/docs/components/data-display/list",
     "hierarchy": { "lvl1": "List" }
   },
   {
     "content": "Import",
-    "id": "0c1a22d1-b56d-42aa-89c3-77ab58ae9ec3",
+    "id": "054a07ba-c0e3-4919-9be4-09ec2c0c85ad",
     "type": "lvl2",
     "url": "/docs/components/data-display/list#import",
     "hierarchy": { "lvl1": "List", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Unordered List",
-    "id": "76d342df-5dce-4179-b0fc-74228a0ecdc4",
+    "id": "30e8256b-12f6-41a4-915b-6becc7f18959",
     "type": "lvl2",
     "url": "/docs/components/data-display/list#unordered-list",
     "hierarchy": { "lvl1": "List", "lvl2": "Unordered List", "lvl3": null }
   },
   {
     "content": "Ordered List",
-    "id": "01d727d3-0fd7-4a0e-8412-26beabba5c94",
+    "id": "f2f524ed-82a6-4c46-9cd6-b02af9d09c47",
     "type": "lvl2",
     "url": "/docs/components/data-display/list#ordered-list",
     "hierarchy": { "lvl1": "List", "lvl2": "Ordered List", "lvl3": null }
   },
   {
     "content": "Unstyled List with icon",
-    "id": "fa8e3171-b0f5-4b09-8b72-f8ca300eeb06",
+    "id": "db51dc1e-cb15-4808-9d1a-7ccccf8488ad",
     "type": "lvl2",
     "url": "/docs/components/data-display/list#unstyled-list-with-icon",
     "hierarchy": {
@@ -564,21 +564,21 @@
   },
   {
     "content": "Props",
-    "id": "29f085c7-5c01-4080-a420-ab4f10dfa2f7",
+    "id": "5a4c7cce-51df-423a-a96e-dc3e251cce0c",
     "type": "lvl2",
     "url": "/docs/components/data-display/list#props",
     "hierarchy": { "lvl1": "List", "lvl2": "Props", "lvl3": null }
   },
   {
     "content": "List Props",
-    "id": "1b942665-d196-41da-8583-9df12dead965",
+    "id": "f462aac0-9af2-41ef-8f20-1fa2155707b5",
     "type": "lvl3",
     "url": "/docs/components/data-display/list#list-props",
     "hierarchy": { "lvl1": "List", "lvl2": "Props", "lvl3": "List Props" }
   },
   {
     "content": "List Item Props",
-    "id": "2243ab6e-1736-4b4a-9b6d-f1a64ce1efc7",
+    "id": "1a9962e3-6c4d-42ec-a018-68d392aa6bee",
     "type": "lvl3",
     "url": "/docs/components/data-display/list#list-item-props",
     "hierarchy": {
@@ -589,28 +589,28 @@
   },
   {
     "content": "Stat",
-    "id": "c8a4cc5a-7d4a-4a34-bd18-3b3895756d08",
+    "id": "1b045099-f4e6-46c4-bb34-20741b09c1cd",
     "type": "lvl1",
     "url": "/docs/components/data-display/stat",
     "hierarchy": { "lvl1": "Stat" }
   },
   {
     "content": "Import",
-    "id": "0d4b1b36-15d9-4039-927c-d0d8093c7080",
+    "id": "b9583cf4-a9c0-4577-8238-19af141ae4b5",
     "type": "lvl2",
     "url": "/docs/components/data-display/stat#import",
     "hierarchy": { "lvl1": "Stat", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Basic Usage",
-    "id": "749311cf-765d-4a45-a946-5dee227086f7",
+    "id": "7d925703-f12f-4a6d-a956-5db283afed03",
     "type": "lvl2",
     "url": "/docs/components/data-display/stat#basic-usage",
     "hierarchy": { "lvl1": "Stat", "lvl2": "Basic Usage", "lvl3": null }
   },
   {
     "content": "Stat with Indicator",
-    "id": "a3023437-5033-43e0-b5be-1378dcd0fdd0",
+    "id": "8e27031e-5f4d-4a3d-8145-cef0375baec4",
     "type": "lvl3",
     "url": "/docs/components/data-display/stat#stat-with-indicator",
     "hierarchy": {
@@ -621,35 +621,35 @@
   },
   {
     "content": "Props",
-    "id": "2be7aeca-a8d1-4518-b8d0-bf5fa5a3985e",
+    "id": "b340bc5a-d8c6-49ee-a9d6-2a01a9353a8e",
     "type": "lvl2",
     "url": "/docs/components/data-display/stat#props",
     "hierarchy": { "lvl1": "Stat", "lvl2": "Props", "lvl3": null }
   },
   {
     "content": "Table",
-    "id": "0e5cc183-df22-48ec-ad4d-af0dedc74ca0",
+    "id": "87c654d4-2891-4f2a-bb43-7e9752170cc9",
     "type": "lvl1",
     "url": "/docs/components/data-display/table",
     "hierarchy": { "lvl1": "Table" }
   },
   {
     "content": "Import",
-    "id": "7f2d0414-ac38-458f-a918-bdfc64e031fd",
+    "id": "1774287b-af18-450b-b67f-6efb727315c8",
     "type": "lvl2",
     "url": "/docs/components/data-display/table#import",
     "hierarchy": { "lvl1": "Table", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Table Variants",
-    "id": "ce22dd75-4602-4bbb-a49b-ff8dd79a3855",
+    "id": "04d5fb11-04ed-4caa-9087-8a1b7d52e00f",
     "type": "lvl2",
     "url": "/docs/components/data-display/table#table-variants",
     "hierarchy": { "lvl1": "Table", "lvl2": "Table Variants", "lvl3": null }
   },
   {
     "content": "Simple Table",
-    "id": "94574c6c-570a-4e5a-b15f-0ae046d209e9",
+    "id": "4f43fe92-076b-42e5-9be1-112c47679089",
     "type": "lvl3",
     "url": "/docs/components/data-display/table#simple-table",
     "hierarchy": {
@@ -660,7 +660,7 @@
   },
   {
     "content": "Striped Table",
-    "id": "6d388b99-5d40-4b46-a96f-9db08a6c5ab1",
+    "id": "f27267ec-d500-41fe-bb56-c8b295bbb605",
     "type": "lvl3",
     "url": "/docs/components/data-display/table#striped-table",
     "hierarchy": {
@@ -671,126 +671,126 @@
   },
   {
     "content": "Table Sizing",
-    "id": "a6f55517-7f3f-4c1b-a78c-d46e4407ea74",
+    "id": "fb689825-0357-433e-b28a-41c36e74bd1c",
     "type": "lvl2",
     "url": "/docs/components/data-display/table#table-sizing",
     "hierarchy": { "lvl1": "Table", "lvl2": "Table Sizing", "lvl3": null }
   },
   {
     "content": "Props",
-    "id": "fafb09ec-07f8-4642-97b2-1f09c50ab169",
+    "id": "e14c4c2c-0bfb-457f-8dab-190bb7ec4485",
     "type": "lvl2",
     "url": "/docs/components/data-display/table#props",
     "hierarchy": { "lvl1": "Table", "lvl2": "Props", "lvl3": null }
   },
   {
     "content": "Table",
-    "id": "ed9c4efb-5f6b-471e-8fdd-058c43df1efc",
+    "id": "849b133c-f6c5-43f2-8447-d047638d8d39",
     "type": "lvl3",
     "url": "/docs/components/data-display/table#table",
     "hierarchy": { "lvl1": "Table", "lvl2": "Props", "lvl3": "Table" }
   },
   {
     "content": "Td",
-    "id": "17455dfd-e603-434f-8ca6-9d509622c597",
+    "id": "25bd6237-74c8-4444-a449-dda4eaaf5d35",
     "type": "lvl3",
     "url": "/docs/components/data-display/table#td",
     "hierarchy": { "lvl1": "Table", "lvl2": "Table", "lvl3": "Td" }
   },
   {
     "content": "Th",
-    "id": "a412c736-9ca9-45a9-b53f-925536c494e4",
+    "id": "c2906aaf-edf1-4ce2-92eb-e58fc52e0e09",
     "type": "lvl3",
     "url": "/docs/components/data-display/table#th",
     "hierarchy": { "lvl1": "Table", "lvl2": "Td", "lvl3": "Th" }
   },
   {
     "content": "TableCaption",
-    "id": "a681409d-2c15-41ab-b4a1-2283326feadb",
+    "id": "8a5a8498-8ee6-4dbf-a9bc-427adcca46a7",
     "type": "lvl3",
     "url": "/docs/components/data-display/table#tablecaption",
     "hierarchy": { "lvl1": "Table", "lvl2": "Th", "lvl3": "TableCaption" }
   },
   {
     "content": "Tag",
-    "id": "e14f9455-e48b-4b38-8bce-1a111160587d",
+    "id": "e9f50a24-4974-436f-bd84-b0c079e9241b",
     "type": "lvl1",
     "url": "/docs/components/data-display/tag",
     "hierarchy": { "lvl1": "Tag" }
   },
   {
     "content": "Import",
-    "id": "46562733-4d9b-4d08-8d86-3dd79d0ccefb",
+    "id": "97cb2cf7-7515-4ab3-ab7c-85f19975bdea",
     "type": "lvl2",
     "url": "/docs/components/data-display/tag#import",
     "hierarchy": { "lvl1": "Tag", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Usage",
-    "id": "36c86ee3-0873-47e1-9aa9-bceb5bdd2f70",
+    "id": "a58f6945-7403-4e69-a00b-eb3f3b31b4a5",
     "type": "lvl2",
     "url": "/docs/components/data-display/tag#usage",
     "hierarchy": { "lvl1": "Tag", "lvl2": "Usage", "lvl3": null }
   },
   {
     "content": "With left icon",
-    "id": "be33daf4-6687-4c4c-ab16-1fa280d4e53b",
+    "id": "dd3ae5ff-9c2f-4037-a2cf-9a0d55acc9c1",
     "type": "lvl2",
     "url": "/docs/components/data-display/tag#with-left-icon",
     "hierarchy": { "lvl1": "Tag", "lvl2": "With left icon", "lvl3": null }
   },
   {
     "content": "With right icon",
-    "id": "35376c4b-4cdc-4720-90a2-76754bc7a977",
+    "id": "df9f89fc-f973-4cad-9a49-1fc7678c3096",
     "type": "lvl2",
     "url": "/docs/components/data-display/tag#with-right-icon",
     "hierarchy": { "lvl1": "Tag", "lvl2": "With right icon", "lvl3": null }
   },
   {
     "content": "With close button",
-    "id": "9f67c9d3-79c9-40f7-9139-653f7e9b7ec4",
+    "id": "2f622071-3cd3-4895-9bc9-1cd526294c9d",
     "type": "lvl2",
     "url": "/docs/components/data-display/tag#with-close-button",
     "hierarchy": { "lvl1": "Tag", "lvl2": "With close button", "lvl3": null }
   },
   {
     "content": "With custom element",
-    "id": "116b271a-62eb-4667-8411-17db2b7b6c85",
+    "id": "ae6ab193-e235-4465-9046-4769b27a121d",
     "type": "lvl2",
     "url": "/docs/components/data-display/tag#with-custom-element",
     "hierarchy": { "lvl1": "Tag", "lvl2": "With custom element", "lvl3": null }
   },
   {
     "content": "Props",
-    "id": "aba10117-7209-4df6-b268-99bc9a4cfa62",
+    "id": "53f7299a-0331-4f8c-803f-9c81d83afb93",
     "type": "lvl2",
     "url": "/docs/components/data-display/tag#props",
     "hierarchy": { "lvl1": "Tag", "lvl2": "Props", "lvl3": null }
   },
   {
     "content": "Accordion",
-    "id": "e796ff71-8569-48c2-a827-7acc98032d8d",
+    "id": "81efbf9f-f7f5-4162-af7d-5c33a1be30e3",
     "type": "lvl1",
     "url": "/docs/components/disclosure/accordion",
     "hierarchy": { "lvl1": "Accordion" }
   },
   {
     "content": "Import",
-    "id": "74a50d41-f421-45ac-833c-881fc07944c1",
+    "id": "338c7e5f-cfe7-4584-8946-a9f0265d7435",
     "type": "lvl2",
     "url": "/docs/components/disclosure/accordion#import",
     "hierarchy": { "lvl1": "Accordion", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Usage",
-    "id": "7b21e7b7-ea00-4355-9e5a-c0b96e78e3cd",
+    "id": "a95c9b43-a660-4d9d-b736-ff1737724355",
     "type": "lvl2",
     "url": "/docs/components/disclosure/accordion#usage",
     "hierarchy": { "lvl1": "Accordion", "lvl2": "Usage", "lvl3": null }
   },
   {
     "content": "Expand multiple items at once",
-    "id": "5b03d7f1-c79f-48bb-8a8d-3d94d3d6b785",
+    "id": "5e94ccd0-c795-4483-ae3d-dc54cdb915ce",
     "type": "lvl3",
     "url": "/docs/components/disclosure/accordion#expand-multiple-items-at-once",
     "hierarchy": {
@@ -801,7 +801,7 @@
   },
   {
     "content": "Toggle each accordion item",
-    "id": "4187244c-5eef-49c0-a25c-0178ed12ce9f",
+    "id": "494c611a-b14b-4dd9-b6a5-6b91037df917",
     "type": "lvl3",
     "url": "/docs/components/disclosure/accordion#toggle-each-accordion-item",
     "hierarchy": {
@@ -812,7 +812,7 @@
   },
   {
     "content": "Styling the expanded state",
-    "id": "f7c4b30a-4164-4417-81b2-87190015cfc5",
+    "id": "1b986fcf-50cc-47a2-872b-db59bb693b3e",
     "type": "lvl3",
     "url": "/docs/components/disclosure/accordion#styling-the-expanded-state",
     "hierarchy": {
@@ -823,7 +823,7 @@
   },
   {
     "content": "Accessing the internal state",
-    "id": "03de6e86-1758-472a-a344-4175e336436a",
+    "id": "573a1e15-393a-4269-8cd5-827ab6cc30f2",
     "type": "lvl3",
     "url": "/docs/components/disclosure/accordion#accessing-the-internal-state",
     "hierarchy": {
@@ -834,21 +834,21 @@
   },
   {
     "content": "Accessibility",
-    "id": "3b3c9f3c-5d88-4001-b0e5-62b156d1abae",
+    "id": "4d83d861-cf14-42d2-820a-15c9d664d94b",
     "type": "lvl2",
     "url": "/docs/components/disclosure/accordion#accessibility",
     "hierarchy": { "lvl1": "Accordion", "lvl2": "Accessibility", "lvl3": null }
   },
   {
     "content": "Props",
-    "id": "527cde11-b8c8-41c6-9b6d-33a38e5e0198",
+    "id": "7fad40e9-b66b-4afa-9280-c9a8693ff464",
     "type": "lvl2",
     "url": "/docs/components/disclosure/accordion#props",
     "hierarchy": { "lvl1": "Accordion", "lvl2": "Props", "lvl3": null }
   },
   {
     "content": "Accordion Props",
-    "id": "63cd1880-42c5-467f-bdca-50f418494085",
+    "id": "00200eea-9a08-45ea-bfd4-4d752718d9b4",
     "type": "lvl3",
     "url": "/docs/components/disclosure/accordion#accordion-props",
     "hierarchy": {
@@ -859,7 +859,7 @@
   },
   {
     "content": "AccordionItem Props",
-    "id": "b6d4090e-274b-470c-8db9-bf73f3353527",
+    "id": "57363fe9-7e96-422b-bc46-5f6e1e5a5548",
     "type": "lvl3",
     "url": "/docs/components/disclosure/accordion#accordionitem-props",
     "hierarchy": {
@@ -870,7 +870,7 @@
   },
   {
     "content": "AccordionButton Props",
-    "id": "15684d87-51d8-40e3-a0b9-0b353e5dd60c",
+    "id": "b262da47-c6c9-4ce0-9d64-ca099e3c86a8",
     "type": "lvl3",
     "url": "/docs/components/disclosure/accordion#accordionbutton-props",
     "hierarchy": {
@@ -881,7 +881,7 @@
   },
   {
     "content": "AccordionPanel Props",
-    "id": "160a1955-4173-4e21-9451-ce54d68f0d48",
+    "id": "8bfb6333-d195-4064-afea-898d72e192ee",
     "type": "lvl3",
     "url": "/docs/components/disclosure/accordion#accordionpanel-props",
     "hierarchy": {
@@ -892,28 +892,28 @@
   },
   {
     "content": "Tabs",
-    "id": "e9721e35-4ece-49dc-8e11-41a2dcee9e98",
+    "id": "561f260a-42e0-434e-ae32-3e25360118a1",
     "type": "lvl1",
     "url": "/docs/components/disclosure/tabs",
     "hierarchy": { "lvl1": "Tabs" }
   },
   {
     "content": "Import",
-    "id": "364e645a-08d2-436d-b2a4-b17b07016dd9",
+    "id": "eb0e1234-faef-4a26-ae23-49d9bfbeed72",
     "type": "lvl2",
     "url": "/docs/components/disclosure/tabs#import",
     "hierarchy": { "lvl1": "Tabs", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Usage",
-    "id": "5dab128e-11b0-4e56-b832-85945010a53e",
+    "id": "c8d2b566-f2ce-4d62-8593-a5e04f0e8284",
     "type": "lvl2",
     "url": "/docs/components/disclosure/tabs#usage",
     "hierarchy": { "lvl1": "Tabs", "lvl2": "Usage", "lvl3": null }
   },
   {
     "content": "Tab variants and color",
-    "id": "f6a34874-27ac-49aa-b9fb-f513b55208c7",
+    "id": "290378aa-3a83-4043-bcb9-80dc4cacc2fa",
     "type": "lvl3",
     "url": "/docs/components/disclosure/tabs#tab-variants-and-color",
     "hierarchy": {
@@ -924,7 +924,7 @@
   },
   {
     "content": "Tab sizes",
-    "id": "a40499b6-ab40-4216-817f-054446c8497b",
+    "id": "bd45ecea-a7b1-4805-9a6d-5106c30f3dc3",
     "type": "lvl3",
     "url": "/docs/components/disclosure/tabs#tab-sizes",
     "hierarchy": {
@@ -935,7 +935,7 @@
   },
   {
     "content": "Changing the tabs alignment",
-    "id": "ee94484d-fa18-4a86-9722-c2b546132e8d",
+    "id": "aa9a954d-e4cc-4a22-bbde-43e7995e9f56",
     "type": "lvl3",
     "url": "/docs/components/disclosure/tabs#changing-the-tabs-alignment",
     "hierarchy": {
@@ -946,7 +946,7 @@
   },
   {
     "content": "Fitted Tabs",
-    "id": "e9061351-1b33-4124-a85a-2dc85cdfa455",
+    "id": "efb2c596-88bc-4018-84fb-839b180152ba",
     "type": "lvl3",
     "url": "/docs/components/disclosure/tabs#fitted-tabs",
     "hierarchy": {
@@ -957,7 +957,7 @@
   },
   {
     "content": "Styling the tab states via props",
-    "id": "3c3ee72c-2034-45b2-a5ac-2f279cf3f228",
+    "id": "1924761c-1f55-484d-ad31-b4d8a33a8ff4",
     "type": "lvl3",
     "url": "/docs/components/disclosure/tabs#styling-the-tab-states-via-props",
     "hierarchy": {
@@ -968,7 +968,7 @@
   },
   {
     "content": "Tabs onChange",
-    "id": "89e41493-0d40-4bc3-8863-864b03fb3960",
+    "id": "61ba1836-8d7f-4487-8fd6-58a94a3db680",
     "type": "lvl3",
     "url": "/docs/components/disclosure/tabs#tabs-onchange",
     "hierarchy": {
@@ -979,7 +979,7 @@
   },
   {
     "content": "Make a tab initially active",
-    "id": "be545cae-71f4-47f5-bc6b-ea88abe8ee20",
+    "id": "fc0aa63b-61aa-405b-8e78-c78c7e37e458",
     "type": "lvl3",
     "url": "/docs/components/disclosure/tabs#make-a-tab-initially-active",
     "hierarchy": {
@@ -990,7 +990,7 @@
   },
   {
     "content": "Make a Tab disabled",
-    "id": "82d495bb-6ea6-4e6f-b2dd-2f00fb610f5d",
+    "id": "ddca2731-f78b-4095-9292-9b76d91f99a2",
     "type": "lvl3",
     "url": "/docs/components/disclosure/tabs#make-a-tab-disabled",
     "hierarchy": {
@@ -1001,7 +1001,7 @@
   },
   {
     "content": "Tabs with manual activation",
-    "id": "61951010-0a30-435a-ac7d-ff694d1f9b57",
+    "id": "d8b170a9-682b-4e6a-8a9c-be50dec1ccfb",
     "type": "lvl3",
     "url": "/docs/components/disclosure/tabs#tabs-with-manual-activation",
     "hierarchy": {
@@ -1012,7 +1012,7 @@
   },
   {
     "content": "Lazily mounting tab panels",
-    "id": "a9735a75-6126-4812-a96d-6e24e5d134b5",
+    "id": "01adb953-657d-4ab8-93d6-40fdd955d6dc",
     "type": "lvl3",
     "url": "/docs/components/disclosure/tabs#lazily-mounting-tab-panels",
     "hierarchy": {
@@ -1023,7 +1023,7 @@
   },
   {
     "content": "Controlled Tabs",
-    "id": "876c7c00-62a0-4846-8ec4-6d0f27f283b1",
+    "id": "5cdf6b5b-ac0c-4218-8fce-b5b0af141a1f",
     "type": "lvl3",
     "url": "/docs/components/disclosure/tabs#controlled-tabs",
     "hierarchy": {
@@ -1034,7 +1034,7 @@
   },
   {
     "content": "Creating custom tab components",
-    "id": "c39742e7-0163-4970-977d-e9c5bdaf9c6c",
+    "id": "b4d707de-7334-4532-8b74-9ad2c77e1a2b",
     "type": "lvl3",
     "url": "/docs/components/disclosure/tabs#creating-custom-tab-components",
     "hierarchy": {
@@ -1045,7 +1045,7 @@
   },
   {
     "content": "DataTabs",
-    "id": "63d780fc-70b4-4cde-a71d-545a34e56ca6",
+    "id": "c9f4a8f1-a53b-43a5-ab19-96ace00fe59b",
     "type": "lvl3",
     "url": "/docs/components/disclosure/tabs#datatabs",
     "hierarchy": {
@@ -1056,70 +1056,70 @@
   },
   {
     "content": "Accessibility",
-    "id": "300f97ee-1b4c-48da-b20b-144116cd1a56",
+    "id": "d9cfaf3f-2187-412f-ac23-287496a13b80",
     "type": "lvl2",
     "url": "/docs/components/disclosure/tabs#accessibility",
     "hierarchy": { "lvl1": "Tabs", "lvl2": "Accessibility", "lvl3": null }
   },
   {
     "content": "Keyboard",
-    "id": "fd59ad77-4aec-410d-b9eb-d3188735806d",
+    "id": "a94bf175-11da-4b5c-bc57-52280a7762c1",
     "type": "lvl3",
     "url": "/docs/components/disclosure/tabs#keyboard",
     "hierarchy": { "lvl1": "Tabs", "lvl2": "Accessibility", "lvl3": "Keyboard" }
   },
   {
     "content": "ARIA roles",
-    "id": "6928e56b-48c0-42ae-a636-0c14bd0ea0db",
+    "id": "3ac42618-5e81-48cf-b679-82f6716313e6",
     "type": "lvl3",
     "url": "/docs/components/disclosure/tabs#aria-roles",
     "hierarchy": { "lvl1": "Tabs", "lvl2": "Keyboard", "lvl3": "ARIA roles" }
   },
   {
     "content": "Props",
-    "id": "4effb024-b7c0-4472-a286-7206a3e0b741",
+    "id": "e42386c6-7403-4fa8-9f2a-fc851c93aa6b",
     "type": "lvl2",
     "url": "/docs/components/disclosure/tabs#props",
     "hierarchy": { "lvl1": "Tabs", "lvl2": "Props", "lvl3": null }
   },
   {
     "content": "Tabs Props",
-    "id": "ec9f017c-3fd6-46d0-b38a-32dc60c33783",
+    "id": "7736795c-5ecd-4195-a04b-e5f832efd5bf",
     "type": "lvl3",
     "url": "/docs/components/disclosure/tabs#tabs-props",
     "hierarchy": { "lvl1": "Tabs", "lvl2": "Props", "lvl3": "Tabs Props" }
   },
   {
     "content": "Tab Props",
-    "id": "4bab1ce7-b9b1-4512-9a4a-a80c61e4fb87",
+    "id": "ca16afd1-5a29-423f-a76b-b0e068ecc3c8",
     "type": "lvl3",
     "url": "/docs/components/disclosure/tabs#tab-props",
     "hierarchy": { "lvl1": "Tabs", "lvl2": "Tabs Props", "lvl3": "Tab Props" }
   },
   {
     "content": "VisuallyHidden",
-    "id": "3e626c76-7bb0-4429-b554-098b5f20c587",
+    "id": "b9c93379-2943-46db-9ee3-190e6ed66f34",
     "type": "lvl1",
     "url": "/docs/components/disclosure/visually-hidden",
     "hierarchy": { "lvl1": "VisuallyHidden" }
   },
   {
     "content": "Import",
-    "id": "d61ba413-5f5b-47ae-b8ca-10b587146d37",
+    "id": "c1832510-ff4c-4ab9-8af7-b8bd3213f865",
     "type": "lvl2",
     "url": "/docs/components/disclosure/visually-hidden#import",
     "hierarchy": { "lvl1": "VisuallyHidden", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Usage",
-    "id": "c839b9fb-f3c7-479b-ad29-e0382174d01b",
+    "id": "37105bd0-6764-4815-8ff4-79891ec73df2",
     "type": "lvl2",
     "url": "/docs/components/disclosure/visually-hidden#usage",
     "hierarchy": { "lvl1": "VisuallyHidden", "lvl2": "Usage", "lvl3": null }
   },
   {
     "content": "`VisuallyHidden` Example",
-    "id": "1bb05d78-d885-4216-8685-029600863c36",
+    "id": "b07953dd-f37d-4850-891f-d78fa2e6d202",
     "type": "lvl3",
     "url": "/docs/components/disclosure/visually-hidden#visuallyhidden-example",
     "hierarchy": {
@@ -1130,7 +1130,7 @@
   },
   {
     "content": "Another Example with `VisuallyHidden`",
-    "id": "629384fd-e1fa-4d78-ab1e-1475a10b8b2c",
+    "id": "d3f88f3b-1d89-4f6f-9f53-1d67c95a5985",
     "type": "lvl3",
     "url": "/docs/components/disclosure/visually-hidden#another-example-with-visuallyhidden",
     "hierarchy": {
@@ -1141,7 +1141,7 @@
   },
   {
     "content": "`VisuallyHiddenInput` Example",
-    "id": "42304911-4ced-453d-8be0-c8545a2e5d1c",
+    "id": "04c113d8-4125-4636-b423-b44ac8dcda86",
     "type": "lvl3",
     "url": "/docs/components/disclosure/visually-hidden#visuallyhiddeninput-example",
     "hierarchy": {
@@ -1152,7 +1152,7 @@
   },
   {
     "content": "Accessibility",
-    "id": "8cbc11ea-d13b-4f1a-890e-156cbbab75e1",
+    "id": "94e1e7f3-5d67-4544-9fcc-79ab4148900b",
     "type": "lvl2",
     "url": "/docs/components/disclosure/visually-hidden#accessibility",
     "hierarchy": {
@@ -1163,70 +1163,70 @@
   },
   {
     "content": "Props",
-    "id": "6c4634c3-b64a-47a7-a00f-ed752e4690f6",
+    "id": "30b8d4bb-342e-4e62-ab21-f8c10aeaa8a8",
     "type": "lvl2",
     "url": "/docs/components/disclosure/visually-hidden#props",
     "hierarchy": { "lvl1": "VisuallyHidden", "lvl2": "Props", "lvl3": null }
   },
   {
     "content": "Alert",
-    "id": "e2eb3998-b4d9-45a1-998c-8a00fd37d8bd",
+    "id": "f899f7e1-bd2d-4fdc-a9c8-7e40e2cc4301",
     "type": "lvl1",
     "url": "/docs/components/feedback/alert",
     "hierarchy": { "lvl1": "Alert" }
   },
   {
     "content": "Import",
-    "id": "a13b9855-e388-4c97-8c49-32fa275d80ae",
+    "id": "d187ac90-2910-473c-acb3-721be0e51c4a",
     "type": "lvl2",
     "url": "/docs/components/feedback/alert#import",
     "hierarchy": { "lvl1": "Alert", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Usage",
-    "id": "e3bac88e-eaa4-4aa0-9047-08a0afcb24ec",
+    "id": "0b0ff4fb-51a1-479f-9cbd-ce2c22f4fdd8",
     "type": "lvl2",
     "url": "/docs/components/feedback/alert#usage",
     "hierarchy": { "lvl1": "Alert", "lvl2": "Usage", "lvl3": null }
   },
   {
     "content": "Status",
-    "id": "0a84aa36-7dab-42b8-afb9-93b2a0c916ee",
+    "id": "72651821-f30c-4e5e-8480-d3d3e1ff014b",
     "type": "lvl3",
     "url": "/docs/components/feedback/alert#status",
     "hierarchy": { "lvl1": "Alert", "lvl2": "Usage", "lvl3": "Status" }
   },
   {
     "content": "Variant",
-    "id": "dfe38593-af8a-4e39-a71c-a84280b90a67",
+    "id": "e71808cf-d4e5-43f8-9013-2126d6d61c7d",
     "type": "lvl3",
     "url": "/docs/components/feedback/alert#variant",
     "hierarchy": { "lvl1": "Alert", "lvl2": "Status", "lvl3": "Variant" }
   },
   {
     "content": "Composition",
-    "id": "deea397c-4e37-410d-9557-92a5bd1d56df",
+    "id": "90cdb73c-78aa-4ecb-ad5b-e293002429d8",
     "type": "lvl3",
     "url": "/docs/components/feedback/alert#composition",
     "hierarchy": { "lvl1": "Alert", "lvl2": "Variant", "lvl3": "Composition" }
   },
   {
     "content": "Props",
-    "id": "0643231d-4eb3-4487-bc1d-cc51a1af5683",
+    "id": "d7095b9f-3c87-457d-a2a7-1615d7e802c9",
     "type": "lvl2",
     "url": "/docs/components/feedback/alert#props",
     "hierarchy": { "lvl1": "Alert", "lvl2": "Props", "lvl3": null }
   },
   {
     "content": "Alert Props",
-    "id": "b203e398-350c-4932-abec-eff3b25a0983",
+    "id": "83fafb3a-8b0f-4ec7-9b75-572e4b2edddf",
     "type": "lvl3",
     "url": "/docs/components/feedback/alert#alert-props",
     "hierarchy": { "lvl1": "Alert", "lvl2": "Props", "lvl3": "Alert Props" }
   },
   {
     "content": "AlertIcon Props",
-    "id": "ba1e900a-0e4a-4786-a0a0-533437355c0c",
+    "id": "26dadc9d-29af-4553-ba84-b6144c061839",
     "type": "lvl3",
     "url": "/docs/components/feedback/alert#alerticon-props",
     "hierarchy": {
@@ -1237,7 +1237,7 @@
   },
   {
     "content": "AlertTitle Props",
-    "id": "c8b28a50-34ea-40bc-8d03-17b9f90ec8dd",
+    "id": "db64db6c-85b2-4b34-b440-04d8e5601c1a",
     "type": "lvl3",
     "url": "/docs/components/feedback/alert#alerttitle-props",
     "hierarchy": {
@@ -1248,7 +1248,7 @@
   },
   {
     "content": "AlertDescription Props",
-    "id": "b9220f4d-e276-4cc4-a111-587c91120b09",
+    "id": "ea88e7dd-7c20-4f54-bd79-52873f901562",
     "type": "lvl3",
     "url": "/docs/components/feedback/alert#alertdescription-props",
     "hierarchy": {
@@ -1259,28 +1259,28 @@
   },
   {
     "content": "Circular Progress",
-    "id": "a03969e4-00f6-468a-9d4a-bd18677f9833",
+    "id": "f220a5ab-8902-491c-a4d9-0531da0d04dd",
     "type": "lvl1",
     "url": "/docs/components/feedback/circular-progress",
     "hierarchy": { "lvl1": "Circular Progress" }
   },
   {
     "content": "Import",
-    "id": "8d2dde95-ac76-4278-ac9b-aa89d104d01a",
+    "id": "143089cb-bbc1-409f-97e4-c460f60461a9",
     "type": "lvl2",
     "url": "/docs/components/feedback/circular-progress#import",
     "hierarchy": { "lvl1": "Circular Progress", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Usage",
-    "id": "7fed2c70-4646-46f9-b2d9-18319eaf457d",
+    "id": "6ed6f058-04f5-47f7-b206-569b4cdcc7cd",
     "type": "lvl2",
     "url": "/docs/components/feedback/circular-progress#usage",
     "hierarchy": { "lvl1": "Circular Progress", "lvl2": "Usage", "lvl3": null }
   },
   {
     "content": "Changing the size",
-    "id": "07e3cfe7-1e2b-4bb7-991b-bd4852047f34",
+    "id": "ac814118-6d64-476f-8101-ce68f729f010",
     "type": "lvl3",
     "url": "/docs/components/feedback/circular-progress#changing-the-size",
     "hierarchy": {
@@ -1291,7 +1291,7 @@
   },
   {
     "content": "Changing the thickness",
-    "id": "1a5f96d8-57d2-43e1-9704-3c2a4f1d696f",
+    "id": "93a16beb-d7ab-40ca-a841-98b63fd63acb",
     "type": "lvl3",
     "url": "/docs/components/feedback/circular-progress#changing-the-thickness",
     "hierarchy": {
@@ -1302,7 +1302,7 @@
   },
   {
     "content": "Changing the color",
-    "id": "6e8335e2-df5a-430b-8248-53eccb102e0c",
+    "id": "cf6165b0-f282-4976-b3cd-5955a321d7c9",
     "type": "lvl3",
     "url": "/docs/components/feedback/circular-progress#changing-the-color",
     "hierarchy": {
@@ -1313,7 +1313,7 @@
   },
   {
     "content": "Adding label",
-    "id": "27ddd94a-352b-411d-95db-2e1884b175b8",
+    "id": "5e98c305-404f-4163-bf96-4fc3f2c48441",
     "type": "lvl3",
     "url": "/docs/components/feedback/circular-progress#adding-label",
     "hierarchy": {
@@ -1324,7 +1324,7 @@
   },
   {
     "content": "Indeterminate Progress",
-    "id": "b24f0a07-ebcb-430d-b75f-64c9779bf205",
+    "id": "6a57dd32-edb7-44f2-82be-4b5ae3edc8e3",
     "type": "lvl3",
     "url": "/docs/components/feedback/circular-progress#indeterminate-progress",
     "hierarchy": {
@@ -1335,7 +1335,7 @@
   },
   {
     "content": "Accessibility",
-    "id": "4724aa29-34e4-463c-b430-c208b14c7255",
+    "id": "48d99ae2-018e-4cd4-bafd-39892e6f1b0c",
     "type": "lvl3",
     "url": "/docs/components/feedback/circular-progress#accessibility",
     "hierarchy": {
@@ -1346,35 +1346,35 @@
   },
   {
     "content": "Props",
-    "id": "a9a73dc0-15c0-4666-9ad4-41eafcbfa84b",
+    "id": "423b2e5b-7c40-47ff-80c4-8d1db807ed67",
     "type": "lvl2",
     "url": "/docs/components/feedback/circular-progress#props",
     "hierarchy": { "lvl1": "Circular Progress", "lvl2": "Props", "lvl3": null }
   },
   {
     "content": "Progress",
-    "id": "4949733b-db01-404f-ba51-9175a19e8ae2",
+    "id": "8252916c-8e1a-48c0-9a5d-eec66d6e0787",
     "type": "lvl1",
     "url": "/docs/components/feedback/progress",
     "hierarchy": { "lvl1": "Progress" }
   },
   {
     "content": "Import",
-    "id": "bacde0ab-a16e-44f5-8f7a-00178bd7a2eb",
+    "id": "b0efdfdf-7bfe-42f9-a6ca-485996ca8353",
     "type": "lvl2",
     "url": "/docs/components/feedback/progress#import",
     "hierarchy": { "lvl1": "Progress", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Usage",
-    "id": "dbbca732-b349-4d0b-943d-65c41d8543c2",
+    "id": "8b9caa0a-8ea2-44dd-b3d0-8c8bda238a85",
     "type": "lvl2",
     "url": "/docs/components/feedback/progress#usage",
     "hierarchy": { "lvl1": "Progress", "lvl2": "Usage", "lvl3": null }
   },
   {
     "content": "Progress with Stripe",
-    "id": "7e7f6afd-72bd-4567-ad90-e4f63c81dd52",
+    "id": "9b74058e-e83f-41f3-a1ab-0e06938ce618",
     "type": "lvl3",
     "url": "/docs/components/feedback/progress#progress-with-stripe",
     "hierarchy": {
@@ -1385,7 +1385,7 @@
   },
   {
     "content": "Progress sizes",
-    "id": "93ba36ff-b9a6-48d8-b077-60760e98bcd5",
+    "id": "5b5048a5-881c-4bfd-bd5d-dfc16849dd49",
     "type": "lvl3",
     "url": "/docs/components/feedback/progress#progress-sizes",
     "hierarchy": {
@@ -1396,7 +1396,7 @@
   },
   {
     "content": "Progress color scheme",
-    "id": "e144b1db-0d8d-4b65-9bd1-4512d168394f",
+    "id": "8fb81047-bff8-4118-9b30-1b68f75ecc24",
     "type": "lvl3",
     "url": "/docs/components/feedback/progress#progress-color-scheme",
     "hierarchy": {
@@ -1407,7 +1407,7 @@
   },
   {
     "content": "Animated Progress",
-    "id": "2f91b8f3-a6ab-4d56-8c8f-61a26b8b6283",
+    "id": "bbf542ce-8677-438b-9e87-aaedfdb155b9",
     "type": "lvl3",
     "url": "/docs/components/feedback/progress#animated-progress",
     "hierarchy": {
@@ -1418,42 +1418,42 @@
   },
   {
     "content": "Accessibility",
-    "id": "a2906131-c12e-47ff-a269-d61b9bdf23bc",
+    "id": "c01bdb19-62d8-49b9-86ad-1b073d667e28",
     "type": "lvl2",
     "url": "/docs/components/feedback/progress#accessibility",
     "hierarchy": { "lvl1": "Progress", "lvl2": "Accessibility", "lvl3": null }
   },
   {
     "content": "Props",
-    "id": "03f9ed66-b36d-4b8b-ae02-16404cccbb70",
+    "id": "fdf7676a-a4e0-4118-831f-68e4b0a405ab",
     "type": "lvl2",
     "url": "/docs/components/feedback/progress#props",
     "hierarchy": { "lvl1": "Progress", "lvl2": "Props", "lvl3": null }
   },
   {
     "content": "Skeleton",
-    "id": "c7ce5980-1af5-4289-a586-dfd26be72865",
+    "id": "d44df8a6-a8f4-452f-b62a-9b8ebd77cf51",
     "type": "lvl1",
     "url": "/docs/components/feedback/skeleton",
     "hierarchy": { "lvl1": "Skeleton" }
   },
   {
     "content": "Import",
-    "id": "9ec9855d-25f9-4f06-a347-9697911f4f56",
+    "id": "65a8c4d2-e425-4032-90c0-f5fde824a799",
     "type": "lvl2",
     "url": "/docs/components/feedback/skeleton#import",
     "hierarchy": { "lvl1": "Skeleton", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Usage",
-    "id": "16af6862-4ba5-4dc4-addc-f7596b3b1f61",
+    "id": "57181732-76b7-4d43-b51c-282b0310d8c7",
     "type": "lvl2",
     "url": "/docs/components/feedback/skeleton#usage",
     "hierarchy": { "lvl1": "Skeleton", "lvl2": "Usage", "lvl3": null }
   },
   {
     "content": "Circle and Text Skeleton",
-    "id": "37196b3e-ed9d-4241-9c8e-431cc3494328",
+    "id": "2dbd5ae0-6cac-42a5-acea-02b994c3472c",
     "type": "lvl3",
     "url": "/docs/components/feedback/skeleton#circle-and-text-skeleton",
     "hierarchy": {
@@ -1464,7 +1464,7 @@
   },
   {
     "content": "Skeleton color",
-    "id": "b8416a6f-2bdf-4d51-974b-f60cb6da290d",
+    "id": "3ab0d922-b7d2-4762-8820-fe0afdc74aed",
     "type": "lvl3",
     "url": "/docs/components/feedback/skeleton#skeleton-color",
     "hierarchy": {
@@ -1475,7 +1475,7 @@
   },
   {
     "content": "Skipping the skeleton when content is loaded",
-    "id": "104cc441-00b0-4eeb-87d1-225534ed0e4c",
+    "id": "9ead3b80-2aa0-4159-8ab3-9d1b7425e291",
     "type": "lvl3",
     "url": "/docs/components/feedback/skeleton#skipping-the-skeleton-when-content-is-loaded",
     "hierarchy": {
@@ -1486,35 +1486,35 @@
   },
   {
     "content": "Props",
-    "id": "074799fe-17c3-49f7-b1d3-12552c0fea3b",
+    "id": "5ca30835-46c8-4d16-ad92-e9d0f51b530d",
     "type": "lvl2",
     "url": "/docs/components/feedback/skeleton#props",
     "hierarchy": { "lvl1": "Skeleton", "lvl2": "Props", "lvl3": null }
   },
   {
     "content": "Spinner",
-    "id": "f63bc17f-2702-474b-8712-978feb15773e",
+    "id": "7868b1c4-b8ea-4c0c-887f-a29e029a8e1b",
     "type": "lvl1",
     "url": "/docs/components/feedback/spinner",
     "hierarchy": { "lvl1": "Spinner" }
   },
   {
     "content": "Import",
-    "id": "5b0ccc6b-e80e-4519-bb28-a6f17c643daa",
+    "id": "660078ec-3a80-4c17-8449-2426d06b104d",
     "type": "lvl2",
     "url": "/docs/components/feedback/spinner#import",
     "hierarchy": { "lvl1": "Spinner", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Usage",
-    "id": "e21dc289-9162-4ccb-89fa-5820d8a99b5a",
+    "id": "4b6a2cbd-3a93-490a-9a16-ba0ed503545f",
     "type": "lvl2",
     "url": "/docs/components/feedback/spinner#usage",
     "hierarchy": { "lvl1": "Spinner", "lvl2": "Usage", "lvl3": null }
   },
   {
     "content": "Spinner with Color",
-    "id": "6b56ef21-95b6-4c38-8217-24563eac8cf2",
+    "id": "67cddcf8-f6a5-4d76-b28e-e1dbe160f9ee",
     "type": "lvl3",
     "url": "/docs/components/feedback/spinner#spinner-with-color",
     "hierarchy": {
@@ -1525,7 +1525,7 @@
   },
   {
     "content": "Spinner with different size",
-    "id": "02fd036a-c8c1-41d8-8ffa-e373d99c4dd3",
+    "id": "70b48682-a671-4069-8035-9b28998cada2",
     "type": "lvl3",
     "url": "/docs/components/feedback/spinner#spinner-with-different-size",
     "hierarchy": {
@@ -1536,7 +1536,7 @@
   },
   {
     "content": "Spinner with empty area color",
-    "id": "71b8e6d2-e0d2-4956-b1d6-68e9f245717b",
+    "id": "d800fe6c-eff4-42af-8a77-ac849dd1fcf6",
     "type": "lvl3",
     "url": "/docs/components/feedback/spinner#spinner-with-empty-area-color",
     "hierarchy": {
@@ -1547,70 +1547,70 @@
   },
   {
     "content": "Props",
-    "id": "2b70553d-6f79-4f85-89d3-0ada8dafa4c1",
+    "id": "91947bc3-9bec-443c-91e6-b4625382ef77",
     "type": "lvl2",
     "url": "/docs/components/feedback/spinner#props",
     "hierarchy": { "lvl1": "Spinner", "lvl2": "Props", "lvl3": null }
   },
   {
     "content": "Toast",
-    "id": "7df0ae8a-3bc0-4a3a-9f85-c9b4ad0de261",
+    "id": "a29ccf00-000c-45c9-936b-fdbc12349158",
     "type": "lvl1",
     "url": "/docs/components/feedback/toast",
     "hierarchy": { "lvl1": "Toast" }
   },
   {
     "content": "Import",
-    "id": "649b35f1-bac9-4c9d-9b48-5461295e6c6e",
+    "id": "4d60277c-dab5-423f-af1d-516894ba8a99",
     "type": "lvl2",
     "url": "/docs/components/feedback/toast#import",
     "hierarchy": { "lvl1": "Toast", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Usage",
-    "id": "4fbb5fb0-daa4-4d80-aa6b-9f8eb55df603",
+    "id": "b1716a9c-a37f-413b-88cf-fe04b0ff1466",
     "type": "lvl2",
     "url": "/docs/components/feedback/toast#usage",
     "hierarchy": { "lvl1": "Toast", "lvl2": "Usage", "lvl3": null }
   },
   {
     "content": "Custom component",
-    "id": "c9e599ff-b311-489b-9407-a74d9091454d",
+    "id": "330ad381-2786-4f18-985d-57416f5d149a",
     "type": "lvl2",
     "url": "/docs/components/feedback/toast#custom-component",
     "hierarchy": { "lvl1": "Toast", "lvl2": "Custom component", "lvl3": null }
   },
   {
     "content": "Closing Toasts",
-    "id": "0a25604f-8628-4562-8aa9-642ba72f0567",
+    "id": "2e7993f0-6d0e-45dd-b556-a645e3d300c1",
     "type": "lvl2",
     "url": "/docs/components/feedback/toast#closing-toasts",
     "hierarchy": { "lvl1": "Toast", "lvl2": "Closing Toasts", "lvl3": null }
   },
   {
     "content": "Updating Toasts",
-    "id": "a9a8f3c2-59ea-4a93-86b6-b979eb24d7ec",
+    "id": "181a997c-aa9d-4075-a523-1dec496c6542",
     "type": "lvl2",
     "url": "/docs/components/feedback/toast#updating-toasts",
     "hierarchy": { "lvl1": "Toast", "lvl2": "Updating Toasts", "lvl3": null }
   },
   {
     "content": "Status",
-    "id": "0e5f0f12-9242-4d2b-858a-1a8d311c5f86",
+    "id": "d6f06e7d-8d4c-4cdc-8ba2-cf25c85e346f",
     "type": "lvl2",
     "url": "/docs/components/feedback/toast#status",
     "hierarchy": { "lvl1": "Toast", "lvl2": "Status", "lvl3": null }
   },
   {
     "content": "Variants",
-    "id": "bbe2ccca-81a8-430e-a78f-7f174b04d9ca",
+    "id": "ded05126-2d78-4976-a852-bfd95e3aa46e",
     "type": "lvl2",
     "url": "/docs/components/feedback/toast#variants",
     "hierarchy": { "lvl1": "Toast", "lvl2": "Variants", "lvl3": null }
   },
   {
     "content": "Custom container styles",
-    "id": "c16cec35-9de1-4fb6-9f19-3b1672051ebb",
+    "id": "6060e233-a943-4e55-aeaf-06288d9c547c",
     "type": "lvl2",
     "url": "/docs/components/feedback/toast#custom-container-styles",
     "hierarchy": {
@@ -1621,7 +1621,7 @@
   },
   {
     "content": "Changing the toast position",
-    "id": "b2f479bb-2119-4215-b1cf-f3a9cbc5eed8",
+    "id": "fb4483ab-ab24-411f-a5be-00da2df0654d",
     "type": "lvl2",
     "url": "/docs/components/feedback/toast#changing-the-toast-position",
     "hierarchy": {
@@ -1632,7 +1632,7 @@
   },
   {
     "content": "Preventing Duplicate Toast",
-    "id": "1707f0f5-c986-4257-a768-580a6a0fb795",
+    "id": "04f5f076-e6a3-4e25-bc50-8af22174ac3a",
     "type": "lvl2",
     "url": "/docs/components/feedback/toast#preventing-duplicate-toast",
     "hierarchy": {
@@ -1643,49 +1643,49 @@
   },
   {
     "content": "Standalone Toasts",
-    "id": "2acf80c9-e6a2-4e4c-839e-5b05eef2fa1b",
+    "id": "d2d5b5de-2857-4f43-bae4-11a2c3db7be7",
     "type": "lvl2",
     "url": "/docs/components/feedback/toast#standalone-toasts",
     "hierarchy": { "lvl1": "Toast", "lvl2": "Standalone Toasts", "lvl3": null }
   },
   {
     "content": "Props",
-    "id": "3cd7ac35-ee7a-4fa0-9eec-229687a1aa87",
+    "id": "8869a697-9eff-4b80-8cef-e11766b8ad8e",
     "type": "lvl2",
     "url": "/docs/components/feedback/toast#props",
     "hierarchy": { "lvl1": "Toast", "lvl2": "Props", "lvl3": null }
   },
   {
     "content": "Button",
-    "id": "272701c9-443c-4bff-aff6-d9a0237cb483",
+    "id": "648bf61f-0493-4919-bfb4-af1d124a2401",
     "type": "lvl1",
     "url": "/docs/components/form/button",
     "hierarchy": { "lvl1": "Button" }
   },
   {
     "content": "Import",
-    "id": "7d6b8439-39ca-4140-ae9c-6e7dfa7e6807",
+    "id": "8c1f8869-9da6-4245-b310-0aedd8f4c521",
     "type": "lvl2",
     "url": "/docs/components/form/button#import",
     "hierarchy": { "lvl1": "Button", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Usage",
-    "id": "fed0c50f-a685-4998-942d-4fd7b426657f",
+    "id": "ca4934e1-e7f7-4f02-ab8c-75835928de05",
     "type": "lvl2",
     "url": "/docs/components/form/button#usage",
     "hierarchy": { "lvl1": "Button", "lvl2": "Usage", "lvl3": null }
   },
   {
     "content": "Button Sizes",
-    "id": "00d1cf89-6e1f-4216-997c-3162f833169e",
+    "id": "00d79766-402d-4c46-816c-b3fc09fa4f51",
     "type": "lvl3",
     "url": "/docs/components/form/button#button-sizes",
     "hierarchy": { "lvl1": "Button", "lvl2": "Usage", "lvl3": "Button Sizes" }
   },
   {
     "content": "Button variants",
-    "id": "aabab51c-4f18-4f33-a7bf-e3e31dae0cb6",
+    "id": "e6a6628e-45a3-42d5-97fa-8f6903aa4039",
     "type": "lvl3",
     "url": "/docs/components/form/button#button-variants",
     "hierarchy": {
@@ -1696,7 +1696,7 @@
   },
   {
     "content": "Button with icon",
-    "id": "988f90ee-b4b6-424e-ab95-59da99c106f9",
+    "id": "b8fb4afd-92dc-4759-bbaf-043d2ab560d2",
     "type": "lvl3",
     "url": "/docs/components/form/button#button-with-icon",
     "hierarchy": {
@@ -1707,7 +1707,7 @@
   },
   {
     "content": "Button loading state",
-    "id": "517556e2-697e-4c7b-bddb-35cc78bfbc03",
+    "id": "0edff8b9-f644-4439-8f88-6357675667b4",
     "type": "lvl3",
     "url": "/docs/components/form/button#button-loading-state",
     "hierarchy": {
@@ -1718,7 +1718,7 @@
   },
   {
     "content": "Social Buttons",
-    "id": "662f14f5-b7a8-465f-a865-4af6437584b1",
+    "id": "23f5e334-9aa1-4a40-abd4-601c34fe8602",
     "type": "lvl3",
     "url": "/docs/components/form/button#social-buttons",
     "hierarchy": {
@@ -1729,7 +1729,7 @@
   },
   {
     "content": "Grouping Buttons",
-    "id": "3da1d180-5630-4ff0-b737-40a0e738aa55",
+    "id": "472c866e-1263-4630-9aac-9e4cc42e0904",
     "type": "lvl3",
     "url": "/docs/components/form/button#grouping-buttons",
     "hierarchy": {
@@ -1740,42 +1740,42 @@
   },
   {
     "content": "Accessibility",
-    "id": "16f2e764-8c46-40f4-81a0-3194e66ad03a",
+    "id": "ea2a6c0d-5ea1-4180-b31f-7065ca1e84aa",
     "type": "lvl2",
     "url": "/docs/components/form/button#accessibility",
     "hierarchy": { "lvl1": "Button", "lvl2": "Accessibility", "lvl3": null }
   },
   {
     "content": "Composition",
-    "id": "0404ddac-98e1-454f-aecd-7829bcb81463",
+    "id": "73880183-142d-47de-b90f-0486086de29c",
     "type": "lvl2",
     "url": "/docs/components/form/button#composition",
     "hierarchy": { "lvl1": "Button", "lvl2": "Composition", "lvl3": null }
   },
   {
     "content": "Custom Button",
-    "id": "24b595d6-1abc-4af7-969c-91f2122dde31",
+    "id": "8ccb6cef-c2b4-493e-9134-04b1a345d8a9",
     "type": "lvl2",
     "url": "/docs/components/form/button#custom-button",
     "hierarchy": { "lvl1": "Button", "lvl2": "Custom Button", "lvl3": null }
   },
   {
     "content": "Props",
-    "id": "76e94c87-63d5-4a9f-ade8-261f548873e8",
+    "id": "2a14e0b7-54fa-4492-8efc-9dffe858ca30",
     "type": "lvl2",
     "url": "/docs/components/form/button#props",
     "hierarchy": { "lvl1": "Button", "lvl2": "Props", "lvl3": null }
   },
   {
     "content": "Button Props",
-    "id": "1597032e-962c-40ac-a6e1-a3ebd3922bd3",
+    "id": "08f2e0e8-29c2-4e91-8708-e348a50fa891",
     "type": "lvl3",
     "url": "/docs/components/form/button#button-props",
     "hierarchy": { "lvl1": "Button", "lvl2": "Props", "lvl3": "Button Props" }
   },
   {
     "content": "Button Group Props",
-    "id": "51730e8d-8567-434c-b5b5-ac63cfaae5dc",
+    "id": "b2d221d3-1199-4d4c-9e11-2c57a94e0afc",
     "type": "lvl3",
     "url": "/docs/components/form/button#button-group-props",
     "hierarchy": {
@@ -1786,28 +1786,28 @@
   },
   {
     "content": "Checkbox",
-    "id": "4d3fa8f2-e008-4972-9d3c-b9bd61e98e28",
+    "id": "5a8c5beb-e89a-45c9-bf8c-4ace87943e72",
     "type": "lvl1",
     "url": "/docs/components/form/checkbox",
     "hierarchy": { "lvl1": "Checkbox" }
   },
   {
     "content": "Import",
-    "id": "3361ab74-4de2-428f-97cc-e07bf798aabc",
+    "id": "d2fe5468-bbc4-4b59-af54-ad27b7be9f22",
     "type": "lvl2",
     "url": "/docs/components/form/checkbox#import",
     "hierarchy": { "lvl1": "Checkbox", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Usage",
-    "id": "3376bf4a-e1aa-47f5-9f9e-67862e971bda",
+    "id": "7f8cf21c-59e6-47c7-8d80-c146736e7b6d",
     "type": "lvl2",
     "url": "/docs/components/form/checkbox#usage",
     "hierarchy": { "lvl1": "Checkbox", "lvl2": "Usage", "lvl3": null }
   },
   {
     "content": "Disabled Checkbox",
-    "id": "f26f3ed2-b706-45e2-8056-88ae56350da1",
+    "id": "76d9e44c-3329-40e7-8aa6-28c5855f4ac1",
     "type": "lvl3",
     "url": "/docs/components/form/checkbox#disabled-checkbox",
     "hierarchy": {
@@ -1818,7 +1818,7 @@
   },
   {
     "content": "Checkbox with custom color",
-    "id": "0f2b2ae6-1404-42da-b77d-a70886fd24dd",
+    "id": "52eee125-7cb2-4bf0-a342-4e59a60ea83f",
     "type": "lvl3",
     "url": "/docs/components/form/checkbox#checkbox-with-custom-color",
     "hierarchy": {
@@ -1829,7 +1829,7 @@
   },
   {
     "content": "Checkbox sizes",
-    "id": "7441e29d-50c6-4ce9-a525-d9e29433cbd1",
+    "id": "daa1c6cc-ffc6-4f84-b2c2-966000973a48",
     "type": "lvl3",
     "url": "/docs/components/form/checkbox#checkbox-sizes",
     "hierarchy": {
@@ -1840,7 +1840,7 @@
   },
   {
     "content": "Invalid Checkbox",
-    "id": "6518d2ed-f2da-4f51-9cf3-c655c4dc5000",
+    "id": "4dcebd95-4b32-417c-ad54-03ceef640e80",
     "type": "lvl3",
     "url": "/docs/components/form/checkbox#invalid-checkbox",
     "hierarchy": {
@@ -1851,7 +1851,7 @@
   },
   {
     "content": "Changing the spacing",
-    "id": "58388738-2756-4e04-b5e2-8ae946f5fdd0",
+    "id": "4557b70b-2825-409f-b155-7bda6dbd06b3",
     "type": "lvl3",
     "url": "/docs/components/form/checkbox#changing-the-spacing",
     "hierarchy": {
@@ -1862,7 +1862,7 @@
   },
   {
     "content": "Changing the icon color and size",
-    "id": "7c7ec33d-0532-44d6-84d2-832cd2aea3ee",
+    "id": "60928d68-4deb-4ffd-91e4-328a7e05a8c1",
     "type": "lvl3",
     "url": "/docs/components/form/checkbox#changing-the-icon-color-and-size",
     "hierarchy": {
@@ -1873,7 +1873,7 @@
   },
   {
     "content": "Indeterminate",
-    "id": "4e665afd-7e19-4c04-a751-ebb44f6b10be",
+    "id": "027d3926-59ce-4e65-90c4-fd456eee5b8f",
     "type": "lvl3",
     "url": "/docs/components/form/checkbox#indeterminate",
     "hierarchy": {
@@ -1884,21 +1884,21 @@
   },
   {
     "content": "Icon",
-    "id": "c3480e82-c855-413d-b27e-6ca5e5de497d",
+    "id": "84739131-5404-47ee-a24b-81188245624a",
     "type": "lvl3",
     "url": "/docs/components/form/checkbox#icon",
     "hierarchy": { "lvl1": "Checkbox", "lvl2": "Indeterminate", "lvl3": "Icon" }
   },
   {
     "content": "CheckboxGroup",
-    "id": "d37c5cd4-fe92-4b68-b126-9fd6009b2622",
+    "id": "3710ae11-ca89-4f54-9bca-8b073d09e69d",
     "type": "lvl3",
     "url": "/docs/components/form/checkbox#checkboxgroup",
     "hierarchy": { "lvl1": "Checkbox", "lvl2": "Icon", "lvl3": "CheckboxGroup" }
   },
   {
     "content": "Hooks",
-    "id": "2724b24f-c6d2-415b-aa22-ab02b520e02d",
+    "id": "3bbdc798-4014-4d36-8dcd-8ed715d32705",
     "type": "lvl3",
     "url": "/docs/components/form/checkbox#hooks",
     "hierarchy": {
@@ -1909,14 +1909,14 @@
   },
   {
     "content": "Props",
-    "id": "86912b95-bd46-4d4c-9eeb-b328b655b067",
+    "id": "5b22eafd-9104-4a30-9f22-aebf59b91bf0",
     "type": "lvl2",
     "url": "/docs/components/form/checkbox#props",
     "hierarchy": { "lvl1": "Checkbox", "lvl2": "Props", "lvl3": null }
   },
   {
     "content": "Checkbox Props",
-    "id": "7c30e2f8-478f-4743-bf05-4124ea83dfb2",
+    "id": "aa08db3a-8f15-4acf-8ed0-82920c56c1a6",
     "type": "lvl3",
     "url": "/docs/components/form/checkbox#checkbox-props",
     "hierarchy": {
@@ -1927,7 +1927,7 @@
   },
   {
     "content": "CheckboxGroup Props",
-    "id": "6da7c86b-6728-4d21-97f1-75aa53ced902",
+    "id": "b1b4c94d-9b1e-4f11-8726-1ac1152c49df",
     "type": "lvl3",
     "url": "/docs/components/form/checkbox#checkboxgroup-props",
     "hierarchy": {
@@ -1938,7 +1938,7 @@
   },
   {
     "content": "Shared Style Props",
-    "id": "f163e096-38f1-4b8a-96e8-341314c8a052",
+    "id": "63992da5-a8e9-4b80-97c9-7ec6211f01f8",
     "type": "lvl4",
     "url": "/docs/components/form/checkbox#shared-style-props",
     "hierarchy": {
@@ -1949,28 +1949,28 @@
   },
   {
     "content": "Editable",
-    "id": "6c253942-444a-4e43-8f70-20fd5dfee362",
+    "id": "47f09af6-7306-4587-85d2-e69394bb861a",
     "type": "lvl1",
     "url": "/docs/components/form/editable",
     "hierarchy": { "lvl1": "Editable" }
   },
   {
     "content": "Import",
-    "id": "f07967f6-5760-4477-9c2d-88e656516d7b",
+    "id": "a9e52da5-6630-4c33-a399-ea8de709355a",
     "type": "lvl2",
     "url": "/docs/components/form/editable#import",
     "hierarchy": { "lvl1": "Editable", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Usage",
-    "id": "e9fd2193-3a09-428d-a0a9-2fe83003284f",
+    "id": "b8d40c2c-25a3-4574-bb0c-fdf73609bc16",
     "type": "lvl2",
     "url": "/docs/components/form/editable#usage",
     "hierarchy": { "lvl1": "Editable", "lvl2": "Usage", "lvl3": null }
   },
   {
     "content": "Usage with textarea",
-    "id": "deab96d2-76b4-478b-9014-fd192e28bb2c",
+    "id": "b97e46ad-484e-4a26-9956-1a898e8ad518",
     "type": "lvl3",
     "url": "/docs/components/form/editable#usage-with-textarea",
     "hierarchy": {
@@ -1981,7 +1981,7 @@
   },
   {
     "content": "With custom input and controls",
-    "id": "bb2ad0b5-b854-421e-b981-435c2de436a2",
+    "id": "5413a9d6-58b1-4b1f-a5fa-1ddab2b824c0",
     "type": "lvl3",
     "url": "/docs/components/form/editable#with-custom-input-and-controls",
     "hierarchy": {
@@ -1992,7 +1992,7 @@
   },
   {
     "content": "Styling the editable",
-    "id": "9236a52a-0702-4831-b1ca-789ded55091a",
+    "id": "dac5004b-1e76-41fa-9417-4a262e3a5221",
     "type": "lvl3",
     "url": "/docs/components/form/editable#styling-the-editable",
     "hierarchy": {
@@ -2003,14 +2003,14 @@
   },
   {
     "content": "Props",
-    "id": "8c648f74-26c8-4141-9442-5f6def5c0b06",
+    "id": "a1f85f07-e240-432c-98c2-8ddfdf4cb9af",
     "type": "lvl2",
     "url": "/docs/components/form/editable#props",
     "hierarchy": { "lvl1": "Editable", "lvl2": "Props", "lvl3": null }
   },
   {
     "content": "Editable Props",
-    "id": "c6841e21-f083-42b9-9261-3180108bfa8d",
+    "id": "60b16f42-d6f6-4e64-82a5-02d2494bbb11",
     "type": "lvl3",
     "url": "/docs/components/form/editable#editable-props",
     "hierarchy": {
@@ -2021,28 +2021,28 @@
   },
   {
     "content": "Form Control",
-    "id": "407f1b2a-aff0-4fbd-a04f-80c0b0223168",
+    "id": "c439f362-1b2e-4e2b-8590-bfb2a0f3ce01",
     "type": "lvl1",
     "url": "/docs/components/form/form-control",
     "hierarchy": { "lvl1": "Form Control" }
   },
   {
     "content": "Import",
-    "id": "048a3f94-b6fd-4882-b9e4-7bd51728005b",
+    "id": "905b9107-5baf-46fa-9f0b-3e01cd6fa08a",
     "type": "lvl2",
     "url": "/docs/components/form/form-control#import",
     "hierarchy": { "lvl1": "Form Control", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Usage",
-    "id": "0072dd7e-8ed1-428e-b8b7-38eef757040f",
+    "id": "730305a8-7b64-4b37-974c-d5920d07b5c9",
     "type": "lvl2",
     "url": "/docs/components/form/form-control#usage",
     "hierarchy": { "lvl1": "Form Control", "lvl2": "Usage", "lvl3": null }
   },
   {
     "content": "Sample usage for a radio or checkbox group",
-    "id": "42abd1e5-5b06-4947-b5f8-7c3511b6d2b5",
+    "id": "a6d447ad-3db5-49c0-ae87-26d5c6e6a37a",
     "type": "lvl3",
     "url": "/docs/components/form/form-control#sample-usage-for-a-radio-or-checkbox-group",
     "hierarchy": {
@@ -2053,7 +2053,7 @@
   },
   {
     "content": "Error message",
-    "id": "8ffe7196-9930-4284-9a07-eb0b7d786f16",
+    "id": "ab2211b7-d479-4d2c-8f4e-74c66d850b00",
     "type": "lvl3",
     "url": "/docs/components/form/form-control#error-message",
     "hierarchy": {
@@ -2064,7 +2064,7 @@
   },
   {
     "content": "Making a field required",
-    "id": "fe3ca88e-d2cd-40c1-9693-7450f9335ac0",
+    "id": "82e86bbb-6b98-4961-bd7d-5beca6628fae",
     "type": "lvl3",
     "url": "/docs/components/form/form-control#making-a-field-required",
     "hierarchy": {
@@ -2075,7 +2075,7 @@
   },
   {
     "content": "Select Example",
-    "id": "198c38d5-04e0-4b6c-8985-6f99683086b2",
+    "id": "9fb83e0b-f16e-4107-8678-e511fd29841a",
     "type": "lvl3",
     "url": "/docs/components/form/form-control#select-example",
     "hierarchy": {
@@ -2086,7 +2086,7 @@
   },
   {
     "content": "Number Input Example",
-    "id": "1857839c-a127-482c-a753-d477cfeb48c7",
+    "id": "4fbb1f95-0be3-4638-b9ef-720dc6a3fe9b",
     "type": "lvl3",
     "url": "/docs/components/form/form-control#number-input-example",
     "hierarchy": {
@@ -2097,7 +2097,7 @@
   },
   {
     "content": "Usage with Form Libraries",
-    "id": "437bdf8b-cff6-4271-bf2a-ff16d0cd65b4",
+    "id": "fe8181d0-2342-479e-a486-9eb49c28847e",
     "type": "lvl3",
     "url": "/docs/components/form/form-control#usage-with-form-libraries",
     "hierarchy": {
@@ -2108,7 +2108,7 @@
   },
   {
     "content": "Improvements from v1",
-    "id": "05ad2151-0ee3-4f58-bb76-5e8240f101e7",
+    "id": "d4af44a0-549d-4d56-b7ad-c9f8a472139c",
     "type": "lvl2",
     "url": "/docs/components/form/form-control#improvements-from-v1",
     "hierarchy": {
@@ -2119,35 +2119,35 @@
   },
   {
     "content": "Props",
-    "id": "d8ea3548-6c3c-4cce-8887-1bef4f7ec584",
+    "id": "9044ebb9-f023-44ed-ba76-e87239788459",
     "type": "lvl2",
     "url": "/docs/components/form/form-control#props",
     "hierarchy": { "lvl1": "Form Control", "lvl2": "Props", "lvl3": null }
   },
   {
     "content": "Icon Button",
-    "id": "4d2aa8c3-390a-47d9-b01d-e087bdc64b64",
+    "id": "e60ba455-07d6-4943-a9ab-fae20c6b0183",
     "type": "lvl1",
     "url": "/docs/components/form/icon-button",
     "hierarchy": { "lvl1": "Icon Button" }
   },
   {
     "content": "Import",
-    "id": "abc7a509-9087-453a-ad79-0bfd21e1bfb3",
+    "id": "d9d71775-35f1-4e8e-9600-e58cec9337ca",
     "type": "lvl2",
     "url": "/docs/components/form/icon-button#import",
     "hierarchy": { "lvl1": "Icon Button", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Usage",
-    "id": "ed644a96-9498-4cd6-ac97-bc24d3398029",
+    "id": "81a10aff-3058-4166-9262-2478d867a8f4",
     "type": "lvl2",
     "url": "/docs/components/form/icon-button#usage",
     "hierarchy": { "lvl1": "Icon Button", "lvl2": "Usage", "lvl3": null }
   },
   {
     "content": "Button Colors",
-    "id": "6713d81b-4ec1-41ef-942b-5830ecbc5635",
+    "id": "bb0740b5-e9ae-4cc1-b2e3-a8d28763eb11",
     "type": "lvl3",
     "url": "/docs/components/form/icon-button#button-colors",
     "hierarchy": {
@@ -2158,7 +2158,7 @@
   },
   {
     "content": "Button Sizes",
-    "id": "042bf15c-bacc-4b49-a448-62f9df571a2b",
+    "id": "197550fd-5222-4cee-bfed-3c0219c37e25",
     "type": "lvl3",
     "url": "/docs/components/form/icon-button#button-sizes",
     "hierarchy": {
@@ -2169,7 +2169,7 @@
   },
   {
     "content": "Button Variants",
-    "id": "b9adcc55-46f2-48d4-8d2e-2a7528b1125e",
+    "id": "9e04a3e7-c6f0-4e9c-8d85-1471138c13a9",
     "type": "lvl3",
     "url": "/docs/components/form/icon-button#button-variants",
     "hierarchy": {
@@ -2180,7 +2180,7 @@
   },
   {
     "content": "With custom icon",
-    "id": "504373bb-dbf4-447c-a5ef-e83b61497b5f",
+    "id": "db323abc-7e0a-421f-9f1f-e8cde0fbb42b",
     "type": "lvl3",
     "url": "/docs/components/form/icon-button#with-custom-icon",
     "hierarchy": {
@@ -2191,35 +2191,35 @@
   },
   {
     "content": "Props",
-    "id": "3b7679c0-a201-4509-93ba-18efc64071ad",
+    "id": "90cc6eeb-d28c-42e1-a8ae-b7f96a1b662e",
     "type": "lvl2",
     "url": "/docs/components/form/icon-button#props",
     "hierarchy": { "lvl1": "Icon Button", "lvl2": "Props", "lvl3": null }
   },
   {
     "content": "Input",
-    "id": "9d9d3803-dbeb-4d96-b0a3-b60acad33287",
+    "id": "e53e2b1a-0188-40a4-bbf1-e20b5a141a65",
     "type": "lvl1",
     "url": "/docs/components/form/input",
     "hierarchy": { "lvl1": "Input" }
   },
   {
     "content": "Import",
-    "id": "9562e755-668b-4a6e-ad83-eaf77daee669",
+    "id": "efe1ec9d-09f2-4e2b-ac89-11fe3db0f2c5",
     "type": "lvl2",
     "url": "/docs/components/form/input#import",
     "hierarchy": { "lvl1": "Input", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Usage",
-    "id": "e53d9e27-84e6-4df5-bb89-7cdaffe2d833",
+    "id": "15bac287-397c-41d3-b636-cbc6285277cc",
     "type": "lvl2",
     "url": "/docs/components/form/input#usage",
     "hierarchy": { "lvl1": "Input", "lvl2": "Usage", "lvl3": null }
   },
   {
     "content": "Changing the size of the Input",
-    "id": "ebc97f84-d9a7-4443-b31a-07c1ff1ffcbb",
+    "id": "c0eb449c-c5e6-4eed-ba30-6bf29ff58009",
     "type": "lvl3",
     "url": "/docs/components/form/input#changing-the-size-of-the-input",
     "hierarchy": {
@@ -2230,7 +2230,7 @@
   },
   {
     "content": "Changing the appearance of the input",
-    "id": "3b907b18-8dfa-4f8e-9637-a04ef74ee45e",
+    "id": "26445264-8326-4725-9f15-fd692375b5c5",
     "type": "lvl3",
     "url": "/docs/components/form/input#changing-the-appearance-of-the-input",
     "hierarchy": {
@@ -2241,7 +2241,7 @@
   },
   {
     "content": "Left and Right Addons",
-    "id": "f7ce9ea2-fb04-40ca-b75a-7570f6fcc018",
+    "id": "747d7249-a37b-4238-9b45-31f1f550f467",
     "type": "lvl3",
     "url": "/docs/components/form/input#left-and-right-addons",
     "hierarchy": {
@@ -2252,7 +2252,7 @@
   },
   {
     "content": "Add elements inside Input",
-    "id": "05640a99-7b4c-4aaf-bbb7-a45e0452e5cf",
+    "id": "8c02e496-0044-4135-8a61-8ab30b45cf3b",
     "type": "lvl3",
     "url": "/docs/components/form/input#add-elements-inside-input",
     "hierarchy": {
@@ -2263,7 +2263,7 @@
   },
   {
     "content": "Password Input Example",
-    "id": "256fbadf-bb04-4380-bce7-de984819e318",
+    "id": "92c5fc61-2401-4ba0-b801-a160cb50dc65",
     "type": "lvl3",
     "url": "/docs/components/form/input#password-input-example",
     "hierarchy": {
@@ -2274,7 +2274,7 @@
   },
   {
     "content": "Controlled Input",
-    "id": "8566c9f3-aad1-4f2b-b6d4-efd40017da7a",
+    "id": "703589ee-5a3f-427e-9c58-9032c2748817",
     "type": "lvl3",
     "url": "/docs/components/form/input#controlled-input",
     "hierarchy": {
@@ -2285,7 +2285,7 @@
   },
   {
     "content": "Changing the focus and error border colors",
-    "id": "1a7ea6c2-aa6e-4cad-b8aa-c47cbf36516a",
+    "id": "5372901d-6dea-4111-80c9-b96f8e86a0a9",
     "type": "lvl3",
     "url": "/docs/components/form/input#changing-the-focus-and-error-border-colors",
     "hierarchy": {
@@ -2296,35 +2296,35 @@
   },
   {
     "content": "Props",
-    "id": "0d214416-40fb-462f-ac88-416000abe958",
+    "id": "bcbacb86-6269-4f94-bcd5-a44f23e5c131",
     "type": "lvl2",
     "url": "/docs/components/form/input#props",
     "hierarchy": { "lvl1": "Input", "lvl2": "Props", "lvl3": null }
   },
   {
     "content": "Number Input",
-    "id": "5659ad89-78fe-42a3-b0ec-f257f8ed4624",
+    "id": "8e986643-356c-46e8-bfb5-1bc071cfca84",
     "type": "lvl1",
     "url": "/docs/components/form/number-input",
     "hierarchy": { "lvl1": "Number Input" }
   },
   {
     "content": "Import",
-    "id": "7f140fb4-aee3-41c4-96df-dee082f5e5f6",
+    "id": "73b51850-74f9-4995-b362-ae4fdb73d8fe",
     "type": "lvl2",
     "url": "/docs/components/form/number-input#import",
     "hierarchy": { "lvl1": "Number Input", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Usage",
-    "id": "8b59c32f-fd35-4de8-90b2-4ec6101bc9b6",
+    "id": "d5884f05-7625-4d84-a72b-0bb14e1e0ece",
     "type": "lvl2",
     "url": "/docs/components/form/number-input#usage",
     "hierarchy": { "lvl1": "Number Input", "lvl2": "Usage", "lvl3": null }
   },
   {
     "content": "Setting a minimum and maximum value",
-    "id": "6c001e38-5df7-47cb-ab1e-140754cd8831",
+    "id": "4465691e-ea61-46a4-93b9-8af05cf541af",
     "type": "lvl3",
     "url": "/docs/components/form/number-input#setting-a-minimum-and-maximum-value",
     "hierarchy": {
@@ -2335,7 +2335,7 @@
   },
   {
     "content": "Setting the step size",
-    "id": "1eaaaed4-6b91-441b-942d-b3ac72776a0d",
+    "id": "9a13d750-5618-411d-84a1-bd23c6232f42",
     "type": "lvl3",
     "url": "/docs/components/form/number-input#setting-the-step-size",
     "hierarchy": {
@@ -2346,7 +2346,7 @@
   },
   {
     "content": "Adjusting the precision of the value",
-    "id": "47014592-ec6c-448c-adfd-b9b065e92100",
+    "id": "241953b5-c76f-41f5-8fc4-b01f710813d5",
     "type": "lvl3",
     "url": "/docs/components/form/number-input#adjusting-the-precision-of-the-value",
     "hierarchy": {
@@ -2357,7 +2357,7 @@
   },
   {
     "content": "Clamp value when user blurs the input",
-    "id": "5b274514-69ee-46ab-8abe-b863d77f7ce1",
+    "id": "d76b0274-c4d0-4315-8ecc-35f64199bc3a",
     "type": "lvl3",
     "url": "/docs/components/form/number-input#clamp-value-when-user-blurs-the-input",
     "hierarchy": {
@@ -2368,7 +2368,7 @@
   },
   {
     "content": "Allowing out of range values",
-    "id": "ed141e9a-820b-492c-bca6-e97ffe3d00eb",
+    "id": "3c4944c5-eebf-45ee-9e05-f52ad7618737",
     "type": "lvl3",
     "url": "/docs/components/form/number-input#allowing-out-of-range-values",
     "hierarchy": {
@@ -2379,7 +2379,7 @@
   },
   {
     "content": "Formatting and Parsing the value",
-    "id": "65c3b36f-268f-43d7-8a9c-901694bd6da9",
+    "id": "b75465b7-361c-4a82-b98b-e258d9d4cf06",
     "type": "lvl3",
     "url": "/docs/components/form/number-input#formatting-and-parsing-the-value",
     "hierarchy": {
@@ -2390,7 +2390,7 @@
   },
   {
     "content": "Changing the size of the input",
-    "id": "a12f56a6-07d8-4f42-a982-38b0444752d0",
+    "id": "e22f941b-d844-4314-81e6-95e29320edf6",
     "type": "lvl3",
     "url": "/docs/components/form/number-input#changing-the-size-of-the-input",
     "hierarchy": {
@@ -2401,7 +2401,7 @@
   },
   {
     "content": "Changing the styles",
-    "id": "0b08319b-2ca8-4be6-b2d0-e4a3a1d96fbb",
+    "id": "ae31221b-9fe7-4da7-9467-6190cba1baeb",
     "type": "lvl3",
     "url": "/docs/components/form/number-input#changing-the-styles",
     "hierarchy": {
@@ -2412,7 +2412,7 @@
   },
   {
     "content": "Combining it with a Slider",
-    "id": "57711829-11ea-41ca-918a-3585575450c8",
+    "id": "5e139f36-f858-4c94-bcdd-2d4d1d4af4ae",
     "type": "lvl3",
     "url": "/docs/components/form/number-input#combining-it-with-a-slider",
     "hierarchy": {
@@ -2423,7 +2423,7 @@
   },
   {
     "content": "Create a mobile spinner",
-    "id": "5c6c1dfa-c99e-4929-ab85-1100a46b4980",
+    "id": "ffa82bc3-8637-40db-bb26-92ca58439860",
     "type": "lvl3",
     "url": "/docs/components/form/number-input#create-a-mobile-spinner",
     "hierarchy": {
@@ -2434,7 +2434,7 @@
   },
   {
     "content": "Increment value using Mouse wheel",
-    "id": "2fdd0000-14aa-4760-a5b3-e1c553dd5e4d",
+    "id": "69775754-c382-4116-aba6-88121bfede5d",
     "type": "lvl3",
     "url": "/docs/components/form/number-input#increment-value-using-mouse-wheel",
     "hierarchy": {
@@ -2445,7 +2445,7 @@
   },
   {
     "content": "Accessibility",
-    "id": "30a9429a-6c29-4ea4-a8ca-9c400aa28210",
+    "id": "46ddc364-231a-4213-9e08-cf355bc5f63b",
     "type": "lvl2",
     "url": "/docs/components/form/number-input#accessibility",
     "hierarchy": {
@@ -2456,7 +2456,7 @@
   },
   {
     "content": "Aria Roles",
-    "id": "62c981f2-95c9-498a-af0e-ceedc875071b",
+    "id": "cff0a1a9-5fbe-41e5-829f-574ba6d6a831",
     "type": "lvl3",
     "url": "/docs/components/form/number-input#aria-roles",
     "hierarchy": {
@@ -2467,7 +2467,7 @@
   },
   {
     "content": "Keyboard Navigation",
-    "id": "f5320b81-86ab-4217-9b1f-32028112bd21",
+    "id": "4e788003-fe26-467b-903f-0ace04924d76",
     "type": "lvl3",
     "url": "/docs/components/form/number-input#keyboard-navigation",
     "hierarchy": {
@@ -2478,14 +2478,14 @@
   },
   {
     "content": "Props",
-    "id": "bcd053ea-e37b-4b1c-ad95-0e69d2b1e1f9",
+    "id": "908893a0-92e9-4411-8344-96dfcba63f29",
     "type": "lvl2",
     "url": "/docs/components/form/number-input#props",
     "hierarchy": { "lvl1": "Number Input", "lvl2": "Props", "lvl3": null }
   },
   {
     "content": "NumberInput Props",
-    "id": "da961c45-a9a1-4490-a14c-d1ade05d11a8",
+    "id": "523a8ca6-e70a-4f51-945c-1b2aca33da8c",
     "type": "lvl3",
     "url": "/docs/components/form/number-input#numberinput-props",
     "hierarchy": {
@@ -2496,7 +2496,7 @@
   },
   {
     "content": "NumberInputField Props",
-    "id": "0e20340e-414a-44c1-862d-76d22c057795",
+    "id": "0e411b8b-7faa-4687-871b-8da73e28e3f0",
     "type": "lvl3",
     "url": "/docs/components/form/number-input#numberinputfield-props",
     "hierarchy": {
@@ -2507,7 +2507,7 @@
   },
   {
     "content": "NumberInputStepper Props",
-    "id": "b59e7ef3-6d09-4ca4-9976-834d369a44fd",
+    "id": "3538a3cf-0d13-44ac-9518-ed01fff68419",
     "type": "lvl3",
     "url": "/docs/components/form/number-input#numberinputstepper-props",
     "hierarchy": {
@@ -2518,7 +2518,7 @@
   },
   {
     "content": "NumberDecrementStepper and NumberIncrementStepper Props",
-    "id": "4c4ff7a2-c0e8-4104-9f60-29f505aee1c7",
+    "id": "5a71afed-9d01-49f7-a043-3baf9f8330a4",
     "type": "lvl3",
     "url": "/docs/components/form/number-input#numberdecrementstepper-and-numberincrementstepper-props",
     "hierarchy": {
@@ -2529,28 +2529,28 @@
   },
   {
     "content": "Pin Input",
-    "id": "9a134047-6d55-4d6f-b20c-60c99e41367f",
+    "id": "a7daac8a-d822-4dc1-a77e-f879706e94c1",
     "type": "lvl1",
     "url": "/docs/components/form/pin-input",
     "hierarchy": { "lvl1": "Pin Input" }
   },
   {
     "content": "Import",
-    "id": "1758d030-d63f-4519-b572-c5f10061ed23",
+    "id": "106f0db4-fda4-4e9f-801d-b5ed62b1f7d0",
     "type": "lvl2",
     "url": "/docs/components/form/pin-input#import",
     "hierarchy": { "lvl1": "Pin Input", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Usage",
-    "id": "59f54b3a-a5f5-45e9-91da-9dd97a7ff0a5",
+    "id": "fa16f3b0-0133-4853-8f97-1ece3335dd52",
     "type": "lvl2",
     "url": "/docs/components/form/pin-input#usage",
     "hierarchy": { "lvl1": "Pin Input", "lvl2": "Usage", "lvl3": null }
   },
   {
     "content": "Allowing Alphanumeric values",
-    "id": "c89e9ad5-a707-4d84-a9ef-258d512143a7",
+    "id": "5c5be64b-d244-4167-9cf6-503efa326c3e",
     "type": "lvl3",
     "url": "/docs/components/form/pin-input#allowing-alphanumeric-values",
     "hierarchy": {
@@ -2561,7 +2561,7 @@
   },
   {
     "content": "Using fields as a one time password (OTP)",
-    "id": "4dc2d796-ee8e-4718-a8eb-823dcd8062f5",
+    "id": "1273b2f1-854e-4426-925a-62b3565a6dd4",
     "type": "lvl3",
     "url": "/docs/components/form/pin-input#using-fields-as-a-one-time-password-otp",
     "hierarchy": {
@@ -2572,7 +2572,7 @@
   },
   {
     "content": "Masking the pin input's value",
-    "id": "ab660b2f-2416-4337-a99e-06abed9eea7d",
+    "id": "b1a1f9dd-4d6e-4122-9fec-53db9b57c67a",
     "type": "lvl3",
     "url": "/docs/components/form/pin-input#masking-the-pin-inputs-value",
     "hierarchy": {
@@ -2583,7 +2583,7 @@
   },
   {
     "content": "Changing the size of the PinInput",
-    "id": "4c857d1d-eb50-4e0c-bfa6-4c1d58fdb3b5",
+    "id": "fdc01e89-98c8-4be7-bd7f-51d6062fb691",
     "type": "lvl3",
     "url": "/docs/components/form/pin-input#changing-the-size-of-the-pininput",
     "hierarchy": {
@@ -2594,7 +2594,7 @@
   },
   {
     "content": "Adding a defaultValue",
-    "id": "78559083-a705-4567-9336-158f84fa17dc",
+    "id": "690908a4-93d9-4349-862d-f2c1ec28fc46",
     "type": "lvl3",
     "url": "/docs/components/form/pin-input#adding-a-defaultvalue",
     "hierarchy": {
@@ -2605,7 +2605,7 @@
   },
   {
     "content": "Changing the placeholder",
-    "id": "6fb87eec-6f6d-4893-873d-e34329502915",
+    "id": "c9113eca-769f-4146-8fb7-0acfa9affe27",
     "type": "lvl3",
     "url": "/docs/components/form/pin-input#changing-the-placeholder",
     "hierarchy": {
@@ -2616,7 +2616,7 @@
   },
   {
     "content": "Disable focus management",
-    "id": "96175c58-4080-463a-a64d-ceaa980f464a",
+    "id": "39d165be-9a20-48e0-8a24-81cf4569dd35",
     "type": "lvl3",
     "url": "/docs/components/form/pin-input#disable-focus-management",
     "hierarchy": {
@@ -2627,7 +2627,7 @@
   },
   {
     "content": "AutoFill and Copy + Paste",
-    "id": "89c525e2-6b85-4c43-9521-15a7b1b5b244",
+    "id": "247e4478-65ee-40b6-a407-722dc4ac290d",
     "type": "lvl3",
     "url": "/docs/components/form/pin-input#autofill-and-copy--paste",
     "hierarchy": {
@@ -2638,14 +2638,14 @@
   },
   {
     "content": "Props",
-    "id": "65bafbdb-d6c0-4710-a386-446e6bf1155e",
+    "id": "eef388b0-0219-4ba7-9227-317461975f1c",
     "type": "lvl2",
     "url": "/docs/components/form/pin-input#props",
     "hierarchy": { "lvl1": "Pin Input", "lvl2": "Props", "lvl3": null }
   },
   {
     "content": "PinInputField",
-    "id": "484654d8-d2fb-4646-b322-4cd0561bacba",
+    "id": "304d3d86-e808-4b76-919f-6c45977cdacb",
     "type": "lvl3",
     "url": "/docs/components/form/pin-input#pininputfield",
     "hierarchy": {
@@ -2656,28 +2656,28 @@
   },
   {
     "content": "Radio",
-    "id": "c0d7d266-6990-4ad4-b48e-8ed15d4b1149",
+    "id": "761a9b16-0769-4033-8bd4-4e6e2f7eb678",
     "type": "lvl1",
     "url": "/docs/components/form/radio",
     "hierarchy": { "lvl1": "Radio" }
   },
   {
     "content": "Import",
-    "id": "b93bc6f4-28c6-4d33-8d57-4c813210e0c0",
+    "id": "d46faaeb-8033-4c07-9029-d261ff0bb799",
     "type": "lvl2",
     "url": "/docs/components/form/radio#import",
     "hierarchy": { "lvl1": "Radio", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Usage",
-    "id": "f0b6cdcc-db0b-42d4-8d92-4b890591c0a4",
+    "id": "72c127c6-d0e1-4c68-89a2-a511fc9f3c02",
     "type": "lvl3",
     "url": "/docs/components/form/radio#usage",
     "hierarchy": { "lvl1": "Radio", "lvl2": "Import", "lvl3": "Usage" }
   },
   {
     "content": "Radio with custom color",
-    "id": "966010ef-56be-428f-b67e-61365a014f5e",
+    "id": "eb373f76-df51-429d-b4f0-53cbf649bc78",
     "type": "lvl3",
     "url": "/docs/components/form/radio#radio-with-custom-color",
     "hierarchy": {
@@ -2688,7 +2688,7 @@
   },
   {
     "content": "Radio sizes",
-    "id": "31604d9d-0236-4585-bb2d-fa57ce039ca2",
+    "id": "793076c1-02e3-432e-a625-cf982d054626",
     "type": "lvl3",
     "url": "/docs/components/form/radio#radio-sizes",
     "hierarchy": {
@@ -2699,7 +2699,7 @@
   },
   {
     "content": "Disabled radios",
-    "id": "17d81319-932c-423e-bf1e-f2dec3751f04",
+    "id": "1bc93267-c496-4991-a4e4-78356ade6950",
     "type": "lvl3",
     "url": "/docs/components/form/radio#disabled-radios",
     "hierarchy": {
@@ -2710,7 +2710,7 @@
   },
   {
     "content": "Horizontal alignment",
-    "id": "367fe876-f19f-4ee9-ab77-209aec8e79f7",
+    "id": "6dcc315e-ee62-4c21-b75e-98671554f3aa",
     "type": "lvl3",
     "url": "/docs/components/form/radio#horizontal-alignment",
     "hierarchy": {
@@ -2721,7 +2721,7 @@
   },
   {
     "content": "Invalid Radio",
-    "id": "abc013de-553d-4739-abfc-2e704930e231",
+    "id": "d87cf8b1-d76f-4ca8-96dc-de845d91a2ce",
     "type": "lvl3",
     "url": "/docs/components/form/radio#invalid-radio",
     "hierarchy": {
@@ -2732,7 +2732,7 @@
   },
   {
     "content": "Custom Radio Buttons",
-    "id": "fa3c4c5e-54c2-4bc2-b93e-059b9b77b559",
+    "id": "d0aa573d-6583-4bc8-b5c8-8e0c2ad970b7",
     "type": "lvl3",
     "url": "/docs/components/form/radio#custom-radio-buttons",
     "hierarchy": {
@@ -2743,7 +2743,7 @@
   },
   {
     "content": "Note about `name` prop",
-    "id": "c641e60c-b5e1-47db-a5a5-ae622c84441a",
+    "id": "a2c59550-c56d-455c-aae2-36863551c369",
     "type": "lvl3",
     "url": "/docs/components/form/radio#note-about-name-prop",
     "hierarchy": {
@@ -2754,35 +2754,35 @@
   },
   {
     "content": "Props",
-    "id": "570ac6a7-51da-4f7e-90e4-c98a754cf323",
+    "id": "01b297b1-1717-4465-8952-c476a8f214e3",
     "type": "lvl2",
     "url": "/docs/components/form/radio#props",
     "hierarchy": { "lvl1": "Radio", "lvl2": "Props", "lvl3": null }
   },
   {
     "content": "Range Slider",
-    "id": "ee04084e-30fd-4d0b-9d9d-713a76337a6b",
+    "id": "bec95952-15d2-4ffd-ade5-9ea75b4135eb",
     "type": "lvl1",
     "url": "/docs/components/form/range-slider",
     "hierarchy": { "lvl1": "Range Slider" }
   },
   {
     "content": "Import",
-    "id": "1d2ca31f-6308-42ec-9997-b8caed67ea0c",
+    "id": "0ec04ecb-e54b-425f-b2fc-901f0d3dc17d",
     "type": "lvl2",
     "url": "/docs/components/form/range-slider#import",
     "hierarchy": { "lvl1": "Range Slider", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Usage",
-    "id": "532fbba9-d6cd-4432-b99b-d0275a8e91c1",
+    "id": "8527e8e6-5c3d-408d-a204-82714ce1f4e6",
     "type": "lvl2",
     "url": "/docs/components/form/range-slider#usage",
     "hierarchy": { "lvl1": "Range Slider", "lvl2": "Usage", "lvl3": null }
   },
   {
     "content": "Changing the slider color scheme",
-    "id": "11f92aca-b282-4f22-b33d-c81ee87f11a0",
+    "id": "a31cfff6-0348-4d7b-a39f-87e27e740c9b",
     "type": "lvl3",
     "url": "/docs/components/form/range-slider#changing-the-slider-color-scheme",
     "hierarchy": {
@@ -2793,7 +2793,7 @@
   },
   {
     "content": "Changing the slider orientation",
-    "id": "e6afc5ea-6900-4b41-943c-9b0d521f239a",
+    "id": "95a7e11b-feea-4e5d-ace6-1b4848255c2b",
     "type": "lvl3",
     "url": "/docs/components/form/range-slider#changing-the-slider-orientation",
     "hierarchy": {
@@ -2804,7 +2804,7 @@
   },
   {
     "content": "Customizing the Slider",
-    "id": "eab94bd3-92b0-463b-9732-2687b2da99df",
+    "id": "3cdeaa6e-89df-460e-8fbe-ecf428b069f6",
     "type": "lvl3",
     "url": "/docs/components/form/range-slider#customizing-the-slider",
     "hierarchy": {
@@ -2815,7 +2815,7 @@
   },
   {
     "content": "Discrete Sliders",
-    "id": "17708c35-ca52-4c90-8fd9-9342287a3e16",
+    "id": "756141a6-3432-4954-9283-e3e7a38654b1",
     "type": "lvl3",
     "url": "/docs/components/form/range-slider#discrete-sliders",
     "hierarchy": {
@@ -2826,7 +2826,7 @@
   },
   {
     "content": "Getting the final value when dragging the slider",
-    "id": "d9a530e8-80a5-4fdb-8d0d-de46c7ac21d2",
+    "id": "5c416509-e99b-495c-8b2f-bbc591985099",
     "type": "lvl3",
     "url": "/docs/components/form/range-slider#getting-the-final-value-when-dragging-the-slider",
     "hierarchy": {
@@ -2837,7 +2837,7 @@
   },
   {
     "content": "useRangeSlider",
-    "id": "e5c48010-6e90-4947-9ede-aa4586e33a30",
+    "id": "9aebabb3-eb35-4dd7-98d8-8e6cc8f15725",
     "type": "lvl3",
     "url": "/docs/components/form/range-slider#userangeslider",
     "hierarchy": {
@@ -2848,14 +2848,14 @@
   },
   {
     "content": "Props",
-    "id": "42ca36b8-1e0b-4a14-9cbf-74ea3c94f9c6",
+    "id": "21dcaedd-94e5-43e8-abf4-9a03ae657891",
     "type": "lvl2",
     "url": "/docs/components/form/range-slider#props",
     "hierarchy": { "lvl1": "Range Slider", "lvl2": "Props", "lvl3": null }
   },
   {
     "content": "RangeSlider Props",
-    "id": "dc7e4ad7-3cac-40bb-906a-9f09dae29fdd",
+    "id": "959c5837-ae20-445b-9514-f0e0690173e7",
     "type": "lvl3",
     "url": "/docs/components/form/range-slider#rangeslider-props",
     "hierarchy": {
@@ -2866,7 +2866,7 @@
   },
   {
     "content": "RangeSliderThumb Props",
-    "id": "11d97fd1-80f7-432a-9d82-4760872d5c31",
+    "id": "56edcd91-a4e3-4d70-aada-8be7b929efc0",
     "type": "lvl3",
     "url": "/docs/components/form/range-slider#rangesliderthumb-props",
     "hierarchy": {
@@ -2877,7 +2877,7 @@
   },
   {
     "content": "RangeSliderFilledTrack Props",
-    "id": "e50a57d3-0b5a-4d94-a41f-72e8f614cfa0",
+    "id": "3a70752b-a71a-4aec-ac89-3b2501edc6c1",
     "type": "lvl3",
     "url": "/docs/components/form/range-slider#rangesliderfilledtrack-props",
     "hierarchy": {
@@ -2888,7 +2888,7 @@
   },
   {
     "content": "RangeSliderTrack Props",
-    "id": "fc0cc5b6-ab21-4e9d-9cf7-e6ba16b56816",
+    "id": "0f48c41b-46af-496c-84f6-64fa6e5ea670",
     "type": "lvl3",
     "url": "/docs/components/form/range-slider#rangeslidertrack-props",
     "hierarchy": {
@@ -2899,28 +2899,28 @@
   },
   {
     "content": "Select",
-    "id": "48a1cef0-e025-4760-be64-eef46a2f9335",
+    "id": "e6e5b6bf-4398-4b13-a58e-dbb8fce5341e",
     "type": "lvl1",
     "url": "/docs/components/form/select",
     "hierarchy": { "lvl1": "Select" }
   },
   {
     "content": "Import",
-    "id": "bdd609ac-139c-4c4c-845b-7faf4ac22f54",
+    "id": "5cd277c0-4e3b-4f14-9412-d724bb406425",
     "type": "lvl2",
     "url": "/docs/components/form/select#import",
     "hierarchy": { "lvl1": "Select", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Usage",
-    "id": "e0bf7260-af76-405f-99d8-c607314bf6ca",
+    "id": "0451e9b0-55b2-4cb8-9a4c-796d7b3f3294",
     "type": "lvl2",
     "url": "/docs/components/form/select#usage",
     "hierarchy": { "lvl1": "Select", "lvl2": "Usage", "lvl3": null }
   },
   {
     "content": "Changing the size of the Select",
-    "id": "4a04287c-19d6-4357-8c6b-9a0e4f05a976",
+    "id": "b896e04e-3fe2-4e5d-b604-e64431b18dd5",
     "type": "lvl3",
     "url": "/docs/components/form/select#changing-the-size-of-the-select",
     "hierarchy": {
@@ -2931,7 +2931,7 @@
   },
   {
     "content": "Changing the appearance of the Select",
-    "id": "9dc0a3d7-2dbe-4619-af1e-2ef7760ed24c",
+    "id": "86d9e28c-01d6-4c3c-9521-905c97380068",
     "type": "lvl3",
     "url": "/docs/components/form/select#changing-the-appearance-of-the-select",
     "hierarchy": {
@@ -2942,7 +2942,7 @@
   },
   {
     "content": "Changing the icon in the Select",
-    "id": "8aba3107-6daa-40ff-8fec-807f7fd118f5",
+    "id": "20e5cfe7-17f8-4792-9b22-4ad4a1b84fcf",
     "type": "lvl3",
     "url": "/docs/components/form/select#changing-the-icon-in-the-select",
     "hierarchy": {
@@ -2953,7 +2953,7 @@
   },
   {
     "content": "Overriding the styles of the Select",
-    "id": "244c2bd9-a541-4093-a9c0-b84559d6d8e3",
+    "id": "875cb6e7-76f5-4893-b22a-b204be193a18",
     "type": "lvl3",
     "url": "/docs/components/form/select#overriding-the-styles-of-the-select",
     "hierarchy": {
@@ -2964,35 +2964,35 @@
   },
   {
     "content": "Props",
-    "id": "58439c96-2a42-41dd-8f19-89c30f0b1d7a",
+    "id": "78273492-a99a-4e8c-92b4-ecbac3a31b7c",
     "type": "lvl2",
     "url": "/docs/components/form/select#props",
     "hierarchy": { "lvl1": "Select", "lvl2": "Props", "lvl3": null }
   },
   {
     "content": "Slider",
-    "id": "0b85da3b-705e-45e7-a7ed-7a2b134ee15a",
+    "id": "33649a3b-f022-4928-adf6-0d877618e9fe",
     "type": "lvl1",
     "url": "/docs/components/form/slider",
     "hierarchy": { "lvl1": "Slider" }
   },
   {
     "content": "Import",
-    "id": "f499387b-8385-4382-bf07-618e58d0cb86",
+    "id": "a46e2d86-5780-405f-953e-e8fdb46ffc38",
     "type": "lvl2",
     "url": "/docs/components/form/slider#import",
     "hierarchy": { "lvl1": "Slider", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Usage",
-    "id": "a7bc9dc3-9496-49f3-987f-17a4f9f185f3",
+    "id": "f73ee6ca-7866-4047-a44d-651839b29db7",
     "type": "lvl2",
     "url": "/docs/components/form/slider#usage",
     "hierarchy": { "lvl1": "Slider", "lvl2": "Usage", "lvl3": null }
   },
   {
     "content": "Changing the slider color scheme",
-    "id": "29ea13ef-88e5-4496-aa13-7420ce29991d",
+    "id": "d78df921-0e01-4454-8751-967eec38dbbe",
     "type": "lvl3",
     "url": "/docs/components/form/slider#changing-the-slider-color-scheme",
     "hierarchy": {
@@ -3003,7 +3003,7 @@
   },
   {
     "content": "Changing the slider orientation",
-    "id": "99f4c13a-f7bb-4e9b-b8aa-51a05548df57",
+    "id": "17914cda-c3b2-4035-bf50-fd0c2e8cc519",
     "type": "lvl3",
     "url": "/docs/components/form/slider#changing-the-slider-orientation",
     "hierarchy": {
@@ -3014,7 +3014,7 @@
   },
   {
     "content": "Customizing the Slider",
-    "id": "8bc83889-6fa9-499e-97d6-15cdbea72c29",
+    "id": "c053e788-6cb9-450b-8c3e-cf06e9cb4647",
     "type": "lvl3",
     "url": "/docs/components/form/slider#customizing-the-slider",
     "hierarchy": {
@@ -3025,7 +3025,7 @@
   },
   {
     "content": "Discrete Sliders",
-    "id": "98262338-bb12-474c-b0d5-e8753634778c",
+    "id": "b62cfa89-662a-43c8-95eb-d1afd537934a",
     "type": "lvl3",
     "url": "/docs/components/form/slider#discrete-sliders",
     "hierarchy": {
@@ -3036,7 +3036,7 @@
   },
   {
     "content": "Slider with custom labels and marks",
-    "id": "2639ed25-e62d-4458-b7fa-416e331d6a8b",
+    "id": "67b8f341-4d45-4236-b4e7-4a7c8e1a1198",
     "type": "lvl3",
     "url": "/docs/components/form/slider#slider-with-custom-labels-and-marks",
     "hierarchy": {
@@ -3047,7 +3047,7 @@
   },
   {
     "content": "Getting the final value when dragging the slider",
-    "id": "974f6bf2-a4eb-47c5-8727-30a83ee5879d",
+    "id": "f391caaa-c815-4764-bd82-fed4b0f27161",
     "type": "lvl3",
     "url": "/docs/components/form/slider#getting-the-final-value-when-dragging-the-slider",
     "hierarchy": {
@@ -3058,7 +3058,7 @@
   },
   {
     "content": "Configure thumb focus with `focusThumbOnChange`",
-    "id": "85e5035a-4045-4263-9d67-b128bac42c2c",
+    "id": "7a270d2f-f84f-42b8-a8df-6a4308ba410b",
     "type": "lvl3",
     "url": "/docs/components/form/slider#configure-thumb-focus-with-focusthumbonchange",
     "hierarchy": {
@@ -3069,7 +3069,7 @@
   },
   {
     "content": "useSlider",
-    "id": "2171bd3f-bc4f-4732-b174-94d56b6dbc21",
+    "id": "0af8462d-a2a0-42c0-a047-54b7f8a91d49",
     "type": "lvl3",
     "url": "/docs/components/form/slider#useslider",
     "hierarchy": {
@@ -3080,21 +3080,21 @@
   },
   {
     "content": "Props",
-    "id": "4cecf466-56b5-4774-a67b-d3be723e5bd5",
+    "id": "c5e34f2f-3a3b-4688-8e83-d3925b26b9dd",
     "type": "lvl2",
     "url": "/docs/components/form/slider#props",
     "hierarchy": { "lvl1": "Slider", "lvl2": "Props", "lvl3": null }
   },
   {
     "content": "Slider Props",
-    "id": "edd2f916-c9e3-43a6-9c25-9b9debc6751d",
+    "id": "b9098104-71cf-4af8-8b42-5f4decdcf1fb",
     "type": "lvl3",
     "url": "/docs/components/form/slider#slider-props",
     "hierarchy": { "lvl1": "Slider", "lvl2": "Props", "lvl3": "Slider Props" }
   },
   {
     "content": "SliderThumb Props",
-    "id": "9f4739ea-58c7-4624-bc09-94484c3a4e09",
+    "id": "2fa1800b-eb7a-4d5d-9aed-062a8d27a01e",
     "type": "lvl3",
     "url": "/docs/components/form/slider#sliderthumb-props",
     "hierarchy": {
@@ -3105,7 +3105,7 @@
   },
   {
     "content": "SliderFilledTrack Props",
-    "id": "be32c74e-6177-4037-bd8f-4bc2ccc1fc5c",
+    "id": "8abae726-9dba-4fa6-89b7-0157f02c4564",
     "type": "lvl3",
     "url": "/docs/components/form/slider#sliderfilledtrack-props",
     "hierarchy": {
@@ -3116,7 +3116,7 @@
   },
   {
     "content": "SliderTrack Props",
-    "id": "01c89575-b98b-41da-b7d2-002b1de415a8",
+    "id": "a5db0de4-e647-4385-8b6e-ad929cea6507",
     "type": "lvl3",
     "url": "/docs/components/form/slider#slidertrack-props",
     "hierarchy": {
@@ -3127,35 +3127,35 @@
   },
   {
     "content": "Switch",
-    "id": "38fa3934-9579-4b15-b5c1-1c0c6b364517",
+    "id": "35dac72b-0e9a-4a56-8fa4-91764722df3f",
     "type": "lvl1",
     "url": "/docs/components/form/switch",
     "hierarchy": { "lvl1": "Switch" }
   },
   {
     "content": "Import",
-    "id": "8b07bee5-4b79-42fd-8454-816574b938f8",
+    "id": "89feaaf3-f1cf-4e12-9065-c5f417195de0",
     "type": "lvl2",
     "url": "/docs/components/form/switch#import",
     "hierarchy": { "lvl1": "Switch", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Usage",
-    "id": "8928e82c-b85c-49f7-b58b-8e94f709a49b",
+    "id": "30a1a9b1-427b-4761-90c1-c7a29c2a49b0",
     "type": "lvl2",
     "url": "/docs/components/form/switch#usage",
     "hierarchy": { "lvl1": "Switch", "lvl2": "Usage", "lvl3": null }
   },
   {
     "content": "Sizes",
-    "id": "b2e877b5-1baf-406f-9e90-b97dde5299cb",
+    "id": "190ecd2f-25ce-4e59-88ca-61db9e4ac339",
     "type": "lvl2",
     "url": "/docs/components/form/switch#sizes",
     "hierarchy": { "lvl1": "Switch", "lvl2": "Sizes", "lvl3": null }
   },
   {
     "content": "Switch background color",
-    "id": "38c6bc43-c6bb-4177-8244-ba68a5010db1",
+    "id": "dcef0f72-1dec-42d4-b506-6c59ab9b92b2",
     "type": "lvl2",
     "url": "/docs/components/form/switch#switch-background-color",
     "hierarchy": {
@@ -3166,7 +3166,7 @@
   },
   {
     "content": "State depending behavior",
-    "id": "14cf94c9-5027-4bc0-8152-25dbc6c937c5",
+    "id": "ab82a22a-77ae-45bf-a07b-d7cb3c47c885",
     "type": "lvl2",
     "url": "/docs/components/form/switch#state-depending-behavior",
     "hierarchy": {
@@ -3177,35 +3177,35 @@
   },
   {
     "content": "Props",
-    "id": "7bbc1170-192b-4475-ba97-31f3e359589c",
+    "id": "dbe56aee-536e-4fb8-a0c7-211d59d42985",
     "type": "lvl2",
     "url": "/docs/components/form/switch#props",
     "hierarchy": { "lvl1": "Switch", "lvl2": "Props", "lvl3": null }
   },
   {
     "content": "Textarea",
-    "id": "37f6cbbc-8d49-4a3e-9ad9-051639558f8b",
+    "id": "e733f49c-e2b7-4a36-a2ee-bda2dea213e3",
     "type": "lvl1",
     "url": "/docs/components/form/textarea",
     "hierarchy": { "lvl1": "Textarea" }
   },
   {
     "content": "Import",
-    "id": "420e6cc3-6d07-4060-b65a-0385e4ace05a",
+    "id": "9d210f2c-cb1a-4217-b88a-2f7c7fbed141",
     "type": "lvl2",
     "url": "/docs/components/form/textarea#import",
     "hierarchy": { "lvl1": "Textarea", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Usage",
-    "id": "f209942d-b31e-4123-a7ed-10bcc5872b9d",
+    "id": "55ed8146-471c-4c60-9423-92f9f75ef071",
     "type": "lvl3",
     "url": "/docs/components/form/textarea#usage",
     "hierarchy": { "lvl1": "Textarea", "lvl2": "Import", "lvl3": "Usage" }
   },
   {
     "content": "Controlled Textarea",
-    "id": "90f54d7c-f60e-47b0-9472-1d5d14961cb6",
+    "id": "527d9598-10ea-4f9c-90e7-7858b2da40f3",
     "type": "lvl3",
     "url": "/docs/components/form/textarea#controlled-textarea",
     "hierarchy": {
@@ -3216,7 +3216,7 @@
   },
   {
     "content": "Resize behavior",
-    "id": "797dfc98-0f76-4925-9671-3d8427662ee6",
+    "id": "3b02224b-66b5-4668-a696-8fb4c3716a60",
     "type": "lvl3",
     "url": "/docs/components/form/textarea#resize-behavior",
     "hierarchy": {
@@ -3227,7 +3227,7 @@
   },
   {
     "content": "Disabled Textarea",
-    "id": "d7c710c7-ecf9-45b2-96fc-7a871b2e91c8",
+    "id": "bd0fda0e-1812-481a-b31d-3f51ec863520",
     "type": "lvl3",
     "url": "/docs/components/form/textarea#disabled-textarea",
     "hierarchy": {
@@ -3238,7 +3238,7 @@
   },
   {
     "content": "Invalid Textarea",
-    "id": "1ef8dee1-09ad-4e59-a600-0371446d91f1",
+    "id": "499e264d-3cf5-4fd3-80f8-2521e387b67e",
     "type": "lvl3",
     "url": "/docs/components/form/textarea#invalid-textarea",
     "hierarchy": {
@@ -3249,35 +3249,35 @@
   },
   {
     "content": "Props",
-    "id": "7c32e5b1-d7df-4233-8b67-06a82ca0ee0f",
+    "id": "4a73d30c-7068-4e34-a702-989cf238bcfd",
     "type": "lvl2",
     "url": "/docs/components/form/textarea#props",
     "hierarchy": { "lvl1": "Textarea", "lvl2": "Props", "lvl3": null }
   },
   {
     "content": "Aspect Ratio",
-    "id": "a231293b-2f4d-4ab1-ae37-05ee4bf2df83",
+    "id": "67b2b53f-671c-49ae-a41e-8338bfd57766",
     "type": "lvl1",
     "url": "/docs/components/layout/aspect-ratio",
     "hierarchy": { "lvl1": "Aspect Ratio" }
   },
   {
     "content": "Import",
-    "id": "37885ff7-e51f-4a93-960b-75bca198d581",
+    "id": "859d8973-0d27-4f0d-bc04-51657a29bd83",
     "type": "lvl2",
     "url": "/docs/components/layout/aspect-ratio#import",
     "hierarchy": { "lvl1": "Aspect Ratio", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Embed Video",
-    "id": "0362f273-aff4-4df8-a1fb-ac2b6e307b08",
+    "id": "6e077e6d-d605-4b3a-8aa9-f528854704cc",
     "type": "lvl2",
     "url": "/docs/components/layout/aspect-ratio#embed-video",
     "hierarchy": { "lvl1": "Aspect Ratio", "lvl2": "Embed Video", "lvl3": null }
   },
   {
     "content": "Embed Image",
-    "id": "97d78cee-e546-4c48-afbb-82b31ec9e637",
+    "id": "b9b07bc0-e5e1-4d36-84bd-11dc4b5a9c93",
     "type": "lvl3",
     "url": "/docs/components/layout/aspect-ratio#embed-image",
     "hierarchy": {
@@ -3288,7 +3288,7 @@
   },
   {
     "content": "Embed a map",
-    "id": "2b98c7a7-c29c-4f67-969f-c72231589d22",
+    "id": "a8ca9c12-8cbb-4631-b369-8b420160d25a",
     "type": "lvl3",
     "url": "/docs/components/layout/aspect-ratio#embed-a-map",
     "hierarchy": {
@@ -3299,77 +3299,77 @@
   },
   {
     "content": "Props",
-    "id": "42b6b259-322c-4bad-88dc-c5ce8d694ea8",
+    "id": "7df535e5-7b38-4ec2-a53b-532923a0f65c",
     "type": "lvl2",
     "url": "/docs/components/layout/aspect-ratio#props",
     "hierarchy": { "lvl1": "Aspect Ratio", "lvl2": "Props", "lvl3": null }
   },
   {
     "content": "Box",
-    "id": "2ff97f76-9f2f-4ac4-95e7-197d7b7ab569",
+    "id": "f3a0304e-e5f7-4a0b-b08e-2c493fe451cc",
     "type": "lvl1",
     "url": "/docs/components/layout/box",
     "hierarchy": { "lvl1": "Box" }
   },
   {
     "content": "Import",
-    "id": "8551889d-2b3b-4770-902a-cf56a97e2bb9",
+    "id": "03ec693e-505a-4e8b-ba34-99ff306a544b",
     "type": "lvl2",
     "url": "/docs/components/layout/box#import",
     "hierarchy": { "lvl1": "Box", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Usage",
-    "id": "bfa96aa3-1e8a-4514-b80f-edbafdc99d81",
+    "id": "01f62ab1-b049-4dd9-9b17-54502c9606ea",
     "type": "lvl2",
     "url": "/docs/components/layout/box#usage",
     "hierarchy": { "lvl1": "Box", "lvl2": "Usage", "lvl3": null }
   },
   {
     "content": "Usage",
-    "id": "123f7451-3286-4f93-ad15-f4cdeefd67b8",
+    "id": "a95ba45e-1209-4e6b-b51e-f985a669624d",
     "type": "lvl3",
     "url": "/docs/components/layout/box#usage-1",
     "hierarchy": { "lvl1": "Box", "lvl2": "Usage", "lvl3": "Usage" }
   },
   {
     "content": "as prop",
-    "id": "ab7c2d27-f518-4045-9029-665d7a36359a",
+    "id": "c91c0c3f-7096-4582-a095-af15f28f425e",
     "type": "lvl3",
     "url": "/docs/components/layout/box#as-prop",
     "hierarchy": { "lvl1": "Box", "lvl2": "Usage", "lvl3": "as prop" }
   },
   {
     "content": "Center",
-    "id": "f2e4b380-402d-4b87-837d-f3958ffc95f2",
+    "id": "98489be4-1bf2-43f5-b36a-2a50ca56dc44",
     "type": "lvl1",
     "url": "/docs/components/layout/center",
     "hierarchy": { "lvl1": "Center" }
   },
   {
     "content": "Import",
-    "id": "6dab082b-fb91-4bdf-9471-91928e466c7a",
+    "id": "9b555ccd-293e-483f-bd47-1125e6f6a4c7",
     "type": "lvl2",
     "url": "/docs/components/layout/center#import",
     "hierarchy": { "lvl1": "Center", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Usage",
-    "id": "b11d1e63-a0e7-479e-8f73-c794985a2fda",
+    "id": "5485143b-11b2-47c0-aa33-b45bd42b3c17",
     "type": "lvl2",
     "url": "/docs/components/layout/center#usage",
     "hierarchy": { "lvl1": "Center", "lvl2": "Usage", "lvl3": null }
   },
   {
     "content": "With icons",
-    "id": "b70e19ff-cd49-456c-a5bf-a69371ad9406",
+    "id": "34c14c8f-bb40-4fe0-97e4-96a57492d78f",
     "type": "lvl3",
     "url": "/docs/components/layout/center#with-icons",
     "hierarchy": { "lvl1": "Center", "lvl2": "Usage", "lvl3": "With icons" }
   },
   {
     "content": "Square and Circle",
-    "id": "1a35a6d1-1f19-49e7-967f-f7cb1a6c7299",
+    "id": "d776baa8-5cbf-42a5-a243-451233d03508",
     "type": "lvl3",
     "url": "/docs/components/layout/center#square-and-circle",
     "hierarchy": {
@@ -3380,35 +3380,35 @@
   },
   {
     "content": "Container",
-    "id": "fe614a76-a73a-4d69-9f85-ca17e491a698",
+    "id": "81be345f-c297-491b-beb7-4c7681a1ede9",
     "type": "lvl1",
     "url": "/docs/components/layout/container",
     "hierarchy": { "lvl1": "Container" }
   },
   {
     "content": "Import",
-    "id": "5465fc31-6aa0-4643-9390-6d03a3bd7458",
+    "id": "3ce28b8b-dfef-4137-92e7-00616a78f99b",
     "type": "lvl2",
     "url": "/docs/components/layout/container#import",
     "hierarchy": { "lvl1": "Container", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Usage",
-    "id": "8fbdfd94-e6a1-4fdd-915f-5c39ffd4e777",
+    "id": "778f5b71-ff0b-4f0c-8468-abf32c43239b",
     "type": "lvl2",
     "url": "/docs/components/layout/container#usage",
     "hierarchy": { "lvl1": "Container", "lvl2": "Usage", "lvl3": null }
   },
   {
     "content": "Container Size",
-    "id": "6b327098-6b36-4868-a648-12c0a0bb8bdf",
+    "id": "aeb58ef5-0ed4-42f8-a3ba-959f74bb373a",
     "type": "lvl2",
     "url": "/docs/components/layout/container#container-size",
     "hierarchy": { "lvl1": "Container", "lvl2": "Container Size", "lvl3": null }
   },
   {
     "content": "Centering the children",
-    "id": "331a4c83-1514-43c9-a010-b0e614de13e3",
+    "id": "49e8c34c-a2d9-484c-bd16-236a8ea182bb",
     "type": "lvl2",
     "url": "/docs/components/layout/container#centering-the-children",
     "hierarchy": {
@@ -3419,42 +3419,42 @@
   },
   {
     "content": "Props",
-    "id": "04a42063-658e-48f5-b2fe-d1bb4ace6272",
+    "id": "4aaaf7d7-747d-4963-9b32-fbe952e82858",
     "type": "lvl2",
     "url": "/docs/components/layout/container#props",
     "hierarchy": { "lvl1": "Container", "lvl2": "Props", "lvl3": null }
   },
   {
     "content": "Flex",
-    "id": "4f31650f-2d73-495b-8e47-d3c40c400d7b",
+    "id": "36674f3d-614e-46ee-b4a4-d6ebcac565b2",
     "type": "lvl1",
     "url": "/docs/components/layout/flex",
     "hierarchy": { "lvl1": "Flex" }
   },
   {
     "content": "Import",
-    "id": "43edaf9e-488a-416e-bae4-879f9f68b2fa",
+    "id": "6c60c861-4710-4ef7-ab05-5bec28607dc4",
     "type": "lvl2",
     "url": "/docs/components/layout/flex#import",
     "hierarchy": { "lvl1": "Flex", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Usage",
-    "id": "67a9288b-fb81-40bb-a8a3-5cc727f10b58",
+    "id": "1a873b0a-6c60-4632-bfaa-7c1c5f0c30a2",
     "type": "lvl2",
     "url": "/docs/components/layout/flex#usage",
     "hierarchy": { "lvl1": "Flex", "lvl2": "Usage", "lvl3": null }
   },
   {
     "content": "Using the Spacer",
-    "id": "a337d00d-f18c-4047-ab18-56b20883dba5",
+    "id": "02b84ab1-eaa7-49e2-81a4-d36622c7ad35",
     "type": "lvl3",
     "url": "/docs/components/layout/flex#using-the-spacer",
     "hierarchy": { "lvl1": "Flex", "lvl2": "Usage", "lvl3": "Using the Spacer" }
   },
   {
     "content": "Flex and Spacer vs Grid vs Stack",
-    "id": "799444dd-2175-4907-9526-9e3d6d8767ed",
+    "id": "82da4058-ab2e-436e-94e3-731f438ebaf3",
     "type": "lvl3",
     "url": "/docs/components/layout/flex#flex-and-spacer-vs-grid-vs-stack",
     "hierarchy": {
@@ -3465,42 +3465,42 @@
   },
   {
     "content": "Props",
-    "id": "16712c19-3d46-4c6b-a5cf-7e822bf909c8",
+    "id": "0f60520b-a467-49b1-9c11-167c0358db92",
     "type": "lvl2",
     "url": "/docs/components/layout/flex#props",
     "hierarchy": { "lvl1": "Flex", "lvl2": "Props", "lvl3": null }
   },
   {
     "content": "Grid",
-    "id": "9e788a7b-2136-4308-86fd-86c3f47a2acb",
+    "id": "37b88e52-654f-45b7-90e6-c9f090f8132e",
     "type": "lvl1",
     "url": "/docs/components/layout/grid",
     "hierarchy": { "lvl1": "Grid" }
   },
   {
     "content": "Import",
-    "id": "be902c1a-cd33-494f-ad3a-619ac28db3bd",
+    "id": "68c5685b-8b25-4ce4-90fc-a8285c6b48ac",
     "type": "lvl2",
     "url": "/docs/components/layout/grid#import",
     "hierarchy": { "lvl1": "Grid", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Template columns",
-    "id": "2ed0d6d8-b038-4958-bc83-1a7a738a9142",
+    "id": "ef194fe2-2602-4a4b-b808-1f12ba0b7b3e",
     "type": "lvl2",
     "url": "/docs/components/layout/grid#template-columns",
     "hierarchy": { "lvl1": "Grid", "lvl2": "Template columns", "lvl3": null }
   },
   {
     "content": "Spanning columns",
-    "id": "4c64fc67-1f73-4f5d-84a7-d0389d8d075d",
+    "id": "e6f57b4b-1abd-457d-b973-bb4ab3727895",
     "type": "lvl2",
     "url": "/docs/components/layout/grid#spanning-columns",
     "hierarchy": { "lvl1": "Grid", "lvl2": "Spanning columns", "lvl3": null }
   },
   {
     "content": "Starting and ending lines",
-    "id": "2f97f663-9e4f-410f-b1b4-3aa5b749dee6",
+    "id": "ee46028f-8b84-44e3-a853-0bb41951404f",
     "type": "lvl2",
     "url": "/docs/components/layout/grid#starting-and-ending-lines",
     "hierarchy": {
@@ -3511,21 +3511,21 @@
   },
   {
     "content": "Props",
-    "id": "c22dbbea-0105-4954-9026-2d2f201850c2",
+    "id": "adc028e5-3d4e-4a88-b085-9d17144e02b1",
     "type": "lvl2",
     "url": "/docs/components/layout/grid#props",
     "hierarchy": { "lvl1": "Grid", "lvl2": "Props", "lvl3": null }
   },
   {
     "content": "Grid Props",
-    "id": "eda9a589-7346-46b9-9c65-53f088f5ade4",
+    "id": "c0102d5e-65f3-4ebd-8dc2-dca0b16b4c0e",
     "type": "lvl3",
     "url": "/docs/components/layout/grid#grid-props",
     "hierarchy": { "lvl1": "Grid", "lvl2": "Props", "lvl3": "Grid Props" }
   },
   {
     "content": "GridItem Props",
-    "id": "abdae4c2-cffe-4fa3-bc12-b264d33fac1c",
+    "id": "e08199f2-c2d3-4068-9fff-76e97839be5c",
     "type": "lvl3",
     "url": "/docs/components/layout/grid#griditem-props",
     "hierarchy": {
@@ -3536,28 +3536,28 @@
   },
   {
     "content": "SimpleGrid",
-    "id": "1629f1da-123b-4c2c-953e-7b77cc81ca06",
+    "id": "d919f858-999c-4c79-9126-67ef4976b313",
     "type": "lvl1",
     "url": "/docs/components/layout/simple-grid",
     "hierarchy": { "lvl1": "SimpleGrid" }
   },
   {
     "content": "Import",
-    "id": "86f1c7cb-59c1-4d45-b74e-ead442946928",
+    "id": "40ea06d6-11fe-4b60-b427-b8dbdd92da2e",
     "type": "lvl2",
     "url": "/docs/components/layout/simple-grid#import",
     "hierarchy": { "lvl1": "SimpleGrid", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Usage",
-    "id": "9a3baf38-924f-4ecf-9711-3cf4ca93eae7",
+    "id": "d87c82ae-2bbd-4f2e-8563-e3830c04bf15",
     "type": "lvl2",
     "url": "/docs/components/layout/simple-grid#usage",
     "hierarchy": { "lvl1": "SimpleGrid", "lvl2": "Usage", "lvl3": null }
   },
   {
     "content": "Auto-responsive grid",
-    "id": "07c6b855-9119-4d2e-a238-7fb8efe03f5f",
+    "id": "dd9fda38-8fb7-4cf5-a7f5-9e047d216de6",
     "type": "lvl3",
     "url": "/docs/components/layout/simple-grid#auto-responsive-grid",
     "hierarchy": {
@@ -3568,7 +3568,7 @@
   },
   {
     "content": "Changing the spacing for columns and rows",
-    "id": "ebf428d1-4bbd-4ab8-af8e-0aa20b7787df",
+    "id": "4f9be38e-666d-40b9-9cf5-e312c79d109f",
     "type": "lvl3",
     "url": "/docs/components/layout/simple-grid#changing-the-spacing-for-columns-and-rows",
     "hierarchy": {
@@ -3579,49 +3579,49 @@
   },
   {
     "content": "Props",
-    "id": "ed7e34f9-ab78-48fe-8e11-53cdc3afd32a",
+    "id": "5080e769-6527-4973-8409-9302e5e1631a",
     "type": "lvl2",
     "url": "/docs/components/layout/simple-grid#props",
     "hierarchy": { "lvl1": "SimpleGrid", "lvl2": "Props", "lvl3": null }
   },
   {
     "content": "Stack",
-    "id": "05fa9a13-74cd-4f83-86f7-84767b0d3f65",
+    "id": "63eafd8f-c6d5-4297-8a02-79a33707e38f",
     "type": "lvl1",
     "url": "/docs/components/layout/stack",
     "hierarchy": { "lvl1": "Stack" }
   },
   {
     "content": "Import",
-    "id": "21dfc020-7b4c-40fb-b708-f489b84165c7",
+    "id": "106b7ebe-1d76-466c-b2bd-cfccc97d7140",
     "type": "lvl2",
     "url": "/docs/components/layout/stack#import",
     "hierarchy": { "lvl1": "Stack", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "VStack",
-    "id": "aade07e2-d815-4361-9319-aee058cae5b4",
+    "id": "f83adfaa-3137-4cd2-a633-f9e5d5a39671",
     "type": "lvl2",
     "url": "/docs/components/layout/stack#vstack",
     "hierarchy": { "lvl1": "Stack", "lvl2": "VStack", "lvl3": null }
   },
   {
     "content": "HStack",
-    "id": "f95000f4-959f-443f-b514-b9bcc9d0abdf",
+    "id": "1e8ef4de-ea22-46d8-9a44-6204ee723329",
     "type": "lvl2",
     "url": "/docs/components/layout/stack#hstack",
     "hierarchy": { "lvl1": "Stack", "lvl2": "HStack", "lvl3": null }
   },
   {
     "content": "Usage",
-    "id": "3d8d72c7-7adc-46ca-aa5f-464f22031f73",
+    "id": "ade17e5b-f900-49fe-939c-86a602926e24",
     "type": "lvl2",
     "url": "/docs/components/layout/stack#usage",
     "hierarchy": { "lvl1": "Stack", "lvl2": "Usage", "lvl3": null }
   },
   {
     "content": "Responsive direction",
-    "id": "c88fdb5d-ee96-4c58-9bcc-e6d65785269f",
+    "id": "0ebecd63-5663-4909-8b31-067fa413b54a",
     "type": "lvl3",
     "url": "/docs/components/layout/stack#responsive-direction",
     "hierarchy": {
@@ -3632,7 +3632,7 @@
   },
   {
     "content": "Stack Dividers",
-    "id": "ec661d59-dded-449a-aefa-d7a8e19adec2",
+    "id": "b551993f-7f16-4ab8-8507-ced1545866e0",
     "type": "lvl3",
     "url": "/docs/components/layout/stack#stack-dividers",
     "hierarchy": {
@@ -3643,7 +3643,7 @@
   },
   {
     "content": "Example",
-    "id": "ce7c01ec-0b11-4b68-bfad-ed2fdb1b6bf2",
+    "id": "1675972c-1588-48c1-bce3-cd43c281988a",
     "type": "lvl3",
     "url": "/docs/components/layout/stack#example",
     "hierarchy": {
@@ -3654,7 +3654,7 @@
   },
   {
     "content": "Stack items horizontally",
-    "id": "9cbb08ce-d82a-4604-9e56-569da23a99fe",
+    "id": "1db8a546-b7a0-4760-b861-a2e8847a4460",
     "type": "lvl3",
     "url": "/docs/components/layout/stack#stack-items-horizontally",
     "hierarchy": {
@@ -3665,7 +3665,7 @@
   },
   {
     "content": "Notes on Stack vs Flex",
-    "id": "b683f71e-c965-4471-bcc3-dfaa0248b13e",
+    "id": "b7091052-3c9c-482b-ac2a-16863483af6a",
     "type": "lvl3",
     "url": "/docs/components/layout/stack#notes-on-stack-vs-flex",
     "hierarchy": {
@@ -3676,35 +3676,35 @@
   },
   {
     "content": "Props",
-    "id": "55b8c7d4-aba3-45a0-892c-5db8df6ff66d",
+    "id": "9640d6a6-0789-4f80-9284-4a891d185a00",
     "type": "lvl2",
     "url": "/docs/components/layout/stack#props",
     "hierarchy": { "lvl1": "Stack", "lvl2": "Props", "lvl3": null }
   },
   {
     "content": "Wrap",
-    "id": "ad2b1ac3-da6a-4ca8-957a-02c66951e152",
+    "id": "dd6e791f-8403-478e-bd54-7e1df76af6f5",
     "type": "lvl1",
     "url": "/docs/components/layout/wrap",
     "hierarchy": { "lvl1": "Wrap" }
   },
   {
     "content": "Import",
-    "id": "ed42b55f-312a-473b-9c67-5e567414c980",
+    "id": "901bb6ab-bbb2-47ae-8726-593087639282",
     "type": "lvl2",
     "url": "/docs/components/layout/wrap#import",
     "hierarchy": { "lvl1": "Wrap", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Usage",
-    "id": "ab85da38-3570-46b4-8fdf-36d4a06a9321",
+    "id": "51e749d5-2793-475d-adb5-a214a0e5ae1a",
     "type": "lvl2",
     "url": "/docs/components/layout/wrap#usage",
     "hierarchy": { "lvl1": "Wrap", "lvl2": "Usage", "lvl3": null }
   },
   {
     "content": "Change the spacing",
-    "id": "fb9f85ae-0113-45b7-ab1d-c2e0fae11a31",
+    "id": "057e3eeb-07b4-47e3-99e3-486c31906660",
     "type": "lvl3",
     "url": "/docs/components/layout/wrap#change-the-spacing",
     "hierarchy": {
@@ -3715,7 +3715,7 @@
   },
   {
     "content": "Change the alignment",
-    "id": "00203dc7-a287-4ab8-90bc-9fb76a364bb8",
+    "id": "dc30f778-bf02-46ce-aca3-5b5429a88eda",
     "type": "lvl3",
     "url": "/docs/components/layout/wrap#change-the-alignment",
     "hierarchy": {
@@ -3726,21 +3726,21 @@
   },
   {
     "content": "Props",
-    "id": "eb3e40ba-c3d0-45eb-b9b2-e301f4998870",
+    "id": "cd0ddd44-ac64-42b1-82ac-9113e24a777e",
     "type": "lvl2",
     "url": "/docs/components/layout/wrap#props",
     "hierarchy": { "lvl1": "Wrap", "lvl2": "Props", "lvl3": null }
   },
   {
     "content": "Wrap Props",
-    "id": "01237506-b25a-411f-bd80-e89ba282a321",
+    "id": "18569ea4-2da6-4c8f-a017-9b529f8b8d01",
     "type": "lvl3",
     "url": "/docs/components/layout/wrap#wrap-props",
     "hierarchy": { "lvl1": "Wrap", "lvl2": "Props", "lvl3": "Wrap Props" }
   },
   {
     "content": "WrapItem Props",
-    "id": "95341c56-25d0-42ef-a797-1c13f8d4e864",
+    "id": "56e11ca1-3d93-4c5d-ad71-4d93b95358a3",
     "type": "lvl3",
     "url": "/docs/components/layout/wrap#wrapitem-props",
     "hierarchy": {
@@ -3751,35 +3751,35 @@
   },
   {
     "content": "Avatar",
-    "id": "e2628e12-5a1d-4e21-825f-ae7eebb1bc39",
+    "id": "d479f591-c0b5-4c41-b57b-eec723a0ad29",
     "type": "lvl1",
     "url": "/docs/components/media-and-icons/avatar",
     "hierarchy": { "lvl1": "Avatar" }
   },
   {
     "content": "Import",
-    "id": "c5294b3e-fe29-4c21-9add-26346ef8bea9",
+    "id": "289ae401-25fb-4536-beed-3b0257468d86",
     "type": "lvl2",
     "url": "/docs/components/media-and-icons/avatar#import",
     "hierarchy": { "lvl1": "Avatar", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Usage",
-    "id": "e7d77396-b50e-4a00-bd8a-cd3f87f8d92e",
+    "id": "9dcf9f0e-dfbc-4324-8fc5-c189f872f0a7",
     "type": "lvl2",
     "url": "/docs/components/media-and-icons/avatar#usage",
     "hierarchy": { "lvl1": "Avatar", "lvl2": "Usage", "lvl3": null }
   },
   {
     "content": "Avatar Sizes",
-    "id": "f225823a-b998-4f2c-9cb4-c51d9bf39033",
+    "id": "2a21718b-7ccd-4f06-b6af-63f283c6aa9c",
     "type": "lvl3",
     "url": "/docs/components/media-and-icons/avatar#avatar-sizes",
     "hierarchy": { "lvl1": "Avatar", "lvl2": "Usage", "lvl3": "Avatar Sizes" }
   },
   {
     "content": "Avatar Fallbacks",
-    "id": "5b027416-1396-48ee-8078-0dba75ddb6ca",
+    "id": "d5eea8fc-59be-43a2-82fb-3f7a2cf82e78",
     "type": "lvl3",
     "url": "/docs/components/media-and-icons/avatar#avatar-fallbacks",
     "hierarchy": {
@@ -3790,7 +3790,7 @@
   },
   {
     "content": "Customize the fallback avatar",
-    "id": "acdd2b2c-eed1-427b-b055-f8f2ab1a1862",
+    "id": "822835dc-9237-4224-a700-117e357dc784",
     "type": "lvl3",
     "url": "/docs/components/media-and-icons/avatar#customize-the-fallback-avatar",
     "hierarchy": {
@@ -3801,7 +3801,7 @@
   },
   {
     "content": "Avatar with badge",
-    "id": "acda91c5-210c-44a1-aa4e-52ac81f1b395",
+    "id": "74387573-8618-4968-9ce7-4afdc1709790",
     "type": "lvl3",
     "url": "/docs/components/media-and-icons/avatar#avatar-with-badge",
     "hierarchy": {
@@ -3812,7 +3812,7 @@
   },
   {
     "content": "AvatarGroup",
-    "id": "188f873e-a2a1-4734-8791-66ebb878c00a",
+    "id": "dbe7ff1c-a48b-4f4f-ac71-30071ae8d520",
     "type": "lvl3",
     "url": "/docs/components/media-and-icons/avatar#avatargroup",
     "hierarchy": {
@@ -3823,7 +3823,7 @@
   },
   {
     "content": "Changing the initials logic",
-    "id": "48b39710-de05-4926-9e07-4e5e4bf81204",
+    "id": "1ade05a3-4f16-4535-8944-ec68ee45c82c",
     "type": "lvl3",
     "url": "/docs/components/media-and-icons/avatar#changing-the-initials-logic",
     "hierarchy": {
@@ -3834,21 +3834,21 @@
   },
   {
     "content": "Props",
-    "id": "c97ef8f8-c207-4655-8262-abd7795f2e7d",
+    "id": "66d16e0c-f0a5-404e-8a71-230c54855822",
     "type": "lvl2",
     "url": "/docs/components/media-and-icons/avatar#props",
     "hierarchy": { "lvl1": "Avatar", "lvl2": "Props", "lvl3": null }
   },
   {
     "content": "Avatar Props",
-    "id": "94e774c0-6f1b-4545-9ff3-98806d77e762",
+    "id": "6647efaf-8544-47ff-9ffc-fa0a9ec96382",
     "type": "lvl3",
     "url": "/docs/components/media-and-icons/avatar#avatar-props",
     "hierarchy": { "lvl1": "Avatar", "lvl2": "Props", "lvl3": "Avatar Props" }
   },
   {
     "content": "Avatar Group Props",
-    "id": "78f7004c-2424-4c1c-b585-a75cacaac816",
+    "id": "74b3fb98-4348-4e5f-968f-aec3ac77a76f",
     "type": "lvl3",
     "url": "/docs/components/media-and-icons/avatar#avatar-group-props",
     "hierarchy": {
@@ -3859,14 +3859,14 @@
   },
   {
     "content": "Icon",
-    "id": "b8bce541-b81d-4d1e-bde6-2be2e85432cc",
+    "id": "90b28c4e-78c9-4ab4-9c91-eafc085774b2",
     "type": "lvl1",
     "url": "/docs/components/media-and-icons/icon",
     "hierarchy": { "lvl1": "Icon" }
   },
   {
     "content": "Using Chakra UI icons",
-    "id": "37e5494d-8cc2-4764-932e-c2c45419269d",
+    "id": "cc3fa461-0456-4c32-974c-be30576f5fd9",
     "type": "lvl2",
     "url": "/docs/components/media-and-icons/icon#using-chakra-ui-icons",
     "hierarchy": {
@@ -3877,7 +3877,7 @@
   },
   {
     "content": "Installation",
-    "id": "ef522366-e493-4aa8-9d43-999a082ff85c",
+    "id": "b357ca78-c858-4d21-8b23-fcc388b130ab",
     "type": "lvl3",
     "url": "/docs/components/media-and-icons/icon#installation",
     "hierarchy": {
@@ -3888,21 +3888,21 @@
   },
   {
     "content": "Usage",
-    "id": "bf31a407-00ef-4de4-979d-4262a32c7a8b",
+    "id": "e1bbedbc-52fc-41a7-b6a9-125fdb198136",
     "type": "lvl3",
     "url": "/docs/components/media-and-icons/icon#usage",
     "hierarchy": { "lvl1": "Icon", "lvl2": "Installation", "lvl3": "Usage" }
   },
   {
     "content": "All icons",
-    "id": "e64f1f10-a115-4f5e-8bb6-f039ad1a6ecd",
+    "id": "9516dbbe-bc6f-4405-8816-1b03a1921fc4",
     "type": "lvl3",
     "url": "/docs/components/media-and-icons/icon#all-icons",
     "hierarchy": { "lvl1": "Icon", "lvl2": "Usage", "lvl3": "All icons" }
   },
   {
     "content": "Using a third-party icon library",
-    "id": "d36ec2e9-60f4-4289-95b6-657ed6ee4221",
+    "id": "d0afc86d-e45d-49b2-9d2f-9b0119517a48",
     "type": "lvl2",
     "url": "/docs/components/media-and-icons/icon#using-a-third-party-icon-library",
     "hierarchy": {
@@ -3913,7 +3913,7 @@
   },
   {
     "content": "Some examples",
-    "id": "eccef36f-0029-4548-8606-398b1198d7fe",
+    "id": "1f3912d4-fbcc-4daa-95c1-fa82fc3dd890",
     "type": "lvl3",
     "url": "/docs/components/media-and-icons/icon#some-examples",
     "hierarchy": {
@@ -3924,7 +3924,7 @@
   },
   {
     "content": "Creating your custom icons",
-    "id": "4e2c411a-5337-4af4-838a-6f5552844a6a",
+    "id": "376e5cd4-ad77-4c64-8327-b8f2ebc992e2",
     "type": "lvl2",
     "url": "/docs/components/media-and-icons/icon#creating-your-custom-icons",
     "hierarchy": {
@@ -3935,7 +3935,7 @@
   },
   {
     "content": "Using the `Icon` component",
-    "id": "06e990c4-00c4-4650-b6dc-df9f759c4831",
+    "id": "ac124a75-4d0f-4f28-a339-82f0230cc0ba",
     "type": "lvl3",
     "url": "/docs/components/media-and-icons/icon#using-the-icon-component",
     "hierarchy": {
@@ -3946,7 +3946,7 @@
   },
   {
     "content": "Using the `createIcon` function",
-    "id": "f6bd6ce9-3d8b-42e8-bbe1-2ee15deffb10",
+    "id": "54ec16fc-46a4-460e-b8d3-8e37c7e1b349",
     "type": "lvl3",
     "url": "/docs/components/media-and-icons/icon#using-the-createicon-function",
     "hierarchy": {
@@ -3957,7 +3957,7 @@
   },
   {
     "content": "Tips for generating your own icons",
-    "id": "6f1ac673-0ff5-44a4-a28e-df73dfbc00f3",
+    "id": "83af9f9b-08bc-4d60-9476-a73fba55a8e2",
     "type": "lvl3",
     "url": "/docs/components/media-and-icons/icon#tips-for-generating-your-own-icons",
     "hierarchy": {
@@ -3968,28 +3968,28 @@
   },
   {
     "content": "Fallback Icon",
-    "id": "6d659970-5aab-4956-ae9f-c5aa1b357de7",
+    "id": "3cf8dfc2-08cf-46a3-a392-e42b064be82f",
     "type": "lvl2",
     "url": "/docs/components/media-and-icons/icon#fallback-icon",
     "hierarchy": { "lvl1": "Icon", "lvl2": "Fallback Icon", "lvl3": null }
   },
   {
     "content": "Props",
-    "id": "9253f4c8-77e9-4cca-bba5-0d9a39e59ef4",
+    "id": "8ecd3217-b958-48ed-a469-7068a6c4baf6",
     "type": "lvl2",
     "url": "/docs/components/media-and-icons/icon#props",
     "hierarchy": { "lvl1": "Icon", "lvl2": "Props", "lvl3": null }
   },
   {
     "content": "`Icon` props",
-    "id": "d32dca2b-bf24-4355-a7c0-62686cef2706",
+    "id": "c71e3c9a-1b60-4bbc-a5c7-c38dbc305b52",
     "type": "lvl3",
     "url": "/docs/components/media-and-icons/icon#icon-props",
     "hierarchy": { "lvl1": "Icon", "lvl2": "Props", "lvl3": "`Icon` props" }
   },
   {
     "content": "`createIcon` options",
-    "id": "395b62a1-68ee-4fef-b3ed-b7c052537ca3",
+    "id": "2d7a31de-9341-4de5-b950-99bc13f70b92",
     "type": "lvl2",
     "url": "/docs/components/media-and-icons/icon#createicon-options",
     "hierarchy": {
@@ -4000,35 +4000,35 @@
   },
   {
     "content": "Image",
-    "id": "3e75fb90-c6bb-4716-b944-6f171fa86efc",
+    "id": "e07d5927-1f6e-4b24-8cac-12744ca15af2",
     "type": "lvl1",
     "url": "/docs/components/media-and-icons/image",
     "hierarchy": { "lvl1": "Image" }
   },
   {
     "content": "Import",
-    "id": "1b7445ff-d501-44e6-88e3-c2262e696a15",
+    "id": "687ac7f0-9eb2-4851-b36a-82d21eab54d3",
     "type": "lvl2",
     "url": "/docs/components/media-and-icons/image#import",
     "hierarchy": { "lvl1": "Image", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Usage",
-    "id": "bbbe6a85-d184-4702-9a05-a6a6c2a4914d",
+    "id": "e9ad1326-3e9a-4ec1-960d-507e1bd1c47b",
     "type": "lvl2",
     "url": "/docs/components/media-and-icons/image#usage",
     "hierarchy": { "lvl1": "Image", "lvl2": "Usage", "lvl3": null }
   },
   {
     "content": "Size",
-    "id": "41bffb5f-089b-4872-9967-8a0db9ae9bb0",
+    "id": "312d8b07-160f-4ea9-a4ec-23efea39016c",
     "type": "lvl2",
     "url": "/docs/components/media-and-icons/image#size",
     "hierarchy": { "lvl1": "Image", "lvl2": "Size", "lvl3": null }
   },
   {
     "content": "Image with border radius",
-    "id": "7bbb86e8-c46b-4fe5-8699-65d4886b6114",
+    "id": "b2878562-c284-428a-aad2-672960263120",
     "type": "lvl2",
     "url": "/docs/components/media-and-icons/image#image-with-border-radius",
     "hierarchy": {
@@ -4039,14 +4039,14 @@
   },
   {
     "content": "Fallback support",
-    "id": "2196fba5-0284-4a66-a363-76987ea26e66",
+    "id": "f6e4f9f8-c37c-41ba-a4b4-c7c3e7077605",
     "type": "lvl2",
     "url": "/docs/components/media-and-icons/image#fallback-support",
     "hierarchy": { "lvl1": "Image", "lvl2": "Fallback support", "lvl3": null }
   },
   {
     "content": "Improvements from v1",
-    "id": "ff4b37b2-f160-40aa-8fe0-e6ac1fe1b32f",
+    "id": "c3d0852f-d71f-4a9d-9a00-c377d0f41ba5",
     "type": "lvl3",
     "url": "/docs/components/media-and-icons/image#improvements-from-v1",
     "hierarchy": {
@@ -4057,49 +4057,49 @@
   },
   {
     "content": "Usage with SSR",
-    "id": "bc318f2c-38dc-4d73-b6a7-c90dfe680745",
+    "id": "601eb4f7-8d6a-417b-b205-9893bfe8334d",
     "type": "lvl2",
     "url": "/docs/components/media-and-icons/image#usage-with-ssr",
     "hierarchy": { "lvl1": "Image", "lvl2": "Usage with SSR", "lvl3": null }
   },
   {
     "content": "Props",
-    "id": "09ab4a01-5cfa-4e2e-850b-932978795d9d",
+    "id": "d32f91d5-faff-4a41-ac27-c91950d17c4a",
     "type": "lvl2",
     "url": "/docs/components/media-and-icons/image#props",
     "hierarchy": { "lvl1": "Image", "lvl2": "Props", "lvl3": null }
   },
   {
     "content": "Breadcrumb",
-    "id": "e289cab6-58ac-4852-a534-b3403b2afff2",
+    "id": "b6ca34a2-6db5-47be-9eb6-b8a5710741ae",
     "type": "lvl1",
     "url": "/docs/components/navigation/breadcrumb",
     "hierarchy": { "lvl1": "Breadcrumb" }
   },
   {
     "content": "Import",
-    "id": "7fc461dd-8cc1-473c-a1f2-7219ffa6f1ec",
+    "id": "d0841237-c8d2-4377-9f7c-d25f4d81fdfe",
     "type": "lvl2",
     "url": "/docs/components/navigation/breadcrumb#import",
     "hierarchy": { "lvl1": "Breadcrumb", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Usage",
-    "id": "f50defac-73df-40e6-af72-5553bb238a7b",
+    "id": "475b4031-1ac8-49ac-9840-9ab3c33243db",
     "type": "lvl2",
     "url": "/docs/components/navigation/breadcrumb#usage",
     "hierarchy": { "lvl1": "Breadcrumb", "lvl2": "Usage", "lvl3": null }
   },
   {
     "content": "Separators",
-    "id": "bb6a19f9-7b30-4e61-8b40-ca0aa41aa0a3",
+    "id": "04287429-7549-4041-a12d-a7a865f2d93f",
     "type": "lvl3",
     "url": "/docs/components/navigation/breadcrumb#separators",
     "hierarchy": { "lvl1": "Breadcrumb", "lvl2": "Usage", "lvl3": "Separators" }
   },
   {
     "content": "Using an icon as the separator",
-    "id": "2ba5747a-0bcc-4d56-8047-968a4aaf8749",
+    "id": "be3d75eb-6fe1-4aca-b85a-a860d915e25d",
     "type": "lvl3",
     "url": "/docs/components/navigation/breadcrumb#using-an-icon-as-the-separator",
     "hierarchy": {
@@ -4110,7 +4110,7 @@
   },
   {
     "content": "Using a separator in last item",
-    "id": "4721e6c4-f6e9-4410-bec3-5dc878f6a79d",
+    "id": "868ee287-843d-4f95-b4b6-4f60c608da17",
     "type": "lvl3",
     "url": "/docs/components/navigation/breadcrumb#using-a-separator-in-last-item",
     "hierarchy": {
@@ -4121,14 +4121,14 @@
   },
   {
     "content": "Composition",
-    "id": "5e2124c7-3a72-4522-b622-cb017c7aca84",
+    "id": "7b0373ec-44e4-4b4d-8ef6-64972f3de6ce",
     "type": "lvl2",
     "url": "/docs/components/navigation/breadcrumb#composition",
     "hierarchy": { "lvl1": "Breadcrumb", "lvl2": "Composition", "lvl3": null }
   },
   {
     "content": "Usage with Routing Library",
-    "id": "fc1f9e19-47d3-414a-b5d9-8f2ba67f4fca",
+    "id": "09d0626e-b5b4-43af-81f5-24f9ad474094",
     "type": "lvl2",
     "url": "/docs/components/navigation/breadcrumb#usage-with-routing-library",
     "hierarchy": {
@@ -4139,21 +4139,21 @@
   },
   {
     "content": "Accessibility",
-    "id": "98b4ff5a-9231-4e28-9163-9edb99db172f",
+    "id": "2020ca1c-30c1-4caa-9317-1ac033a61751",
     "type": "lvl2",
     "url": "/docs/components/navigation/breadcrumb#accessibility",
     "hierarchy": { "lvl1": "Breadcrumb", "lvl2": "Accessibility", "lvl3": null }
   },
   {
     "content": "Props",
-    "id": "3028a4a6-7b86-4bea-9b96-4b0a4bfb7172",
+    "id": "77a3d94b-c158-4688-9be8-ba1d2a4438d4",
     "type": "lvl2",
     "url": "/docs/components/navigation/breadcrumb#props",
     "hierarchy": { "lvl1": "Breadcrumb", "lvl2": "Props", "lvl3": null }
   },
   {
     "content": "Breadcrumb Props",
-    "id": "3c694221-9ed9-4132-80b8-31d294e4b361",
+    "id": "12cc77b7-e08e-4c7d-a196-14af6edac8bd",
     "type": "lvl3",
     "url": "/docs/components/navigation/breadcrumb#breadcrumb-props",
     "hierarchy": {
@@ -4164,7 +4164,7 @@
   },
   {
     "content": "BreadcrumbItem Props",
-    "id": "06afd3ad-56d6-410f-8c0e-5841f354f4d7",
+    "id": "c1ef9c97-96bc-4ab3-9913-f6ab90c59d92",
     "type": "lvl3",
     "url": "/docs/components/navigation/breadcrumb#breadcrumbitem-props",
     "hierarchy": {
@@ -4175,7 +4175,7 @@
   },
   {
     "content": "BreadcrumbLink Props",
-    "id": "b76b0434-0522-4107-8f57-7207ad4f7c47",
+    "id": "5965967b-fd47-4958-88e1-2f5ceb34c6c0",
     "type": "lvl3",
     "url": "/docs/components/navigation/breadcrumb#breadcrumblink-props",
     "hierarchy": {
@@ -4186,7 +4186,7 @@
   },
   {
     "content": "BreadcrumbSeparator Props",
-    "id": "586b0bc6-cbd7-4243-ab7e-0926a2827a5e",
+    "id": "303f1e34-a81e-42a8-afe7-8c1224be94a9",
     "type": "lvl3",
     "url": "/docs/components/navigation/breadcrumb#breadcrumbseparator-props",
     "hierarchy": {
@@ -4197,28 +4197,28 @@
   },
   {
     "content": "Link Overlay",
-    "id": "85637c62-ddbb-4f2e-ab52-380b321ef9ed",
+    "id": "42574589-fa8a-4b8d-b317-ac9ee422f8bb",
     "type": "lvl1",
     "url": "/docs/components/navigation/link-overlay",
     "hierarchy": { "lvl1": "Link Overlay" }
   },
   {
     "content": "Import",
-    "id": "6c558263-2ea4-4e90-8e49-efdae885c4e1",
+    "id": "4a48aa27-d69a-4743-a8db-2d99c0a2cd63",
     "type": "lvl2",
     "url": "/docs/components/navigation/link-overlay#import",
     "hierarchy": { "lvl1": "Link Overlay", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Usage",
-    "id": "4ff52cf6-1347-45f1-bbf6-902b7e31acac",
+    "id": "7f60e3a6-3769-48ae-85b9-dfb70194416e",
     "type": "lvl2",
     "url": "/docs/components/navigation/link-overlay#usage",
     "hierarchy": { "lvl1": "Link Overlay", "lvl2": "Usage", "lvl3": null }
   },
   {
     "content": "Nested Links",
-    "id": "49e1c34f-026a-41d1-af58-ec9962f698cf",
+    "id": "6001a92c-711c-41ae-9264-c3a2b9d810bb",
     "type": "lvl3",
     "url": "/docs/components/navigation/link-overlay#nested-links",
     "hierarchy": {
@@ -4229,7 +4229,7 @@
   },
   {
     "content": "Usage with Routing Library",
-    "id": "b90198d2-22f3-475d-abd1-0751f5aa3c38",
+    "id": "1e58a1c9-caf7-4774-be13-c0c793dfe63b",
     "type": "lvl2",
     "url": "/docs/components/navigation/link-overlay#usage-with-routing-library",
     "hierarchy": {
@@ -4240,49 +4240,49 @@
   },
   {
     "content": "Caveat",
-    "id": "d95c4e62-ade0-493b-bd2f-7fa7c656c8e3",
+    "id": "4319ed62-766b-41ba-b640-b19879ca7087",
     "type": "lvl2",
     "url": "/docs/components/navigation/link-overlay#caveat",
     "hierarchy": { "lvl1": "Link Overlay", "lvl2": "Caveat", "lvl3": null }
   },
   {
     "content": "Props",
-    "id": "a124a4b1-fce3-4007-a93c-9dc168ad2e88",
+    "id": "8661aac4-fcfa-4827-ae2d-8e278a29501f",
     "type": "lvl2",
     "url": "/docs/components/navigation/link-overlay#props",
     "hierarchy": { "lvl1": "Link Overlay", "lvl2": "Props", "lvl3": null }
   },
   {
     "content": "Link",
-    "id": "1cec1aba-1c19-4783-b59f-8854b1c1c11c",
+    "id": "6ee79d72-9a28-4fb1-9bac-5b2e55a0b336",
     "type": "lvl1",
     "url": "/docs/components/navigation/link",
     "hierarchy": { "lvl1": "Link" }
   },
   {
     "content": "Imports",
-    "id": "3c5b580b-d1dd-45ef-8c6a-150498a62d6e",
+    "id": "3e8327c8-76d0-466b-8af2-ac8c44db4d45",
     "type": "lvl2",
     "url": "/docs/components/navigation/link#imports",
     "hierarchy": { "lvl1": "Link", "lvl2": "Imports", "lvl3": null }
   },
   {
     "content": "Usage",
-    "id": "ac97b078-70c0-4956-95f5-163f6be9ecc4",
+    "id": "2dba34d1-869e-4e77-aa7e-bc8d8b432cfe",
     "type": "lvl2",
     "url": "/docs/components/navigation/link#usage",
     "hierarchy": { "lvl1": "Link", "lvl2": "Usage", "lvl3": null }
   },
   {
     "content": "External Link",
-    "id": "6cca7295-d17f-49a0-9e07-f4bcf1484063",
+    "id": "e5b669af-706b-4057-a8ca-90b474641e7f",
     "type": "lvl3",
     "url": "/docs/components/navigation/link#external-link",
     "hierarchy": { "lvl1": "Link", "lvl2": "Usage", "lvl3": "External Link" }
   },
   {
     "content": "Link inline with text",
-    "id": "eed997fa-49ae-4260-9220-1c241c8b4bc6",
+    "id": "4f807157-f8e0-432b-9d39-25d4d53a3ddb",
     "type": "lvl3",
     "url": "/docs/components/navigation/link#link-inline-with-text",
     "hierarchy": {
@@ -4293,7 +4293,7 @@
   },
   {
     "content": "Usage with Routing Library",
-    "id": "8721a39f-78ed-4b04-9d9d-215f6f37069e",
+    "id": "9c9bf052-076c-4c95-91b9-7fdd21d86f9d",
     "type": "lvl2",
     "url": "/docs/components/navigation/link#usage-with-routing-library",
     "hierarchy": {
@@ -4304,42 +4304,42 @@
   },
   {
     "content": "Usage with Next.js",
-    "id": "bdd3b018-25e9-4bae-8883-951a2f70f9f0",
+    "id": "2c98dc81-b864-432d-a0e3-e212ba95ad07",
     "type": "lvl2",
     "url": "/docs/components/navigation/link#usage-with-nextjs",
     "hierarchy": { "lvl1": "Link", "lvl2": "Usage with Next.js", "lvl3": null }
   },
   {
     "content": "Props",
-    "id": "1ff6daa9-8446-4a32-a8f7-2cc8c2dc75ab",
+    "id": "dd420856-ceb1-42d2-b90c-53bc42940d14",
     "type": "lvl2",
     "url": "/docs/components/navigation/link#props",
     "hierarchy": { "lvl1": "Link", "lvl2": "Props", "lvl3": null }
   },
   {
     "content": "CloseButton",
-    "id": "bfab683a-4a34-4864-b9f6-66ad31c6d1d1",
+    "id": "78617016-e5de-4aa2-a1a5-fd0fbd815d53",
     "type": "lvl1",
     "url": "/docs/components/other/close-button",
     "hierarchy": { "lvl1": "CloseButton" }
   },
   {
     "content": "Import",
-    "id": "04c2e0c4-d3aa-407d-9b75-4be5e661e1a0",
+    "id": "f88035eb-cd8a-4db3-bbc5-de22b4455f84",
     "type": "lvl2",
     "url": "/docs/components/other/close-button#import",
     "hierarchy": { "lvl1": "CloseButton", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Usage",
-    "id": "e5d7c2c5-1309-4e7d-a12f-0c577a26803a",
+    "id": "4bbd76e4-8a17-4efe-9c09-f5704d45d06a",
     "type": "lvl2",
     "url": "/docs/components/other/close-button#usage",
     "hierarchy": { "lvl1": "CloseButton", "lvl2": "Usage", "lvl3": null }
   },
   {
     "content": "Button Size",
-    "id": "891d47c3-45d6-4db4-9fc6-1b3b90a2b9bc",
+    "id": "1b45b634-8674-4b62-9b16-ccbf2942cf84",
     "type": "lvl3",
     "url": "/docs/components/other/close-button#button-size",
     "hierarchy": {
@@ -4350,35 +4350,35 @@
   },
   {
     "content": "Props",
-    "id": "b1f1075d-4c67-411a-9d96-77ad2709f149",
+    "id": "be7ea195-c217-4746-9991-6e6c59457729",
     "type": "lvl2",
     "url": "/docs/components/other/close-button#props",
     "hierarchy": { "lvl1": "CloseButton", "lvl2": "Props", "lvl3": null }
   },
   {
     "content": "Portal",
-    "id": "f7b57d37-66b9-48ee-a1f3-3685ffef08a5",
+    "id": "7d17251b-bed0-4311-bf30-de41cfea563a",
     "type": "lvl1",
     "url": "/docs/components/other/portal",
     "hierarchy": { "lvl1": "Portal" }
   },
   {
     "content": "Import",
-    "id": "339219f5-ba23-4112-9259-458621f948d6",
+    "id": "279a7ad3-bfd9-4501-a9f1-fec55467bb60",
     "type": "lvl2",
     "url": "/docs/components/other/portal#import",
     "hierarchy": { "lvl1": "Portal", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Usage",
-    "id": "c583a4c7-fa18-498d-b39a-60c8ceaeac56",
+    "id": "c616df7b-b120-4163-bf5e-bf4e88edfec8",
     "type": "lvl2",
     "url": "/docs/components/other/portal#usage",
     "hierarchy": { "lvl1": "Portal", "lvl2": "Usage", "lvl3": null }
   },
   {
     "content": "Using a custom container",
-    "id": "09acbd42-e488-47e4-9381-96aece9cb092",
+    "id": "c46d5a07-52f5-4d01-9cc9-7f22f185c3e4",
     "type": "lvl3",
     "url": "/docs/components/other/portal#using-a-custom-container",
     "hierarchy": {
@@ -4389,7 +4389,7 @@
   },
   {
     "content": "Nesting Portals",
-    "id": "cefda44e-8a91-437f-8c60-bc0cf2935b08",
+    "id": "c6fdf416-e966-443f-8bdb-d214ed5510d3",
     "type": "lvl3",
     "url": "/docs/components/other/portal#nesting-portals",
     "hierarchy": {
@@ -4400,7 +4400,7 @@
   },
   {
     "content": "Opting out of portal nesting",
-    "id": "2f15c88d-aa25-4b2a-9a8d-b83661d85bcf",
+    "id": "f361c9b6-f7c4-4009-84eb-28936e81efb1",
     "type": "lvl3",
     "url": "/docs/components/other/portal#opting-out-of-portal-nesting",
     "hierarchy": {
@@ -4411,35 +4411,35 @@
   },
   {
     "content": "Props",
-    "id": "dcbdbe38-efed-42a9-8ef5-af4002eb210d",
+    "id": "90b5be82-26ff-4788-a083-c1345d4f8271",
     "type": "lvl2",
     "url": "/docs/components/other/portal#props",
     "hierarchy": { "lvl1": "Portal", "lvl2": "Props", "lvl3": null }
   },
   {
     "content": "Show / Hide",
-    "id": "7572db82-d355-4372-adc9-d244eb9fdba9",
+    "id": "12e63e7e-abfc-458f-9c32-fe36df3d402c",
     "type": "lvl1",
     "url": "/docs/components/other/show-hide",
     "hierarchy": { "lvl1": "Show / Hide" }
   },
   {
     "content": "Import",
-    "id": "f3d34e32-1952-46c8-acd4-3cd8eb26b57a",
+    "id": "2fc65b5a-60b2-417e-9ccc-fbe4c820aeee",
     "type": "lvl2",
     "url": "/docs/components/other/show-hide#import",
     "hierarchy": { "lvl1": "Show / Hide", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Usage",
-    "id": "869efdcb-82bb-4795-8d54-8e6c6327b3cb",
+    "id": "8418da68-aed4-45af-a701-d36f7064165b",
     "type": "lvl2",
     "url": "/docs/components/other/show-hide#usage",
     "hierarchy": { "lvl1": "Show / Hide", "lvl2": "Usage", "lvl3": null }
   },
   {
     "content": "Breakpoint Prop",
-    "id": "773f919b-ac92-4121-bfb8-396e49143ffa",
+    "id": "9d1e9fec-425c-4585-9e2a-2ed3d3294f80",
     "type": "lvl3",
     "url": "/docs/components/other/show-hide#breakpoint-prop",
     "hierarchy": {
@@ -4450,7 +4450,7 @@
   },
   {
     "content": "Above / Below",
-    "id": "f5f8e62c-18fb-4d92-8896-8dfe551d23e7",
+    "id": "a96af35e-5d34-4f0a-a793-2e007b46439b",
     "type": "lvl3",
     "url": "/docs/components/other/show-hide#above--below",
     "hierarchy": {
@@ -4461,35 +4461,35 @@
   },
   {
     "content": "Props",
-    "id": "66cd73b0-727e-450a-aae4-5c341dd41c70",
+    "id": "4ba254f1-1068-47d9-baef-fdc388bdd16d",
     "type": "lvl2",
     "url": "/docs/components/other/show-hide#props",
     "hierarchy": { "lvl1": "Show / Hide", "lvl2": "Props", "lvl3": null }
   },
   {
     "content": "Transitions",
-    "id": "d5a5143f-161c-4959-aa58-8a29c1e14508",
+    "id": "30793378-c5b5-46c9-b271-6aaa71e3a84c",
     "type": "lvl1",
     "url": "/docs/components/other/transitions",
     "hierarchy": { "lvl1": "Transitions" }
   },
   {
     "content": "Import",
-    "id": "62df9b99-f0dd-4d7b-bb92-39a09cefb58d",
+    "id": "8d06a7d5-b7d7-4f29-afd7-be40a2efca80",
     "type": "lvl2",
     "url": "/docs/components/other/transitions#import",
     "hierarchy": { "lvl1": "Transitions", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Usage",
-    "id": "e10b0176-0d83-47f2-b2fc-958c613a6236",
+    "id": "f1d87bb1-04d2-4304-880e-47d2d77f796b",
     "type": "lvl2",
     "url": "/docs/components/other/transitions#usage",
     "hierarchy": { "lvl1": "Transitions", "lvl2": "Usage", "lvl3": null }
   },
   {
     "content": "Fade transition",
-    "id": "cc85a2e1-16d3-46f6-be07-77ac9a3cde67",
+    "id": "1977986f-ea29-474e-a6af-326f0d590a40",
     "type": "lvl3",
     "url": "/docs/components/other/transitions#fade-transition",
     "hierarchy": {
@@ -4500,7 +4500,7 @@
   },
   {
     "content": "ScaleFade transition",
-    "id": "44e2d503-eef7-496f-897e-fd9c6a7e10ac",
+    "id": "7f483cd1-df23-4a67-89ac-c3bc45fefd66",
     "type": "lvl3",
     "url": "/docs/components/other/transitions#scalefade-transition",
     "hierarchy": {
@@ -4511,7 +4511,7 @@
   },
   {
     "content": "Slide transition",
-    "id": "d8b7b16c-2f27-497f-8410-08f5c8fae3c4",
+    "id": "f0723ce8-caab-4c6a-8533-2311067c8479",
     "type": "lvl3",
     "url": "/docs/components/other/transitions#slide-transition",
     "hierarchy": {
@@ -4522,7 +4522,7 @@
   },
   {
     "content": "Slide Fade transition",
-    "id": "bfa90407-2bf0-472f-833a-f40c1987bba6",
+    "id": "b4ead583-047e-46b6-87f9-81b3c232c89a",
     "type": "lvl3",
     "url": "/docs/components/other/transitions#slide-fade-transition",
     "hierarchy": {
@@ -4533,7 +4533,7 @@
   },
   {
     "content": "Collapse transition",
-    "id": "e8909737-fca1-4f25-be91-b71f1c2c13e8",
+    "id": "72958217-bdfa-49ec-859d-b5a8f8f2ea46",
     "type": "lvl3",
     "url": "/docs/components/other/transitions#collapse-transition",
     "hierarchy": {
@@ -4544,7 +4544,7 @@
   },
   {
     "content": "Changing the startingHeight",
-    "id": "243a38d2-8fb1-47ab-99bf-604cb069adf8",
+    "id": "be2f92e6-5395-4a29-b041-71a11eb9f20f",
     "type": "lvl4",
     "url": "/docs/components/other/transitions#changing-the-startingheight",
     "hierarchy": {
@@ -4555,14 +4555,14 @@
   },
   {
     "content": "Props",
-    "id": "1d856878-2d95-4d9a-99e5-06730a4716a4",
+    "id": "99a5d484-46df-4686-895f-913ff3894867",
     "type": "lvl2",
     "url": "/docs/components/other/transitions#props",
     "hierarchy": { "lvl1": "Transitions", "lvl2": "Props", "lvl3": null }
   },
   {
     "content": "Fade Props",
-    "id": "2fb03aa3-4095-43e3-b9b7-f162d51747b8",
+    "id": "de2a31d8-d569-4a60-8cf8-fa843d59654c",
     "type": "lvl3",
     "url": "/docs/components/other/transitions#fade-props",
     "hierarchy": {
@@ -4573,7 +4573,7 @@
   },
   {
     "content": "ScaleFade Props",
-    "id": "cee71b15-0af0-48ba-b1f5-11cc3e9be12a",
+    "id": "9b628d90-a92a-421a-baac-c60c7c15c1ae",
     "type": "lvl3",
     "url": "/docs/components/other/transitions#scalefade-props",
     "hierarchy": {
@@ -4584,7 +4584,7 @@
   },
   {
     "content": "Slide Props",
-    "id": "7fb99aed-b0fa-4fe0-afd9-70528242b94b",
+    "id": "779e401c-b592-4fd1-ba0e-f3944dfb8a3d",
     "type": "lvl3",
     "url": "/docs/components/other/transitions#slide-props",
     "hierarchy": {
@@ -4595,7 +4595,7 @@
   },
   {
     "content": "SlideFade Props",
-    "id": "022ed31d-c980-458f-93a9-93e03918a156",
+    "id": "b19bee7f-e706-4f4b-8996-a138e2272669",
     "type": "lvl3",
     "url": "/docs/components/other/transitions#slidefade-props",
     "hierarchy": {
@@ -4606,7 +4606,7 @@
   },
   {
     "content": "Collapse Props",
-    "id": "337a4a0e-a086-443d-a74e-b8374c2cc4e8",
+    "id": "ea7e1448-9171-4922-829d-70e62c92689e",
     "type": "lvl3",
     "url": "/docs/components/other/transitions#collapse-props",
     "hierarchy": {
@@ -4617,28 +4617,28 @@
   },
   {
     "content": "Alert Dialog",
-    "id": "7278b213-0eeb-46aa-bde9-e891aa74fb00",
+    "id": "f65f1d6a-246e-4eb1-ae14-641cd3d8d085",
     "type": "lvl1",
     "url": "/docs/components/overlay/alert-dialog",
     "hierarchy": { "lvl1": "Alert Dialog" }
   },
   {
     "content": "Import",
-    "id": "b43f761c-e7ab-49a8-b033-69ebeba38500",
+    "id": "6ca0ee99-47b7-4061-80d4-4cb42b2f9e2d",
     "type": "lvl2",
     "url": "/docs/components/overlay/alert-dialog#import",
     "hierarchy": { "lvl1": "Alert Dialog", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Usage",
-    "id": "83ec69a8-1b2c-46c8-9581-0432214fec86",
+    "id": "a6cb5762-bdc4-4325-834a-31d205eff34e",
     "type": "lvl2",
     "url": "/docs/components/overlay/alert-dialog#usage",
     "hierarchy": { "lvl1": "Alert Dialog", "lvl2": "Usage", "lvl3": null }
   },
   {
     "content": "Changing the transition",
-    "id": "e101e83b-a70a-437b-9e46-54a8b32b3837",
+    "id": "c9723088-5755-48d7-9247-74cced36ba21",
     "type": "lvl3",
     "url": "/docs/components/overlay/alert-dialog#changing-the-transition",
     "hierarchy": {
@@ -4649,7 +4649,7 @@
   },
   {
     "content": "Accessibility",
-    "id": "8c44a8be-8cdb-4687-9f28-c39c24ea0fd9",
+    "id": "147139d8-29fc-465e-8eb2-1cc9d01b2bbf",
     "type": "lvl2",
     "url": "/docs/components/overlay/alert-dialog#accessibility",
     "hierarchy": {
@@ -4660,42 +4660,42 @@
   },
   {
     "content": "Props",
-    "id": "fbff15b2-1c21-4cab-a737-a466750f445e",
+    "id": "f0c541e1-0b29-42cb-8435-bc755187f05e",
     "type": "lvl2",
     "url": "/docs/components/overlay/alert-dialog#props",
     "hierarchy": { "lvl1": "Alert Dialog", "lvl2": "Props", "lvl3": null }
   },
   {
     "content": "Drawer",
-    "id": "63398633-1ed4-4c03-8084-f860987942b1",
+    "id": "c449392c-ca1d-4e10-97e7-2ff6beb11f9a",
     "type": "lvl1",
     "url": "/docs/components/overlay/drawer",
     "hierarchy": { "lvl1": "Drawer" }
   },
   {
     "content": "Import",
-    "id": "f4be6335-8b22-44c1-a773-9e6013b15f09",
+    "id": "c2f0389e-6d6d-4230-a156-9ea90496e82f",
     "type": "lvl2",
     "url": "/docs/components/overlay/drawer#import",
     "hierarchy": { "lvl1": "Drawer", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Usage",
-    "id": "c222ad40-32d6-400e-a3ce-7f6f0c739d70",
+    "id": "ab8621e4-7db0-4bc7-8ae1-9369b51e3de2",
     "type": "lvl2",
     "url": "/docs/components/overlay/drawer#usage",
     "hierarchy": { "lvl1": "Drawer", "lvl2": "Usage", "lvl3": null }
   },
   {
     "content": "Basic Drawer",
-    "id": "96c3aa65-f935-40ad-a18a-1121db0e953d",
+    "id": "eaf96481-5945-4238-87ec-23edb9c5fd76",
     "type": "lvl3",
     "url": "/docs/components/overlay/drawer#basic-drawer",
     "hierarchy": { "lvl1": "Drawer", "lvl2": "Usage", "lvl3": "Basic Drawer" }
   },
   {
     "content": "Drawer placement",
-    "id": "d9762d9e-5feb-476d-9179-441cad314ef0",
+    "id": "29966cfb-80a2-4725-a2fc-3eb8746947e5",
     "type": "lvl3",
     "url": "/docs/components/overlay/drawer#drawer-placement",
     "hierarchy": {
@@ -4706,7 +4706,7 @@
   },
   {
     "content": "Focus on specific element",
-    "id": "313cfbfd-9c76-4766-8703-391327ccceaf",
+    "id": "56d9ddf0-b54a-42cb-bca3-3537b28cae3d",
     "type": "lvl3",
     "url": "/docs/components/overlay/drawer#focus-on-specific-element",
     "hierarchy": {
@@ -4717,7 +4717,7 @@
   },
   {
     "content": "Drawer Widths",
-    "id": "dceac50c-fb6e-48ee-ad37-8c672be3b21b",
+    "id": "035605d5-cb4d-4f49-94a3-0b026b3ea1f3",
     "type": "lvl3",
     "url": "/docs/components/overlay/drawer#drawer-widths",
     "hierarchy": {
@@ -4728,7 +4728,7 @@
   },
   {
     "content": "Using a form in a Drawer",
-    "id": "f691365a-0415-4f85-8ff3-40a090e01976",
+    "id": "ff7d6b0b-f0d7-4135-b6ba-739fd7cdc368",
     "type": "lvl3",
     "url": "/docs/components/overlay/drawer#using-a-form-in-a-drawer",
     "hierarchy": {
@@ -4739,28 +4739,28 @@
   },
   {
     "content": "Accessibility",
-    "id": "b06950ce-5192-497d-b93a-1550ef406e2f",
+    "id": "6277c5ec-cf62-4888-b362-c3b763840e14",
     "type": "lvl2",
     "url": "/docs/components/overlay/drawer#accessibility",
     "hierarchy": { "lvl1": "Drawer", "lvl2": "Accessibility", "lvl3": null }
   },
   {
     "content": "Props",
-    "id": "19a9a746-8e54-415f-a0a6-e78f443a2a15",
+    "id": "eed9b3cc-7b18-4d6a-ba62-f21627eb5d00",
     "type": "lvl2",
     "url": "/docs/components/overlay/drawer#props",
     "hierarchy": { "lvl1": "Drawer", "lvl2": "Props", "lvl3": null }
   },
   {
     "content": "Drawer Props",
-    "id": "4bbe90e1-92a2-4610-b6f7-f3675f0998ec",
+    "id": "8e8be5ab-fdc5-4bae-a21f-484fbdc99cc1",
     "type": "lvl3",
     "url": "/docs/components/overlay/drawer#drawer-props",
     "hierarchy": { "lvl1": "Drawer", "lvl2": "Props", "lvl3": "Drawer Props" }
   },
   {
     "content": "Other components",
-    "id": "803c4ef5-f67d-420a-9787-dfa3de23cf10",
+    "id": "b5c002fc-8f7a-419f-a2d6-aafc4a643cf7",
     "type": "lvl3",
     "url": "/docs/components/overlay/drawer#other-components",
     "hierarchy": {
@@ -4771,28 +4771,28 @@
   },
   {
     "content": "Menu",
-    "id": "6664caae-498c-49da-a089-11573cc381be",
+    "id": "ff2a52ab-8934-40e5-b7a5-207dfeb4bcab",
     "type": "lvl1",
     "url": "/docs/components/overlay/menu",
     "hierarchy": { "lvl1": "Menu" }
   },
   {
     "content": "Import",
-    "id": "1e49e382-40a4-4a30-8930-53dbfe5cddeb",
+    "id": "4e6a06e3-3e0d-4454-89f9-1d2afc270c64",
     "type": "lvl2",
     "url": "/docs/components/overlay/menu#import",
     "hierarchy": { "lvl1": "Menu", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Usage",
-    "id": "4a9b616d-a034-4511-8c27-48710b2a18f1",
+    "id": "813550bc-94b4-47d7-9c47-c92ecf0ef37c",
     "type": "lvl2",
     "url": "/docs/components/overlay/menu#usage",
     "hierarchy": { "lvl1": "Menu", "lvl2": "Usage", "lvl3": null }
   },
   {
     "content": "Accessing the internal state",
-    "id": "f48b42ef-e5ca-4eb0-8dd5-752ae74a8cd7",
+    "id": "13b2c712-7700-4bec-9dc7-27e44a42c181",
     "type": "lvl3",
     "url": "/docs/components/overlay/menu#accessing-the-internal-state",
     "hierarchy": {
@@ -4803,7 +4803,7 @@
   },
   {
     "content": "Customizing the button",
-    "id": "47e1230b-0860-476d-846f-dd3c86390a76",
+    "id": "91043772-240e-4c71-b942-c89fe06f8f14",
     "type": "lvl3",
     "url": "/docs/components/overlay/menu#customizing-the-button",
     "hierarchy": {
@@ -4814,7 +4814,7 @@
   },
   {
     "content": "Letter Navigation",
-    "id": "e5eb0653-0368-49f4-a5bb-2605f53b4f03",
+    "id": "06be08ef-44d4-439e-8e63-99e7514ea10c",
     "type": "lvl3",
     "url": "/docs/components/overlay/menu#letter-navigation",
     "hierarchy": {
@@ -4825,7 +4825,7 @@
   },
   {
     "content": "Just another example",
-    "id": "7aa8d9f2-7dcc-45cf-9d6f-2feb07055452",
+    "id": "5c7ddd2e-d2a2-455c-bff1-c301d782e6e3",
     "type": "lvl3",
     "url": "/docs/components/overlay/menu#just-another-example",
     "hierarchy": {
@@ -4836,7 +4836,7 @@
   },
   {
     "content": "Adding icons and commands",
-    "id": "2a697565-2d33-4e78-a182-4594aac0125e",
+    "id": "181085cc-c5ab-4c2f-b1bc-a635b9845f63",
     "type": "lvl3",
     "url": "/docs/components/overlay/menu#adding-icons-and-commands",
     "hierarchy": {
@@ -4847,7 +4847,7 @@
   },
   {
     "content": "Lazily mounting MenuItem",
-    "id": "b332e040-8ea1-4edc-8755-4181ef64306b",
+    "id": "f813b3ad-122e-413b-9d77-100b5219b8cb",
     "type": "lvl3",
     "url": "/docs/components/overlay/menu#lazily-mounting-menuitem",
     "hierarchy": {
@@ -4858,7 +4858,7 @@
   },
   {
     "content": "Rendering menu in a portal",
-    "id": "332464cf-e1e3-48b3-a655-ec2a669da1ad",
+    "id": "b3781128-c12a-4e68-ae0b-be1f55a07e51",
     "type": "lvl3",
     "url": "/docs/components/overlay/menu#rendering-menu-in-a-portal",
     "hierarchy": {
@@ -4869,7 +4869,7 @@
   },
   {
     "content": "MenuGroup",
-    "id": "e9dae98a-0e0a-4643-bff4-ec3811d87269",
+    "id": "1d47c8fb-55ab-4231-9db3-e07af35d460d",
     "type": "lvl3",
     "url": "/docs/components/overlay/menu#menugroup",
     "hierarchy": {
@@ -4880,21 +4880,21 @@
   },
   {
     "content": "Menu option groups",
-    "id": "d5683a73-7cdb-4b08-a157-df814c0daf89",
+    "id": "a1490992-9783-4752-b031-e739b5c5c01a",
     "type": "lvl2",
     "url": "/docs/components/overlay/menu#menu-option-groups",
     "hierarchy": { "lvl1": "Menu", "lvl2": "Menu option groups", "lvl3": null }
   },
   {
     "content": "Accessibility",
-    "id": "c37c5639-9475-4c26-b280-d34c058e4d11",
+    "id": "2f3737ab-a5b3-4c1d-a9a1-e4f5bf00ce96",
     "type": "lvl2",
     "url": "/docs/components/overlay/menu#accessibility",
     "hierarchy": { "lvl1": "Menu", "lvl2": "Accessibility", "lvl3": null }
   },
   {
     "content": "Keyboard Interaction",
-    "id": "3d957d81-1632-4d0a-b230-405251584449",
+    "id": "db8750f5-149e-4fc0-921a-4587c210d954",
     "type": "lvl3",
     "url": "/docs/components/overlay/menu#keyboard-interaction",
     "hierarchy": {
@@ -4905,7 +4905,7 @@
   },
   {
     "content": "ARIA roles",
-    "id": "ee07c148-ef9f-412d-a549-2553f6e30b50",
+    "id": "e62d4d5b-35bc-4251-84a2-dcb36f81cd39",
     "type": "lvl3",
     "url": "/docs/components/overlay/menu#aria-roles",
     "hierarchy": {
@@ -4916,21 +4916,21 @@
   },
   {
     "content": "Props",
-    "id": "ba24367f-f381-40fe-ad58-299c8d0fd7bc",
+    "id": "d496ceae-2e6b-4d7b-8c93-780d06080cf9",
     "type": "lvl2",
     "url": "/docs/components/overlay/menu#props",
     "hierarchy": { "lvl1": "Menu", "lvl2": "Props", "lvl3": null }
   },
   {
     "content": "Menu Props",
-    "id": "9009cec7-7193-4c0a-b43b-9af91f00f2d6",
+    "id": "47607d76-412b-4f62-a65e-f9bd36c1ce0f",
     "type": "lvl3",
     "url": "/docs/components/overlay/menu#menu-props",
     "hierarchy": { "lvl1": "Menu", "lvl2": "Props", "lvl3": "Menu Props" }
   },
   {
     "content": "MenuButton Props",
-    "id": "e9a9e791-2ea0-4016-94f7-ae605941747f",
+    "id": "278fee80-faa2-4a76-a6db-5e948ba0f365",
     "type": "lvl3",
     "url": "/docs/components/overlay/menu#menubutton-props",
     "hierarchy": {
@@ -4941,7 +4941,7 @@
   },
   {
     "content": "MenuList Props",
-    "id": "6da337e5-5e19-4114-aee4-76b8c8e937c0",
+    "id": "6b7b8752-d532-47ef-9d63-1ac337152ba6",
     "type": "lvl3",
     "url": "/docs/components/overlay/menu#menulist-props",
     "hierarchy": {
@@ -4952,7 +4952,7 @@
   },
   {
     "content": "MenuItem Props",
-    "id": "7b2065a4-2903-4964-b134-e418d6e786f1",
+    "id": "39fcdcd0-3f3f-4247-9b29-fd4d970af91c",
     "type": "lvl3",
     "url": "/docs/components/overlay/menu#menuitem-props",
     "hierarchy": {
@@ -4963,7 +4963,7 @@
   },
   {
     "content": "MenuGroup Props",
-    "id": "198ee197-ca24-4152-9790-4e11c8d7b53b",
+    "id": "ad70c6f8-76d9-4764-b764-d2c36ae66331",
     "type": "lvl3",
     "url": "/docs/components/overlay/menu#menugroup-props",
     "hierarchy": {
@@ -4974,7 +4974,7 @@
   },
   {
     "content": "MenuOptionGroup Props",
-    "id": "e0dc5142-9efb-48d4-be40-896c5a337569",
+    "id": "6817dfcb-c424-48d0-b754-f33d57a1d67e",
     "type": "lvl3",
     "url": "/docs/components/overlay/menu#menuoptiongroup-props",
     "hierarchy": {
@@ -4985,7 +4985,7 @@
   },
   {
     "content": "MenuItemOption Props",
-    "id": "a4806b41-677b-4356-88d1-64ad65e6cd42",
+    "id": "9bd94e97-b084-4c8f-b90e-3eeeaaadf57b",
     "type": "lvl3",
     "url": "/docs/components/overlay/menu#menuitemoption-props",
     "hierarchy": {
@@ -4996,28 +4996,28 @@
   },
   {
     "content": "Modal Dialog",
-    "id": "a83cfabf-c6bc-4a5c-8d7c-510b2821589b",
+    "id": "cf297032-2e07-439e-a176-e60fea625999",
     "type": "lvl1",
     "url": "/docs/components/overlay/modal",
     "hierarchy": { "lvl1": "Modal Dialog" }
   },
   {
     "content": "Import",
-    "id": "9843a72d-850d-4893-a6d5-86b2979f2c68",
+    "id": "eefc0c20-87fe-407e-9455-7bc9d360e54e",
     "type": "lvl2",
     "url": "/docs/components/overlay/modal#import",
     "hierarchy": { "lvl1": "Modal Dialog", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Usage",
-    "id": "6b237547-a70b-447d-bd00-3f474a51297f",
+    "id": "ea4e3ac5-a746-4b41-8883-0b12811150c9",
     "type": "lvl2",
     "url": "/docs/components/overlay/modal#usage",
     "hierarchy": { "lvl1": "Modal Dialog", "lvl2": "Usage", "lvl3": null }
   },
   {
     "content": "Control Focus when Modal closes",
-    "id": "10e861ec-66b1-4971-8ddf-b9b10332554a",
+    "id": "934b2fa7-a808-4124-9112-415202b79dac",
     "type": "lvl3",
     "url": "/docs/components/overlay/modal#control-focus-when-modal-closes",
     "hierarchy": {
@@ -5028,7 +5028,7 @@
   },
   {
     "content": "Block Scrolling when Modal opens",
-    "id": "7dcd5826-a6bd-4eab-83e0-fa74c66ffa4c",
+    "id": "711beb96-b37c-43f1-9127-83c79c46d174",
     "type": "lvl3",
     "url": "/docs/components/overlay/modal#block-scrolling-when-modal-opens",
     "hierarchy": {
@@ -5039,7 +5039,7 @@
   },
   {
     "content": "Focus on specific element",
-    "id": "829b9905-dc7c-43f4-9473-22ee2820d769",
+    "id": "16f776bb-56f9-446f-a7a6-798ea60b10a0",
     "type": "lvl3",
     "url": "/docs/components/overlay/modal#focus-on-specific-element",
     "hierarchy": {
@@ -5050,7 +5050,7 @@
   },
   {
     "content": "Close Modal on Overlay Click",
-    "id": "69187d54-1c0e-4702-887b-dd25f6aac231",
+    "id": "1911cb3d-30f1-4f55-bab3-110c629c3e4c",
     "type": "lvl3",
     "url": "/docs/components/overlay/modal#close-modal-on-overlay-click",
     "hierarchy": {
@@ -5061,7 +5061,7 @@
   },
   {
     "content": "Make modal vertically centered",
-    "id": "79923bde-efd7-4827-9b66-ae21e92ada58",
+    "id": "225b614f-ee28-4616-b170-e73e08e79916",
     "type": "lvl3",
     "url": "/docs/components/overlay/modal#make-modal-vertically-centered",
     "hierarchy": {
@@ -5072,7 +5072,7 @@
   },
   {
     "content": "Changing the transition",
-    "id": "82e1332b-1e31-4ae7-bd84-0c072d50cbed",
+    "id": "a3ea6b9b-fffc-48ca-8795-f7157a31dfd2",
     "type": "lvl3",
     "url": "/docs/components/overlay/modal#changing-the-transition",
     "hierarchy": {
@@ -5083,7 +5083,7 @@
   },
   {
     "content": "Modal overflow behavior",
-    "id": "99fb7ee3-4fc8-4941-8f84-787fa6e21ecb",
+    "id": "75862350-1117-4cbf-a824-e53912359a7e",
     "type": "lvl3",
     "url": "/docs/components/overlay/modal#modal-overflow-behavior",
     "hierarchy": {
@@ -5094,7 +5094,7 @@
   },
   {
     "content": "Modal Sizes",
-    "id": "cd59fec2-faaa-4c84-98c6-73f445f1c09c",
+    "id": "a9d53ac0-7e82-43d3-b0cf-cd7200e11ad5",
     "type": "lvl3",
     "url": "/docs/components/overlay/modal#modal-sizes",
     "hierarchy": {
@@ -5105,7 +5105,7 @@
   },
   {
     "content": "Making other elements Inert",
-    "id": "0c1b0501-b0b2-43a4-9477-82e10287520d",
+    "id": "b4dac80f-d3a5-4c74-a5d5-a058d3584289",
     "type": "lvl3",
     "url": "/docs/components/overlay/modal#making-other-elements-inert",
     "hierarchy": {
@@ -5116,7 +5116,7 @@
   },
   {
     "content": "Prevent focus trapping",
-    "id": "f6573f3a-c8d5-4fd8-9d0c-8ea5a5fef406",
+    "id": "64ac0c0e-dfc7-4548-b756-b3651fb0f437",
     "type": "lvl3",
     "url": "/docs/components/overlay/modal#prevent-focus-trapping",
     "hierarchy": {
@@ -5127,7 +5127,7 @@
   },
   {
     "content": "Styling the backdrop",
-    "id": "e325d398-5951-4377-a2a2-ef69d609266d",
+    "id": "f9b545a5-5c03-46ac-abec-8d18a76ac0a6",
     "type": "lvl3",
     "url": "/docs/components/overlay/modal#styling-the-backdrop",
     "hierarchy": {
@@ -5138,7 +5138,7 @@
   },
   {
     "content": "Accessibility",
-    "id": "071ff8a7-20d3-4a82-9583-9396fbe8de25",
+    "id": "b08739cf-41ea-486b-93f1-10f9938c82e7",
     "type": "lvl2",
     "url": "/docs/components/overlay/modal#accessibility",
     "hierarchy": {
@@ -5149,7 +5149,7 @@
   },
   {
     "content": "Keyboard and Focus Management",
-    "id": "e2bef7fe-4018-40b6-9501-dda54dd8e4d0",
+    "id": "2fd3be0f-3d1d-4803-9cf4-aefee64b1fe7",
     "type": "lvl3",
     "url": "/docs/components/overlay/modal#keyboard-and-focus-management",
     "hierarchy": {
@@ -5160,7 +5160,7 @@
   },
   {
     "content": "ARIA",
-    "id": "47ac4ada-18c2-4983-b725-15190846b0be",
+    "id": "24804df8-81cb-4d9c-822c-1445d721bd81",
     "type": "lvl3",
     "url": "/docs/components/overlay/modal#aria",
     "hierarchy": {
@@ -5171,14 +5171,14 @@
   },
   {
     "content": "Props",
-    "id": "c059a9d8-3350-4fc9-9106-3d8602a604ec",
+    "id": "4f73359e-9c86-4957-ad6d-d4ee9d0c7a9a",
     "type": "lvl2",
     "url": "/docs/components/overlay/modal#props",
     "hierarchy": { "lvl1": "Modal Dialog", "lvl2": "Props", "lvl3": null }
   },
   {
     "content": "Modal Props",
-    "id": "199ed756-cc6f-4b6d-b08a-f84d9e4ab472",
+    "id": "78c1e614-0a89-4fe1-b524-81ed7db32795",
     "type": "lvl3",
     "url": "/docs/components/overlay/modal#modal-props",
     "hierarchy": {
@@ -5189,7 +5189,7 @@
   },
   {
     "content": "Other components",
-    "id": "539740a2-9c49-4b90-b47c-672690356a1e",
+    "id": "04086a4b-1c52-41c7-94b8-5a8ac21bee37",
     "type": "lvl3",
     "url": "/docs/components/overlay/modal#other-components",
     "hierarchy": {
@@ -5200,28 +5200,28 @@
   },
   {
     "content": "Popover",
-    "id": "0b44e5c7-a2c8-407c-9268-3bcf33e2727b",
+    "id": "dacba188-acc9-4306-abdd-707a002802e5",
     "type": "lvl1",
     "url": "/docs/components/overlay/popover",
     "hierarchy": { "lvl1": "Popover" }
   },
   {
     "content": "Import",
-    "id": "ddffe601-6ef5-495c-9ae7-415a118eff61",
+    "id": "f52bd374-b32f-4875-b091-eecbba96694b",
     "type": "lvl2",
     "url": "/docs/components/overlay/popover#import",
     "hierarchy": { "lvl1": "Popover", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Basic Usage",
-    "id": "bf877e62-0a15-4410-b24a-c221d814a218",
+    "id": "11e3630c-579a-4e24-8a89-9f4c674026f4",
     "type": "lvl2",
     "url": "/docs/components/overlay/popover#basic-usage",
     "hierarchy": { "lvl1": "Popover", "lvl2": "Basic Usage", "lvl3": null }
   },
   {
     "content": "Rendering the Popover in a Portal",
-    "id": "e901d099-c508-458f-bd72-92978a545c0c",
+    "id": "ec620c82-4b55-41a2-abf9-7caf2cc0b871",
     "type": "lvl2",
     "url": "/docs/components/overlay/popover#rendering-the-popover-in-a-portal",
     "hierarchy": {
@@ -5232,7 +5232,7 @@
   },
   {
     "content": "Focus an element when Popover opens",
-    "id": "9042bc66-a48d-4459-a0c8-82f3e571b768",
+    "id": "d6ff7b57-6fcc-4709-a629-93e1f2728926",
     "type": "lvl2",
     "url": "/docs/components/overlay/popover#focus-an-element-when-popover-opens",
     "hierarchy": {
@@ -5243,7 +5243,7 @@
   },
   {
     "content": "Trapping Focus within Popover",
-    "id": "6d8bdd2f-4084-491d-a419-2d7cb9ce10df",
+    "id": "75c3c8a2-5a49-41b5-a613-61ba711e37a8",
     "type": "lvl2",
     "url": "/docs/components/overlay/popover#trapping-focus-within-popover",
     "hierarchy": {
@@ -5254,21 +5254,21 @@
   },
   {
     "content": "Controlled Usage",
-    "id": "988d5da3-61a6-404c-a40e-c6e039ae7870",
+    "id": "48fdf7ba-40d8-4cbb-97b7-44b1f748c6e4",
     "type": "lvl2",
     "url": "/docs/components/overlay/popover#controlled-usage",
     "hierarchy": { "lvl1": "Popover", "lvl2": "Controlled Usage", "lvl3": null }
   },
   {
     "content": "Popover Anchor",
-    "id": "41d7cc8d-12a2-4656-a3f9-3e4a53fc77e5",
+    "id": "b88f9443-7153-4bd7-ad37-7980701f9d91",
     "type": "lvl2",
     "url": "/docs/components/overlay/popover#popover-anchor",
     "hierarchy": { "lvl1": "Popover", "lvl2": "Popover Anchor", "lvl3": null }
   },
   {
     "content": "Accessing Internal state",
-    "id": "fb90d575-8808-4235-8bb8-1beb6df133b9",
+    "id": "e316da83-6500-471c-be46-07b43e14059f",
     "type": "lvl2",
     "url": "/docs/components/overlay/popover#accessing-internal-state",
     "hierarchy": {
@@ -5279,7 +5279,7 @@
   },
   {
     "content": "Customizing the Popover",
-    "id": "59429b61-e41f-487e-8a93-407e85faa2f6",
+    "id": "866b687f-55f2-4845-8257-be9ce188b1a1",
     "type": "lvl2",
     "url": "/docs/components/overlay/popover#customizing-the-popover",
     "hierarchy": {
@@ -5290,7 +5290,7 @@
   },
   {
     "content": "Popover Placements",
-    "id": "1f6f72fb-54a2-45f6-a5b5-f4e1c611267e",
+    "id": "a9923983-fdd1-4472-80a1-4b4a7619bf23",
     "type": "lvl2",
     "url": "/docs/components/overlay/popover#popover-placements",
     "hierarchy": {
@@ -5301,7 +5301,7 @@
   },
   {
     "content": "Lazily mounting Popover",
-    "id": "667d1a8d-ef0d-464e-b95d-5b846bab28cf",
+    "id": "9d850414-39e6-4259-b16e-554663447a60",
     "type": "lvl3",
     "url": "/docs/components/overlay/popover#lazily-mounting-popover",
     "hierarchy": {
@@ -5312,14 +5312,14 @@
   },
   {
     "content": "Accessiblity",
-    "id": "8c16cd00-a70a-4ea0-95ac-2df57f312d65",
+    "id": "fa47800e-8028-4fdf-ab0b-e01e52f31713",
     "type": "lvl2",
     "url": "/docs/components/overlay/popover#accessiblity",
     "hierarchy": { "lvl1": "Popover", "lvl2": "Accessiblity", "lvl3": null }
   },
   {
     "content": "Keyboard and Focus",
-    "id": "d3a57c13-ef9c-49d8-9046-3bf6eb9a0845",
+    "id": "fd72289f-f344-49b2-9201-b1e4397e28ba",
     "type": "lvl3",
     "url": "/docs/components/overlay/popover#keyboard-and-focus",
     "hierarchy": {
@@ -5330,7 +5330,7 @@
   },
   {
     "content": "ARIA Attributes",
-    "id": "10064f40-1b8d-43b6-bec4-1c810ecd2767",
+    "id": "5c43b235-bcd8-482b-a8b8-7ab576e241d0",
     "type": "lvl3",
     "url": "/docs/components/overlay/popover#aria-attributes",
     "hierarchy": {
@@ -5341,21 +5341,21 @@
   },
   {
     "content": "Props",
-    "id": "4bb8f91d-3f81-4726-9f15-a326fb2e3947",
+    "id": "d1d1303b-8f6e-4607-8809-3b2de4673369",
     "type": "lvl2",
     "url": "/docs/components/overlay/popover#props",
     "hierarchy": { "lvl1": "Popover", "lvl2": "Props", "lvl3": null }
   },
   {
     "content": "Popover Props",
-    "id": "18730fe8-5d93-4072-99e8-ca745d9206ec",
+    "id": "024b2f10-aae8-49bd-ab98-993bfa1f32a4",
     "type": "lvl3",
     "url": "/docs/components/overlay/popover#popover-props",
     "hierarchy": { "lvl1": "Popover", "lvl2": "Props", "lvl3": "Popover Props" }
   },
   {
     "content": "Other Props",
-    "id": "0c56b198-b892-453d-bcae-18f1a52d68a1",
+    "id": "338d190a-8229-4d33-b28a-e991b5694097",
     "type": "lvl3",
     "url": "/docs/components/overlay/popover#other-props",
     "hierarchy": {
@@ -5366,28 +5366,28 @@
   },
   {
     "content": "Tooltip",
-    "id": "9c351bdf-8e2c-45df-a7f2-8805a021de04",
+    "id": "c1b38b09-7f3d-4d02-a682-9b099323b669",
     "type": "lvl1",
     "url": "/docs/components/overlay/tooltip",
     "hierarchy": { "lvl1": "Tooltip" }
   },
   {
     "content": "Import",
-    "id": "ebc148f4-15a2-4e23-82ee-91525c5f7e65",
+    "id": "57fb2090-1fe0-4b75-b473-53f30161e0b6",
     "type": "lvl2",
     "url": "/docs/components/overlay/tooltip#import",
     "hierarchy": { "lvl1": "Tooltip", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Usage",
-    "id": "1c052309-4d50-4ef6-b33a-01bf154b7e2a",
+    "id": "c931ab20-a74f-45db-8ce0-3d074904e254",
     "type": "lvl2",
     "url": "/docs/components/overlay/tooltip#usage",
     "hierarchy": { "lvl1": "Tooltip", "lvl2": "Usage", "lvl3": null }
   },
   {
     "content": "Using custom components",
-    "id": "01777125-9524-4a35-bfae-fa42cc0a3256",
+    "id": "e29a30a7-2f40-4e76-b166-8a2ed0ac2239",
     "type": "lvl3",
     "url": "/docs/components/overlay/tooltip#using-custom-components",
     "hierarchy": {
@@ -5398,7 +5398,7 @@
   },
   {
     "content": "With an icon",
-    "id": "0fd86a1a-2ada-44cf-b1ab-2edd82a07705",
+    "id": "0b8b9c5f-eb94-448a-9b8d-f11754741708",
     "type": "lvl3",
     "url": "/docs/components/overlay/tooltip#with-an-icon",
     "hierarchy": {
@@ -5409,7 +5409,7 @@
   },
   {
     "content": "With arrow",
-    "id": "82f9b321-19be-44c2-a521-d02941901849",
+    "id": "530b5b55-c2f6-426c-a812-e01722d6e9be",
     "type": "lvl3",
     "url": "/docs/components/overlay/tooltip#with-arrow",
     "hierarchy": {
@@ -5420,7 +5420,7 @@
   },
   {
     "content": "Tooltip with focusable content",
-    "id": "9fac7b40-de54-4118-8955-7cc93e970c71",
+    "id": "20033721-141c-458c-90ed-ce99f5116cfb",
     "type": "lvl3",
     "url": "/docs/components/overlay/tooltip#tooltip-with-focusable-content",
     "hierarchy": {
@@ -5431,7 +5431,7 @@
   },
   {
     "content": "Disabled Tooltip",
-    "id": "2465ad41-8be1-4920-b616-c8d2bc9982ab",
+    "id": "e8d9e572-5b7c-437b-8554-02a94c50f18c",
     "type": "lvl3",
     "url": "/docs/components/overlay/tooltip#disabled-tooltip",
     "hierarchy": {
@@ -5442,7 +5442,7 @@
   },
   {
     "content": "Tooltip around disabled Button",
-    "id": "79001de2-f3a1-4bf7-8360-e61f059c409f",
+    "id": "4c80fff0-7481-447c-bf65-574eca773e2c",
     "type": "lvl3",
     "url": "/docs/components/overlay/tooltip#tooltip-around-disabled-button",
     "hierarchy": {
@@ -5453,42 +5453,42 @@
   },
   {
     "content": "Placement",
-    "id": "1a8b1ce1-fe25-48da-a2fe-ac245ebee136",
+    "id": "ded8a355-6203-4c1a-aff9-50534a1879cb",
     "type": "lvl2",
     "url": "/docs/components/overlay/tooltip#placement",
     "hierarchy": { "lvl1": "Tooltip", "lvl2": "Placement", "lvl3": null }
   },
   {
     "content": "More examples",
-    "id": "24e6cead-b7aa-4fb4-9fc5-15b0159a1d5b",
+    "id": "e73e6124-d67a-436f-bead-bcb5e3ce00a5",
     "type": "lvl2",
     "url": "/docs/components/overlay/tooltip#more-examples",
     "hierarchy": { "lvl1": "Tooltip", "lvl2": "More examples", "lvl3": null }
   },
   {
     "content": "Props",
-    "id": "7b6d84b2-0b13-4b32-811c-6b9da178b960",
+    "id": "016bd524-9fa0-404c-8e32-32a35b25ee94",
     "type": "lvl2",
     "url": "/docs/components/overlay/tooltip#props",
     "hierarchy": { "lvl1": "Tooltip", "lvl2": "Props", "lvl3": null }
   },
   {
     "content": "Components",
-    "id": "ff6e44f9-0532-44ba-bd63-d414dee099c3",
+    "id": "361fe317-2cd1-41fb-89d6-121c7a5ca482",
     "type": "lvl1",
     "url": "/docs/components/overview",
     "hierarchy": { "lvl1": "Components" }
   },
   {
     "content": "The as prop and Custom component",
-    "id": "960294c6-44dc-4522-8065-aeec3eef8577",
+    "id": "dd50e5ea-849c-4dc0-b81c-9f7cc40dc375",
     "type": "lvl1",
     "url": "/docs/components/recipes/as-prop",
     "hierarchy": { "lvl1": "The as prop and Custom component" }
   },
   {
     "content": "Option 1: Using `forwardRef` from `@chakra-ui/react`",
-    "id": "e250caae-bbe1-4ab5-a002-6d1bfa5f5b25",
+    "id": "ccdbc394-6862-407b-9d7a-b5ad4595eb34",
     "type": "lvl2",
     "url": "/docs/components/recipes/as-prop#option-1-using-forwardref-from-chakra-uireact",
     "hierarchy": {
@@ -5499,7 +5499,7 @@
   },
   {
     "content": "Option 2: Cast the component as a `ChakraComponent`",
-    "id": "637095d2-c6d9-4f6c-ae72-7a591570d487",
+    "id": "529a91d0-f1f4-4db7-a0ee-3c031ea416fe",
     "type": "lvl2",
     "url": "/docs/components/recipes/as-prop#option-2-cast-the-component-as-a-chakracomponent",
     "hierarchy": {
@@ -5510,7 +5510,7 @@
   },
   {
     "content": "Option 3: Use the `chakra` factory function",
-    "id": "fa3a0a31-023d-471a-b10a-b71ea5389cf7",
+    "id": "5cb68d9d-4212-4e58-af46-b5a34d025cc1",
     "type": "lvl2",
     "url": "/docs/components/recipes/as-prop#option-3-use-the-chakra-factory-function",
     "hierarchy": {
@@ -5521,28 +5521,28 @@
   },
   {
     "content": "Floating Labels",
-    "id": "7cbdd9c1-0e5d-4e7a-b727-9abe0cac632e",
+    "id": "b330fc8b-5f5c-4f7d-ac4f-b13265a12855",
     "type": "lvl1",
     "url": "/docs/components/recipes/floating-labels",
     "hierarchy": { "lvl1": "Floating Labels" }
   },
   {
     "content": "Horizontal Collapse",
-    "id": "ca01c833-5604-4b7d-9d01-b46c39ef5d6e",
+    "id": "fd9c0b4f-c341-4f71-b83f-75c76955b384",
     "type": "lvl1",
     "url": "/docs/components/recipes/horizontal-collapse",
     "hierarchy": { "lvl1": "Horizontal Collapse" }
   },
   {
     "content": "Portals and z-index",
-    "id": "04f403e1-9fb8-4844-bef6-9b6b50bef9f2",
+    "id": "7c7154f5-f052-42c2-bba2-d943e066219b",
     "type": "lvl1",
     "url": "/docs/components/recipes/z-index",
     "hierarchy": { "lvl1": "Portals and z-index" }
   },
   {
     "content": "What's wrong with z-index?",
-    "id": "da015f5e-a91c-4521-8f91-2dce93a21ae3",
+    "id": "5f53f404-daa2-46e4-9b95-2dd1d1bc88c4",
     "type": "lvl2",
     "url": "/docs/components/recipes/z-index#whats-wrong-with-z-index",
     "hierarchy": {
@@ -5553,7 +5553,7 @@
   },
   {
     "content": "Stacking contexts",
-    "id": "c213ee11-e7d4-4935-a9b0-1ada1e23a77d",
+    "id": "66fb5018-c4e7-4573-85dd-52d73b448b58",
     "type": "lvl3",
     "url": "/docs/components/recipes/z-index#stacking-contexts",
     "hierarchy": {
@@ -5564,7 +5564,7 @@
   },
   {
     "content": "Chakra Portal to the rescue",
-    "id": "4fed384e-f474-4745-ae54-515568853372",
+    "id": "39f9d570-32cf-4225-9d40-523fb6ac000c",
     "type": "lvl2",
     "url": "/docs/components/recipes/z-index#chakra-portal-to-the-rescue",
     "hierarchy": {
@@ -5575,7 +5575,7 @@
   },
   {
     "content": "Can I still use z-index alongside Portals?",
-    "id": "efeb2a4d-eb52-46cc-aeeb-be8bdc164622",
+    "id": "a8a74a0d-a1fd-49e6-a8df-3ac10f9978e6",
     "type": "lvl3",
     "url": "/docs/components/recipes/z-index#can-i-still-use-z-index-alongside-portals",
     "hierarchy": {
@@ -5586,7 +5586,7 @@
   },
   {
     "content": "Further reading",
-    "id": "c46a64bc-33ce-44fb-8fb9-b0104b54f0a8",
+    "id": "fa4190ac-2c07-4ece-919e-d8d58cfba57e",
     "type": "lvl2",
     "url": "/docs/components/recipes/z-index#further-reading",
     "hierarchy": {
@@ -5597,28 +5597,28 @@
   },
   {
     "content": "Heading",
-    "id": "4293ddeb-a59e-4f03-8843-2455333488e2",
+    "id": "7ee7daec-e04c-4790-a21d-5f6fc4579a0b",
     "type": "lvl1",
     "url": "/docs/components/typography/heading",
     "hierarchy": { "lvl1": "Heading" }
   },
   {
     "content": "Import",
-    "id": "b47ee61d-1dde-4cfb-8a71-e3a0acbf0704",
+    "id": "25efd815-e516-470e-9329-48926eaf10ce",
     "type": "lvl2",
     "url": "/docs/components/typography/heading#import",
     "hierarchy": { "lvl1": "Heading", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Usage",
-    "id": "73eb0851-454e-44ff-8171-7460773e6610",
+    "id": "c6a7003e-8d86-452c-9374-e5f5755c8a94",
     "type": "lvl2",
     "url": "/docs/components/typography/heading#usage",
     "hierarchy": { "lvl1": "Heading", "lvl2": "Usage", "lvl3": null }
   },
   {
     "content": "Changing font size",
-    "id": "ae526659-580f-4259-b051-b730c3b00c34",
+    "id": "29a230dd-3176-4e4e-9cd2-1fb162198ee9",
     "type": "lvl3",
     "url": "/docs/components/typography/heading#changing-font-size",
     "hierarchy": {
@@ -5629,7 +5629,7 @@
   },
   {
     "content": "Truncate heading",
-    "id": "9341be56-f9cc-4fcc-a3da-2077d151cf0c",
+    "id": "69d675d6-752c-4f5e-a694-76671605da1e",
     "type": "lvl3",
     "url": "/docs/components/typography/heading#truncate-heading",
     "hierarchy": {
@@ -5640,7 +5640,7 @@
   },
   {
     "content": "Override style",
-    "id": "fbcecbff-356e-494c-ade5-06e712c95234",
+    "id": "537ec18c-47da-4ea5-a906-6e9ef073ff3c",
     "type": "lvl3",
     "url": "/docs/components/typography/heading#override-style",
     "hierarchy": {
@@ -5651,35 +5651,35 @@
   },
   {
     "content": "Composition",
-    "id": "072eb0b6-7d5d-4e8a-b5f2-b599bb405d1c",
+    "id": "6b6ab824-1cd3-442a-8d8f-035bdb607963",
     "type": "lvl2",
     "url": "/docs/components/typography/heading#composition",
     "hierarchy": { "lvl1": "Heading", "lvl2": "Composition", "lvl3": null }
   },
   {
     "content": "Props",
-    "id": "2e05e57e-f4b8-440e-9d23-0b442646b616",
+    "id": "ec3bbcdf-fe66-4e36-9ba3-cf0c547021e1",
     "type": "lvl2",
     "url": "/docs/components/typography/heading#props",
     "hierarchy": { "lvl1": "Heading", "lvl2": "Props", "lvl3": null }
   },
   {
     "content": "Text",
-    "id": "438ee15d-1949-4cc3-bd54-8ffb2fca0cd7",
+    "id": "0ecf9b61-6285-4801-bbcc-dd0c86ed037c",
     "type": "lvl1",
     "url": "/docs/components/typography/text",
     "hierarchy": { "lvl1": "Text" }
   },
   {
     "content": "Import",
-    "id": "38c162ae-4681-4f3d-886b-bd3d010054a8",
+    "id": "1b782cea-e70f-46ea-859f-dcbe94047426",
     "type": "lvl2",
     "url": "/docs/components/typography/text#import",
     "hierarchy": { "lvl1": "Text", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Changing the font size",
-    "id": "174df847-b30a-4864-9fa2-2a926c5dbcc6",
+    "id": "795756d5-d46f-4bc8-816e-9e52bfb16a21",
     "type": "lvl2",
     "url": "/docs/components/typography/text#changing-the-font-size",
     "hierarchy": {
@@ -5690,7 +5690,7 @@
   },
   {
     "content": "Truncate text",
-    "id": "463999c5-a540-475f-b630-cf1a8fa10481",
+    "id": "7f281b0c-2408-4e65-8786-2ed530ae7819",
     "type": "lvl3",
     "url": "/docs/components/typography/text#truncate-text",
     "hierarchy": {
@@ -5701,7 +5701,7 @@
   },
   {
     "content": "Override style",
-    "id": "f8a2302a-ac46-4c07-bdb3-544a2a1ccacf",
+    "id": "046fb59b-93e4-43f5-8802-a1f5dd2e3d03",
     "type": "lvl3",
     "url": "/docs/components/typography/text#override-style",
     "hierarchy": {
@@ -5712,7 +5712,7 @@
   },
   {
     "content": "Override the element",
-    "id": "a8ab83bd-b63c-4c90-a75a-be5137d0c1ac",
+    "id": "f77a49ed-1cf5-46ca-b9e4-58143d49c8e4",
     "type": "lvl3",
     "url": "/docs/components/typography/text#override-the-element",
     "hierarchy": {
@@ -5723,28 +5723,28 @@
   },
   {
     "content": "Props",
-    "id": "b0e4967b-a966-4633-8733-906b800b0b24",
+    "id": "e8fa361a-e005-4456-aea0-b415fe54f54a",
     "type": "lvl2",
     "url": "/docs/components/typography/text#props",
     "hierarchy": { "lvl1": "Text", "lvl2": "Props", "lvl3": null }
   },
   {
     "content": "useCheckboxGroup",
-    "id": "9bfc18e0-0bf4-477f-aaee-85dd0f20d8a4",
+    "id": "fa59397f-8f31-472e-bab4-492daa9e0ea4",
     "type": "lvl1",
     "url": "/docs/styled-system/component-hooks/use-checkbox-group",
     "hierarchy": { "lvl1": "useCheckboxGroup" }
   },
   {
     "content": "Import",
-    "id": "ffe6a970-e5a0-4fce-b49e-7abd83840fa9",
+    "id": "acd789d0-ba5a-4393-a994-055d0411170e",
     "type": "lvl2",
     "url": "/docs/styled-system/component-hooks/use-checkbox-group#import",
     "hierarchy": { "lvl1": "useCheckboxGroup", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Return value",
-    "id": "bf76e9b9-6d1d-4010-a24c-94e8dc544a32",
+    "id": "bebe9674-983c-4f03-95da-e143cbdcfabe",
     "type": "lvl2",
     "url": "/docs/styled-system/component-hooks/use-checkbox-group#return-value",
     "hierarchy": {
@@ -5755,14 +5755,14 @@
   },
   {
     "content": "Usage",
-    "id": "3745d6e9-559d-427a-9214-36ba453cabc7",
+    "id": "cd787455-5050-41ad-9bea-b141e43a3c32",
     "type": "lvl2",
     "url": "/docs/styled-system/component-hooks/use-checkbox-group#usage",
     "hierarchy": { "lvl1": "useCheckboxGroup", "lvl2": "Usage", "lvl3": null }
   },
   {
     "content": "Parameters",
-    "id": "32ec6820-2a6d-4cb1-8697-0b02a33accee",
+    "id": "12f04880-b433-4e25-9960-b3caed78130a",
     "type": "lvl2",
     "url": "/docs/styled-system/component-hooks/use-checkbox-group#parameters",
     "hierarchy": {
@@ -5773,49 +5773,49 @@
   },
   {
     "content": "useCheckbox",
-    "id": "d0e5b09b-0e82-4d2d-8ac9-ec3967cfc7e1",
+    "id": "f7a6c822-7024-4517-96fc-a631654135bd",
     "type": "lvl1",
     "url": "/docs/styled-system/component-hooks/use-checkbox",
     "hierarchy": { "lvl1": "useCheckbox" }
   },
   {
     "content": "Return value",
-    "id": "22641fa9-1fdd-4097-b76c-07aefec6ff39",
+    "id": "40392a5c-e859-43ff-94d4-c5f79eac7fd2",
     "type": "lvl2",
     "url": "/docs/styled-system/component-hooks/use-checkbox#return-value",
     "hierarchy": { "lvl1": "useCheckbox", "lvl2": "Return value", "lvl3": null }
   },
   {
     "content": "Import",
-    "id": "6544a46e-0cdb-45bf-8c0a-97350128b8d5",
+    "id": "aeed5580-92fc-462c-a90e-f679fd698c2f",
     "type": "lvl2",
     "url": "/docs/styled-system/component-hooks/use-checkbox#import",
     "hierarchy": { "lvl1": "useCheckbox", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Usage",
-    "id": "7e05d552-96ff-4711-91cb-9ac3dc18d927",
+    "id": "6634ef5e-85e0-452a-a04c-548bfb63651b",
     "type": "lvl2",
     "url": "/docs/styled-system/component-hooks/use-checkbox#usage",
     "hierarchy": { "lvl1": "useCheckbox", "lvl2": "Usage", "lvl3": null }
   },
   {
     "content": "Parameters",
-    "id": "cc1af709-4ecb-4ca1-a37d-a4f747913e11",
+    "id": "9506b3e0-4b94-4fdf-8526-fa0d34ebf8a5",
     "type": "lvl2",
     "url": "/docs/styled-system/component-hooks/use-checkbox#parameters",
     "hierarchy": { "lvl1": "useCheckbox", "lvl2": "Parameters", "lvl3": null }
   },
   {
     "content": "Chakra Factory",
-    "id": "0a7ac59e-be35-4dc8-80ff-f4d11ab06b55",
+    "id": "c6a5d439-7f0f-4592-98c9-6d7ef7d50848",
     "type": "lvl1",
     "url": "/docs/styled-system/features/chakra-factory",
     "hierarchy": { "lvl1": "Chakra Factory" }
   },
   {
     "content": "Chakra JSX Elements",
-    "id": "7d6d3fef-345e-4b2b-9430-aa195a4fda1e",
+    "id": "1a621c23-7f61-43ba-934b-28c2bf05263b",
     "type": "lvl2",
     "url": "/docs/styled-system/features/chakra-factory#chakra-jsx-elements",
     "hierarchy": {
@@ -5826,7 +5826,7 @@
   },
   {
     "content": "Chakra factory function",
-    "id": "1fe66ad0-52f4-440b-941a-60e759bfc84f",
+    "id": "61b8f166-8f14-4a6f-a32c-aee83e1a4ff4",
     "type": "lvl2",
     "url": "/docs/styled-system/features/chakra-factory#chakra-factory-function",
     "hierarchy": {
@@ -5837,7 +5837,7 @@
   },
   {
     "content": "Attaching styles",
-    "id": "77a0475a-514c-4512-babb-229c843daa74",
+    "id": "abbcb4f7-23e0-4be6-a796-5b33f0395983",
     "type": "lvl3",
     "url": "/docs/styled-system/features/chakra-factory#attaching-styles",
     "hierarchy": {
@@ -5848,7 +5848,7 @@
   },
   {
     "content": "Allowing custom props to be forwarded",
-    "id": "c029ce9d-1a2e-47fd-82de-7c6bff44db3a",
+    "id": "84ec77db-0bec-4c81-97be-5876ab64333c",
     "type": "lvl3",
     "url": "/docs/styled-system/features/chakra-factory#allowing-custom-props-to-be-forwarded",
     "hierarchy": {
@@ -5859,21 +5859,21 @@
   },
   {
     "content": "Color Mode",
-    "id": "685de7a8-c748-4379-83b2-66d39b201777",
+    "id": "ad41a042-09ad-4433-8d01-5a64a6c2be49",
     "type": "lvl1",
     "url": "/docs/styled-system/features/color-mode",
     "hierarchy": { "lvl1": "Color Mode" }
   },
   {
     "content": "Setup",
-    "id": "33503085-3dfc-404a-b78b-aa50d13711b4",
+    "id": "84631fcb-a4d2-46db-beb5-49f4cfccb5dd",
     "type": "lvl2",
     "url": "/docs/styled-system/features/color-mode#setup",
     "hierarchy": { "lvl1": "Color Mode", "lvl2": "Setup", "lvl3": null }
   },
   {
     "content": "Updating the theme config",
-    "id": "0c943c02-4467-4f65-a8a2-8da3d5c4c7ed",
+    "id": "044f21cc-cea6-4775-bf50-8bb06b315c5d",
     "type": "lvl3",
     "url": "/docs/styled-system/features/color-mode#updating-the-theme-config",
     "hierarchy": {
@@ -5884,7 +5884,7 @@
   },
   {
     "content": "Behavior of ColorMode",
-    "id": "76f16137-cc6f-4974-8f77-3611895545a1",
+    "id": "b61d48dc-c759-4528-819e-33a6cdc8525d",
     "type": "lvl4",
     "url": "/docs/styled-system/features/color-mode#behavior-of-colormode",
     "hierarchy": {
@@ -5895,7 +5895,7 @@
   },
   {
     "content": "Difference between `initialColorMode='system'` and `useSystemColorMode`",
-    "id": "22d59a04-9d92-4460-b740-49ab7435b4c5",
+    "id": "ddee6325-87a0-4d5a-81de-d89ec71396ca",
     "type": "lvl4",
     "url": "/docs/styled-system/features/color-mode#difference-between-initialcolormodesystem-and-usesystemcolormode",
     "hierarchy": {
@@ -5906,7 +5906,7 @@
   },
   {
     "content": "Adding the `ColorModeScript`",
-    "id": "3faa8ee2-c202-484e-9ae5-fc0913aa2336",
+    "id": "d72b442e-4c6d-42e2-91f1-69fe4dbb357d",
     "type": "lvl3",
     "url": "/docs/styled-system/features/color-mode#adding-the-colormodescript",
     "hierarchy": {
@@ -5917,7 +5917,7 @@
   },
   {
     "content": "For Next.js",
-    "id": "d5187378-a2ee-4e9d-a3ad-4748d5e86e02",
+    "id": "a907fb9f-f661-4f57-9acc-d6dad24a669b",
     "type": "lvl4",
     "url": "/docs/styled-system/features/color-mode#for-nextjs",
     "hierarchy": {
@@ -5928,14 +5928,14 @@
   },
   {
     "content": "For Create React App",
-    "id": "8bfe247d-8629-44d2-b31d-83e06c53b8c6",
+    "id": "27d6b459-1195-4331-86ec-839fc6f5b249",
     "type": "lvl4",
     "url": "/docs/styled-system/features/color-mode#for-create-react-app",
     "hierarchy": { "lvl1": "Color Mode", "lvl2": "For Next.js", "lvl3": null }
   },
   {
     "content": "For Gatsby",
-    "id": "f60fefe1-ee4c-4a15-bb12-999b0d425639",
+    "id": "47600392-3999-42b1-a444-0a2accc9be9f",
     "type": "lvl4",
     "url": "/docs/styled-system/features/color-mode#for-gatsby",
     "hierarchy": {
@@ -5946,7 +5946,7 @@
   },
   {
     "content": "Changing Color Mode",
-    "id": "86e2edc1-41c1-4b71-bfe4-b8161c742943",
+    "id": "b92d99bd-9239-4078-a08c-9aeb2758200f",
     "type": "lvl2",
     "url": "/docs/styled-system/features/color-mode#changing-color-mode",
     "hierarchy": {
@@ -5957,7 +5957,7 @@
   },
   {
     "content": "useColorMode",
-    "id": "74fe753f-90f6-406e-bbc0-7b2e273caea9",
+    "id": "8197fadd-2ed1-4e58-989d-27f4ee4e112f",
     "type": "lvl3",
     "url": "/docs/styled-system/features/color-mode#usecolormode",
     "hierarchy": {
@@ -5968,7 +5968,7 @@
   },
   {
     "content": "useColorModeValue",
-    "id": "c6fd8cb6-e5a3-4a56-95e4-827df9180dfd",
+    "id": "6ad0cd40-39a3-4501-b5d7-2b9751af95b3",
     "type": "lvl3",
     "url": "/docs/styled-system/features/color-mode#usecolormodevalue",
     "hierarchy": {
@@ -5979,7 +5979,7 @@
   },
   {
     "content": "Forcing a specific mode",
-    "id": "1162a667-37b4-4dca-8c6f-c21bd6da044a",
+    "id": "b56bd634-ad33-4f8e-bfaa-7f49f56f87bd",
     "type": "lvl2",
     "url": "/docs/styled-system/features/color-mode#forcing-a-specific-mode",
     "hierarchy": {
@@ -5990,7 +5990,7 @@
   },
   {
     "content": "Add colorModeManager (Optional, for SSR)",
-    "id": "ad6cdfc0-7588-4279-94fc-d599d8c3eff1",
+    "id": "f0857126-0688-4eee-a645-5a1c284b038b",
     "type": "lvl2",
     "url": "/docs/styled-system/features/color-mode#add-colormodemanager-optional-for-ssr",
     "hierarchy": {
@@ -6001,7 +6001,7 @@
   },
   {
     "content": "Color Mode Flash Issue",
-    "id": "a858af35-03bb-4c2a-9945-f93f5f430417",
+    "id": "577cb84d-d530-4db2-9edf-bb11cb759627",
     "type": "lvl2",
     "url": "/docs/styled-system/features/color-mode#color-mode-flash-issue",
     "hierarchy": {
@@ -6012,21 +6012,21 @@
   },
   {
     "content": "CSS Variables",
-    "id": "43842a88-dcb5-4a92-b0a8-c4f686a61650",
+    "id": "3bfb81cc-18c6-4702-b760-db7607f88a58",
     "type": "lvl1",
     "url": "/docs/styled-system/features/css-variables",
     "hierarchy": { "lvl1": "CSS Variables" }
   },
   {
     "content": "Overview",
-    "id": "b3f0ff86-4256-48ba-8dc7-8d9e20a7e5a9",
+    "id": "2ae5e1fa-bbeb-4346-81e0-5fbe139e4e52",
     "type": "lvl2",
     "url": "/docs/styled-system/features/css-variables#overview",
     "hierarchy": { "lvl1": "CSS Variables", "lvl2": "Overview", "lvl3": null }
   },
   {
     "content": "Converting theme tokens to CSS variables",
-    "id": "a3242fc9-8bcf-4fc3-9931-b5b2bae48a78",
+    "id": "e14eff1c-a490-4e2c-83a4-149bccac26e1",
     "type": "lvl2",
     "url": "/docs/styled-system/features/css-variables#converting-theme-tokens-to-css-variables",
     "hierarchy": {
@@ -6037,7 +6037,7 @@
   },
   {
     "content": "Consuming CSS Variables",
-    "id": "1da2aec2-d72a-4391-878a-e59982660606",
+    "id": "0403197b-d317-44de-8e05-cb4eee1b7476",
     "type": "lvl2",
     "url": "/docs/styled-system/features/css-variables#consuming-css-variables",
     "hierarchy": {
@@ -6048,7 +6048,7 @@
   },
   {
     "content": "Styling non-chakra components",
-    "id": "c45e25d7-82aa-4cc2-8aa4-96675ca470cf",
+    "id": "58dc091b-9a9a-4c17-8612-39b41eb4658f",
     "type": "lvl3",
     "url": "/docs/styled-system/features/css-variables#styling-non-chakra-components",
     "hierarchy": {
@@ -6059,7 +6059,7 @@
   },
   {
     "content": "Attaching the CSS variables",
-    "id": "a5ba0c6f-94e5-4c96-a2da-ea4c5d9241b9",
+    "id": "598cddd1-0a26-4905-b8db-da8de872430d",
     "type": "lvl2",
     "url": "/docs/styled-system/features/css-variables#attaching-the-css-variables",
     "hierarchy": {
@@ -6070,7 +6070,7 @@
   },
   {
     "content": "Creating scoped, theme-aware CSS variables",
-    "id": "06204460-9378-41fd-8508-fd3ad7dbe5fc",
+    "id": "e3b09f01-5162-4abc-b0a1-6d36047bf309",
     "type": "lvl2",
     "url": "/docs/styled-system/features/css-variables#creating-scoped-theme-aware-css-variables",
     "hierarchy": {
@@ -6081,14 +6081,14 @@
   },
   {
     "content": "Global Styles",
-    "id": "607e944d-5595-400e-92d0-372028eb1031",
+    "id": "83a54031-150d-425c-bd47-2b0c5163e490",
     "type": "lvl1",
     "url": "/docs/styled-system/features/global-styles",
     "hierarchy": { "lvl1": "Global Styles" }
   },
   {
     "content": "How it works",
-    "id": "470df52e-d3b9-4b4c-8883-e9a4e9036436",
+    "id": "9d42a978-c321-401f-b36f-fab271f0855b",
     "type": "lvl2",
     "url": "/docs/styled-system/features/global-styles#how-it-works",
     "hierarchy": {
@@ -6099,7 +6099,7 @@
   },
   {
     "content": "Default styles",
-    "id": "4604e36a-5d36-480f-bf56-a66523c2900c",
+    "id": "196558cc-f3ad-4d50-ad24-fd4c24a6c8e7",
     "type": "lvl2",
     "url": "/docs/styled-system/features/global-styles#default-styles",
     "hierarchy": {
@@ -6110,7 +6110,7 @@
   },
   {
     "content": "Styling non-Chakra elements globally",
-    "id": "4e220e90-4497-4abf-96ff-085cdd4cda19",
+    "id": "cb28e0cf-60c1-4b63-a084-4dd493b5cabb",
     "type": "lvl2",
     "url": "/docs/styled-system/features/global-styles#styling-non-chakra-elements-globally",
     "hierarchy": {
@@ -6121,14 +6121,14 @@
   },
   {
     "content": "Gradient",
-    "id": "60a34623-df5e-42e3-8e46-9943168aae79",
+    "id": "8fe70772-08a2-482c-be78-eb9588cecb96",
     "type": "lvl1",
     "url": "/docs/styled-system/features/gradient",
     "hierarchy": { "lvl1": "Gradient" }
   },
   {
     "content": "Background Gradient API",
-    "id": "a1758961-048f-4c8c-9088-83186cec1b1f",
+    "id": "3d884725-41e5-434f-b940-5109c47d0ae8",
     "type": "lvl2",
     "url": "/docs/styled-system/features/gradient#background-gradient-api",
     "hierarchy": {
@@ -6139,14 +6139,14 @@
   },
   {
     "content": "Usage",
-    "id": "6ac6c82c-a6f6-4719-9143-165417f872a4",
+    "id": "9aa1419f-0bac-470a-9a3d-e98c9f9c2be0",
     "type": "lvl2",
     "url": "/docs/styled-system/features/gradient#usage",
     "hierarchy": { "lvl1": "Gradient", "lvl2": "Usage", "lvl3": null }
   },
   {
     "content": "Customizing Colors",
-    "id": "58f597ea-b009-4880-8753-35a8fc8e5455",
+    "id": "af152777-2487-4034-a588-cf6f70895e72",
     "type": "lvl3",
     "url": "/docs/styled-system/features/gradient#customizing-colors",
     "hierarchy": {
@@ -6157,7 +6157,7 @@
   },
   {
     "content": "Multiple Color Stops",
-    "id": "763f0ab3-6fde-4f42-957d-ea38bd806abb",
+    "id": "e8a53ffa-591d-40b6-b30a-27c6633c1d44",
     "type": "lvl3",
     "url": "/docs/styled-system/features/gradient#multiple-color-stops",
     "hierarchy": {
@@ -6168,7 +6168,7 @@
   },
   {
     "content": "Text Gradient API",
-    "id": "230fc16e-23ef-4194-90e2-98ae058eaf85",
+    "id": "fcf95b3f-6d89-4bc5-845b-47253db8d144",
     "type": "lvl2",
     "url": "/docs/styled-system/features/gradient#text-gradient-api",
     "hierarchy": {
@@ -6179,7 +6179,7 @@
   },
   {
     "content": "Responsive Gradients",
-    "id": "e7b896d3-d418-44a4-b919-ee0ea50050fc",
+    "id": "4118a850-839c-4333-a16d-92a9a7823b27",
     "type": "lvl2",
     "url": "/docs/styled-system/features/gradient#responsive-gradients",
     "hierarchy": {
@@ -6190,7 +6190,7 @@
   },
   {
     "content": "Changing gradient with pseudo props",
-    "id": "b33ef62d-e5b7-4b00-974b-3fc09346a655",
+    "id": "0bd8d52d-7388-4b74-844d-dda6c9cd4e4f",
     "type": "lvl2",
     "url": "/docs/styled-system/features/gradient#changing-gradient-with-pseudo-props",
     "hierarchy": {
@@ -6201,14 +6201,14 @@
   },
   {
     "content": "Responsive Styles",
-    "id": "7e37ca76-d109-492d-a02a-769e38468941",
+    "id": "404b2aa5-05ff-4064-a463-162e2f330870",
     "type": "lvl1",
     "url": "/docs/styled-system/features/responsive-styles",
     "hierarchy": { "lvl1": "Responsive Styles" }
   },
   {
     "content": "The Array syntax",
-    "id": "2f44d491-2599-4445-aa44-7be7b2e38d66",
+    "id": "8093d923-5bc4-4af5-a180-ae1b782807a4",
     "type": "lvl2",
     "url": "/docs/styled-system/features/responsive-styles#the-array-syntax",
     "hierarchy": {
@@ -6219,7 +6219,7 @@
   },
   {
     "content": "The Object syntax",
-    "id": "5ca8f0c2-03d4-487d-8759-e6a7f4405f66",
+    "id": "69e7ae06-bf62-49b5-b423-50b4ef57e9e2",
     "type": "lvl2",
     "url": "/docs/styled-system/features/responsive-styles#the-object-syntax",
     "hierarchy": {
@@ -6230,7 +6230,7 @@
   },
   {
     "content": "More Examples",
-    "id": "15d4bbcf-18a9-42d0-ab59-02f5a3fb5ab5",
+    "id": "3010fe81-0a0a-4461-9334-3e928a1493ec",
     "type": "lvl2",
     "url": "/docs/styled-system/features/responsive-styles#more-examples",
     "hierarchy": {
@@ -6241,7 +6241,7 @@
   },
   {
     "content": "Under the hood",
-    "id": "430a53d1-945d-410a-aee9-ec59f8f2a303",
+    "id": "931a9f91-5cd3-4428-a2fb-51a9349fb331",
     "type": "lvl2",
     "url": "/docs/styled-system/features/responsive-styles#under-the-hood",
     "hierarchy": {
@@ -6252,7 +6252,7 @@
   },
   {
     "content": "Customizing Breakpoints",
-    "id": "54e65d57-645c-49b6-9105-606082476dd3",
+    "id": "fbf424ec-3f06-41ce-a8e1-773064c14a5b",
     "type": "lvl2",
     "url": "/docs/styled-system/features/responsive-styles#customizing-breakpoints",
     "hierarchy": {
@@ -6263,21 +6263,21 @@
   },
   {
     "content": "Demo",
-    "id": "ec6b6180-9947-416b-92b0-8c522053aa01",
+    "id": "14c93357-87b1-48b9-b0b1-8d893d55d0f1",
     "type": "lvl2",
     "url": "/docs/styled-system/features/responsive-styles#demo",
     "hierarchy": { "lvl1": "Responsive Styles", "lvl2": "Demo", "lvl3": null }
   },
   {
     "content": "RTL Support",
-    "id": "9598a9a5-8b2b-4421-87ab-ecedf5b15fdc",
+    "id": "36aea513-e11c-4172-b24b-b37d1ed4e47c",
     "type": "lvl1",
     "url": "/docs/styled-system/features/rtl-support",
     "hierarchy": { "lvl1": "RTL Support" }
   },
   {
     "content": "Using RTL Stylis Plugin",
-    "id": "529c4993-7fac-47fb-85b4-31072f161f08",
+    "id": "5f0e8820-ce13-45b3-a94d-aaa1a1a25b53",
     "type": "lvl2",
     "url": "/docs/styled-system/features/rtl-support#using-rtl-stylis-plugin",
     "hierarchy": {
@@ -6288,7 +6288,7 @@
   },
   {
     "content": "Caveats of this approach",
-    "id": "45833cf2-b6ab-4a24-9d4e-09f1c1ad8162",
+    "id": "ce9755f7-25ac-4afc-835c-75e450319f0e",
     "type": "lvl3",
     "url": "/docs/styled-system/features/rtl-support#caveats-of-this-approach",
     "hierarchy": {
@@ -6299,7 +6299,7 @@
   },
   {
     "content": "Using RTL-aware style props",
-    "id": "07029206-e135-48f6-8a02-6f21dc12cc3b",
+    "id": "6121dcba-a018-42a8-b7c8-7fab4865e5d9",
     "type": "lvl2",
     "url": "/docs/styled-system/features/rtl-support#using-rtl-aware-style-props",
     "hierarchy": {
@@ -6310,7 +6310,7 @@
   },
   {
     "content": "Additional resources",
-    "id": "b87a0d8e-13fe-4306-a9c9-105368cf9d69",
+    "id": "29bad27a-ccfb-4640-ba79-459dff7e71c1",
     "type": "lvl2",
     "url": "/docs/styled-system/features/rtl-support#additional-resources",
     "hierarchy": {
@@ -6321,14 +6321,14 @@
   },
   {
     "content": "Semantic Tokens",
-    "id": "f6597660-5d67-451e-8f5f-0a7336662ee8",
+    "id": "cb5c2354-d87c-43eb-bdb7-23633a278d51",
     "type": "lvl1",
     "url": "/docs/styled-system/features/semantic-tokens",
     "hierarchy": { "lvl1": "Semantic Tokens" }
   },
   {
     "content": "Token References",
-    "id": "4e020d55-6136-458a-b7c1-dd099d3a79dd",
+    "id": "6c7d3740-997f-4cb6-9244-ecd0e633da9b",
     "type": "lvl2",
     "url": "/docs/styled-system/features/semantic-tokens#token-references",
     "hierarchy": {
@@ -6339,7 +6339,7 @@
   },
   {
     "content": "Conditional Tokens",
-    "id": "1dc13233-f780-44f6-a1d3-aab74055a97b",
+    "id": "67bacfe6-aa3d-40de-92b6-b908f662f309",
     "type": "lvl2",
     "url": "/docs/styled-system/features/semantic-tokens#conditional-tokens",
     "hierarchy": {
@@ -6350,7 +6350,7 @@
   },
   {
     "content": "Theme Example",
-    "id": "632524d8-67f0-43ac-a23a-bca31dca96bf",
+    "id": "526e10b9-7fb8-4b5c-87fa-d8a189a88549",
     "type": "lvl2",
     "url": "/docs/styled-system/features/semantic-tokens#theme-example",
     "hierarchy": {
@@ -6361,21 +6361,21 @@
   },
   {
     "content": "Style Props",
-    "id": "fbf43ad2-0a4e-40bf-ad5c-7f1d54cb64ef",
+    "id": "1333f395-5883-4cf7-8a5f-6f1db1207c9b",
     "type": "lvl1",
     "url": "/docs/styled-system/features/style-props",
     "hierarchy": { "lvl1": "Style Props" }
   },
   {
     "content": "Reference",
-    "id": "189040da-cab3-42d7-9213-e037a793f3db",
+    "id": "af427c3e-77a4-4f5a-a2d1-5a27352c7615",
     "type": "lvl2",
     "url": "/docs/styled-system/features/style-props#reference",
     "hierarchy": { "lvl1": "Style Props", "lvl2": "Reference", "lvl3": null }
   },
   {
     "content": "Margin and padding",
-    "id": "9311a4c6-566a-4d45-a1f4-f7db426d8ceb",
+    "id": "d37d8647-98da-4301-9b27-057af0b2e8bf",
     "type": "lvl3",
     "url": "/docs/styled-system/features/style-props#margin-and-padding",
     "hierarchy": {
@@ -6386,7 +6386,7 @@
   },
   {
     "content": "Color and background color",
-    "id": "b2322727-35ef-4149-b334-e56848f509e7",
+    "id": "4408dd01-5df3-4332-91e1-242590e6e2ae",
     "type": "lvl3",
     "url": "/docs/styled-system/features/style-props#color-and-background-color",
     "hierarchy": {
@@ -6397,7 +6397,7 @@
   },
   {
     "content": "Gradient",
-    "id": "cd43bdc0-01e5-411d-8c8d-63041a861d63",
+    "id": "fbc547af-a235-4520-9801-a424f49aff13",
     "type": "lvl3",
     "url": "/docs/styled-system/features/style-props#gradient",
     "hierarchy": {
@@ -6408,7 +6408,7 @@
   },
   {
     "content": "Typography",
-    "id": "3107f632-8e3b-4be9-8919-411319a7cf6a",
+    "id": "8596748e-1b19-4f95-8fc5-2f44121ac992",
     "type": "lvl3",
     "url": "/docs/styled-system/features/style-props#typography",
     "hierarchy": {
@@ -6419,7 +6419,7 @@
   },
   {
     "content": "Layout, width and height",
-    "id": "11d357c3-55fe-48b7-abfd-af43679fc968",
+    "id": "c6bffe8c-1382-44a2-ba33-9a031b5e7208",
     "type": "lvl3",
     "url": "/docs/styled-system/features/style-props#layout-width-and-height",
     "hierarchy": {
@@ -6430,7 +6430,7 @@
   },
   {
     "content": "Flexbox",
-    "id": "c8b6ffa8-5cd9-4a70-9925-e47accf18641",
+    "id": "60de459b-6e38-4fb2-92f0-2deea5e848c4",
     "type": "lvl3",
     "url": "/docs/styled-system/features/style-props#flexbox",
     "hierarchy": {
@@ -6441,7 +6441,7 @@
   },
   {
     "content": "Grid Layout",
-    "id": "10c85b2d-19d4-4d50-bc89-f4eefbf5d97d",
+    "id": "9df9f740-3e76-44ab-935e-3e20d540028f",
     "type": "lvl3",
     "url": "/docs/styled-system/features/style-props#grid-layout",
     "hierarchy": {
@@ -6452,7 +6452,7 @@
   },
   {
     "content": "Background",
-    "id": "f3926ee7-543e-495c-baba-c8d4b60b633e",
+    "id": "fc3c49e9-f4e5-4fe9-8f76-38987e01ff34",
     "type": "lvl3",
     "url": "/docs/styled-system/features/style-props#background",
     "hierarchy": {
@@ -6463,7 +6463,7 @@
   },
   {
     "content": "Borders",
-    "id": "f7f0fcfc-74cc-444c-879d-ce2e82ee1a93",
+    "id": "38c06ed7-34f2-4362-a6ed-c854d5ad0d93",
     "type": "lvl3",
     "url": "/docs/styled-system/features/style-props#borders",
     "hierarchy": {
@@ -6474,7 +6474,7 @@
   },
   {
     "content": "Border Radius",
-    "id": "ff5f7004-a868-45aa-bb96-bd39d8101e73",
+    "id": "3623191a-1148-4b32-85f6-c8c1bcaa6627",
     "type": "lvl3",
     "url": "/docs/styled-system/features/style-props#border-radius",
     "hierarchy": {
@@ -6485,7 +6485,7 @@
   },
   {
     "content": "Position",
-    "id": "b96b8a8f-4cd6-44b0-9185-672489b91611",
+    "id": "8e41ccf1-818b-4e3b-87b0-ec3543e24d50",
     "type": "lvl3",
     "url": "/docs/styled-system/features/style-props#position",
     "hierarchy": {
@@ -6496,28 +6496,28 @@
   },
   {
     "content": "Shadow",
-    "id": "e38185d8-19c1-4c22-ad3e-2b073cc8721b",
+    "id": "c88e0dd8-4d35-4d34-bd90-188d03a3b3d3",
     "type": "lvl3",
     "url": "/docs/styled-system/features/style-props#shadow",
     "hierarchy": { "lvl1": "Style Props", "lvl2": "Position", "lvl3": "Shadow" }
   },
   {
     "content": "Filter",
-    "id": "d27307ba-9198-4e48-8960-3e49cadbe8ec",
+    "id": "2012c2d7-8bb9-4868-a326-0f91153ecb8d",
     "type": "lvl3",
     "url": "/docs/styled-system/features/style-props#filter",
     "hierarchy": { "lvl1": "Style Props", "lvl2": "Shadow", "lvl3": "Filter" }
   },
   {
     "content": "Pseudo",
-    "id": "1f34b22d-6dc2-4108-8a2d-cb2f3591a729",
+    "id": "8b649298-9724-408f-94ad-6c95c8ec5abe",
     "type": "lvl3",
     "url": "/docs/styled-system/features/style-props#pseudo",
     "hierarchy": { "lvl1": "Style Props", "lvl2": "Filter", "lvl3": "Pseudo" }
   },
   {
     "content": "Other Props",
-    "id": "fb3e2f7d-122f-41a2-8c1d-08b1e50b4275",
+    "id": "57a2371d-0ffa-4b78-af22-973e96a083fe",
     "type": "lvl3",
     "url": "/docs/styled-system/features/style-props#other-props",
     "hierarchy": {
@@ -6528,7 +6528,7 @@
   },
   {
     "content": "The `as` prop",
-    "id": "03a2668b-93db-42eb-8f72-a3e42abbc500",
+    "id": "e200f677-4f5b-44f1-8eda-5b7c4469b54a",
     "type": "lvl2",
     "url": "/docs/styled-system/features/style-props#the-as-prop",
     "hierarchy": {
@@ -6539,14 +6539,14 @@
   },
   {
     "content": "Text and Layer Styles",
-    "id": "9a370d06-ee34-4285-8d05-4f32d11ba4c3",
+    "id": "938682a9-1696-4aa0-b1d6-f740d98c3845",
     "type": "lvl1",
     "url": "/docs/styled-system/features/text-and-layer-styles",
     "hierarchy": { "lvl1": "Text and Layer Styles" }
   },
   {
     "content": "Layer Style",
-    "id": "d8face43-c490-45e1-84dd-929eb410a1bb",
+    "id": "58682fe5-f041-41da-93fe-dfd482b5d2e5",
     "type": "lvl2",
     "url": "/docs/styled-system/features/text-and-layer-styles#layer-style",
     "hierarchy": {
@@ -6557,7 +6557,7 @@
   },
   {
     "content": "Text Styles",
-    "id": "f53c4dee-d238-4bbd-9838-55624eec1b85",
+    "id": "b96185d7-f4fc-4361-bd37-983ad6d421ee",
     "type": "lvl2",
     "url": "/docs/styled-system/features/text-and-layer-styles#text-styles",
     "hierarchy": {
@@ -6568,7 +6568,7 @@
   },
   {
     "content": "Naming text styles",
-    "id": "35391198-6b80-40e0-81b5-4e0eae7ef8f3",
+    "id": "1a725f27-d685-4853-a43d-8327e72ef1bd",
     "type": "lvl3",
     "url": "/docs/styled-system/features/text-and-layer-styles#naming-text-styles",
     "hierarchy": {
@@ -6579,21 +6579,21 @@
   },
   {
     "content": "The `sx` Prop",
-    "id": "5b18d267-d587-4df7-970c-303a1cffdab3",
+    "id": "7d1c01ed-e1d0-4c94-a72b-8df5fe364c0d",
     "type": "lvl1",
     "url": "/docs/styled-system/features/the-sx-prop",
     "hierarchy": { "lvl1": "The `sx` Prop" }
   },
   {
     "content": "Use cases",
-    "id": "4d8b8fd0-b15a-412e-be5f-954092b10c21",
+    "id": "ce460675-348f-42e2-822d-a77c17ed0cfd",
     "type": "lvl2",
     "url": "/docs/styled-system/features/the-sx-prop#use-cases",
     "hierarchy": { "lvl1": "The `sx` Prop", "lvl2": "Use cases", "lvl3": null }
   },
   {
     "content": "Defining Any Standard CSS Property",
-    "id": "aa7533af-2ea3-40ce-bfbb-cb69556da1a8",
+    "id": "9612f2c3-0557-4ddb-b34a-cc9c7bec455b",
     "type": "lvl3",
     "url": "/docs/styled-system/features/the-sx-prop#defining-any-standard-css-property",
     "hierarchy": {
@@ -6604,7 +6604,7 @@
   },
   {
     "content": "Defining CSS Custom Properties",
-    "id": "3413bdc9-4114-4089-a1c0-f6bc6a6ed878",
+    "id": "a6720bde-75e2-4a55-8e01-829cd6ac9fba",
     "type": "lvl3",
     "url": "/docs/styled-system/features/the-sx-prop#defining-css-custom-properties",
     "hierarchy": {
@@ -6615,7 +6615,7 @@
   },
   {
     "content": "Creating Nested Selectors",
-    "id": "b6274622-9e8f-4bef-8dbc-3aa833266b17",
+    "id": "add5b339-10c1-423c-8269-c8e411169732",
     "type": "lvl3",
     "url": "/docs/styled-system/features/the-sx-prop#creating-nested-selectors",
     "hierarchy": {
@@ -6626,7 +6626,7 @@
   },
   {
     "content": "Custom Media queries",
-    "id": "54c7caf4-4636-4d3c-a39d-876177fcf0a9",
+    "id": "90a8f297-3864-4ac8-bdf9-3353d7e88f6d",
     "type": "lvl3",
     "url": "/docs/styled-system/features/the-sx-prop#custom-media-queries",
     "hierarchy": {
@@ -6637,28 +6637,28 @@
   },
   {
     "content": "Styled System",
-    "id": "91c5b7be-1742-4450-bb0c-96c72208f139",
+    "id": "53b174b4-227c-4ad3-899c-6e39b41d4731",
     "type": "lvl1",
     "url": "/docs/styled-system/overview",
     "hierarchy": { "lvl1": "Styled System" }
   },
   {
     "content": "Page specific color mode",
-    "id": "078ab7fb-374d-4536-9004-2fe79e31855f",
+    "id": "c533432d-1b41-497a-b893-40ffb624dbe4",
     "type": "lvl1",
     "url": "/docs/styled-system/recipes/page-specific-color-mode",
     "hierarchy": { "lvl1": "Page specific color mode" }
   },
   {
     "content": "Using Fonts",
-    "id": "d32bdd5c-87f1-4dbe-94f6-0a2ae46e5c75",
+    "id": "590ce806-0863-44b9-a0b1-8b28d09370b3",
     "type": "lvl1",
     "url": "/docs/styled-system/recipes/using-fonts",
     "hierarchy": { "lvl1": "Using Fonts" }
   },
   {
     "content": "Option 1: Install with NPM",
-    "id": "c2403690-0a27-43b2-a042-b05fce98e466",
+    "id": "088e6a52-bc2f-4951-8ab1-58e059857c34",
     "type": "lvl2",
     "url": "/docs/styled-system/recipes/using-fonts#option-1-install-with-npm",
     "hierarchy": {
@@ -6669,7 +6669,7 @@
   },
   {
     "content": "Option 2: Using `@font-face`",
-    "id": "395f47e1-af2b-4de6-84fd-85933df4da74",
+    "id": "ad1b5c87-ee2f-450c-a8a4-738e3a3b3ece",
     "type": "lvl2",
     "url": "/docs/styled-system/recipes/using-fonts#option-2-using-font-face",
     "hierarchy": {
@@ -6680,14 +6680,14 @@
   },
   {
     "content": "Advanced Theming",
-    "id": "44942eed-9f26-483e-b53e-efab558666f2",
+    "id": "e263cdfa-7761-464b-a8fc-b5b915f9b492",
     "type": "lvl1",
     "url": "/docs/styled-system/theming/advanced",
     "hierarchy": { "lvl1": "Advanced Theming" }
   },
   {
     "content": "Single Part Component",
-    "id": "31eeedf6-6085-4005-9e52-f6676c2f332c",
+    "id": "43c48a77-fb4f-4332-a69f-c78113a06353",
     "type": "lvl2",
     "url": "/docs/styled-system/theming/advanced#single-part-component",
     "hierarchy": {
@@ -6698,7 +6698,7 @@
   },
   {
     "content": "Multipart or Composite Component",
-    "id": "a57fb092-5fb8-4820-9b47-79a02c8487e8",
+    "id": "06cfb815-1b62-4a4a-9bbe-b28e6cdab117",
     "type": "lvl2",
     "url": "/docs/styled-system/theming/advanced#multipart-or-composite-component",
     "hierarchy": {
@@ -6709,7 +6709,7 @@
   },
   {
     "content": "Distributing a Theme Package",
-    "id": "e2ad515e-50d5-46d8-a1d8-3e7d3b6774e3",
+    "id": "d616272c-0732-4be0-bbb7-be9646b4a250",
     "type": "lvl2",
     "url": "/docs/styled-system/theming/advanced#distributing-a-theme-package",
     "hierarchy": {
@@ -6720,7 +6720,7 @@
   },
   {
     "content": "Theme Typings",
-    "id": "8d07940c-3669-40e2-be42-c7068e0b0955",
+    "id": "69737c6f-7ace-415d-8b81-0ef9dddf2525",
     "type": "lvl2",
     "url": "/docs/styled-system/theming/advanced#theme-typings",
     "hierarchy": {
@@ -6731,7 +6731,7 @@
   },
   {
     "content": "Install",
-    "id": "82100294-e24d-48af-9f0e-178cd030bcf1",
+    "id": "8aae2d33-51aa-407c-b4e3-4e027bfba0a1",
     "type": "lvl3",
     "url": "/docs/styled-system/theming/advanced#install",
     "hierarchy": {
@@ -6742,7 +6742,7 @@
   },
   {
     "content": "Usage",
-    "id": "17ebe960-329a-4692-b038-1dca2e9dd8d4",
+    "id": "e76780b4-20ee-4280-9dd1-c718cb88225b",
     "type": "lvl3",
     "url": "/docs/styled-system/theming/advanced#usage",
     "hierarchy": {
@@ -6753,14 +6753,14 @@
   },
   {
     "content": "Component Style",
-    "id": "69fab41d-3246-4eb2-88de-b8137e8dc341",
+    "id": "7f95ea52-e05b-41ae-8dc1-3f4dc56cfc67",
     "type": "lvl1",
     "url": "/docs/styled-system/theming/component-style",
     "hierarchy": { "lvl1": "Component Style" }
   },
   {
     "content": "Base styles and Modifier styles",
-    "id": "86189e4f-ab63-40bb-a311-4055c92fb103",
+    "id": "c748aca2-b59c-43bc-a9ba-15d5d6f9fd0f",
     "type": "lvl2",
     "url": "/docs/styled-system/theming/component-style#base-styles-and-modifier-styles",
     "hierarchy": {
@@ -6771,7 +6771,7 @@
   },
   {
     "content": "Single part and multipart components",
-    "id": "710802cd-6244-4b7f-b1b9-34f0cac8e5b5",
+    "id": "12891533-dfb8-4768-8bcb-de0dd97d6fed",
     "type": "lvl3",
     "url": "/docs/styled-system/theming/component-style#single-part-and-multipart-components",
     "hierarchy": {
@@ -6782,7 +6782,7 @@
   },
   {
     "content": "Styling single part components",
-    "id": "775a6f12-6f1c-4115-85e2-36d85f6281f1",
+    "id": "633ffcaa-3c2c-4983-acd5-bf950d6d7b65",
     "type": "lvl2",
     "url": "/docs/styled-system/theming/component-style#styling-single-part-components",
     "hierarchy": {
@@ -6793,7 +6793,7 @@
   },
   {
     "content": "Consuming style config",
-    "id": "d606cfad-3e21-4e1d-ad04-012bcc1f9053",
+    "id": "b73224d2-e6c9-4f16-90e8-84870ecea276",
     "type": "lvl3",
     "url": "/docs/styled-system/theming/component-style#consuming-style-config",
     "hierarchy": {
@@ -6804,7 +6804,7 @@
   },
   {
     "content": "useStyleConfig API",
-    "id": "66eb6098-78a3-40e3-8b4a-9e723fd225ae",
+    "id": "792a6ca7-6156-41f3-851a-25f9f2708ced",
     "type": "lvl3",
     "url": "/docs/styled-system/theming/component-style#usestyleconfig-api",
     "hierarchy": {
@@ -6815,7 +6815,7 @@
   },
   {
     "content": "Parameters",
-    "id": "f20a4aba-7820-4975-88b8-aadacb00c97e",
+    "id": "e0b8efeb-dbe6-4004-b829-f96e2bbc67a0",
     "type": "lvl4",
     "url": "/docs/styled-system/theming/component-style#parameters",
     "hierarchy": {
@@ -6826,7 +6826,7 @@
   },
   {
     "content": "Return Value",
-    "id": "628b2b0f-589b-414b-af65-7eca6db388b9",
+    "id": "8b922a91-f277-4b5a-a010-18eb3e6e14a5",
     "type": "lvl4",
     "url": "/docs/styled-system/theming/component-style#return-value",
     "hierarchy": {
@@ -6837,7 +6837,7 @@
   },
   {
     "content": "Styling multipart components",
-    "id": "97d8abe8-d580-4ea8-85b2-614be247c6d1",
+    "id": "8d7ff57e-3a3c-4f20-836b-1531552c03a9",
     "type": "lvl2",
     "url": "/docs/styled-system/theming/component-style#styling-multipart-components",
     "hierarchy": {
@@ -6848,7 +6848,7 @@
   },
   {
     "content": "Consuming multipart style config",
-    "id": "bf0c473e-1cd8-4ac7-bf88-936be472c200",
+    "id": "ca36b01e-683a-4288-94bb-c7da722a6e45",
     "type": "lvl3",
     "url": "/docs/styled-system/theming/component-style#consuming-multipart-style-config",
     "hierarchy": {
@@ -6859,7 +6859,7 @@
   },
   {
     "content": "useMultiStyleConfig API",
-    "id": "dd120259-b352-4409-ad4a-83e005b34fac",
+    "id": "d2701dc5-2884-418a-bab7-495bf9ebf271",
     "type": "lvl3",
     "url": "/docs/styled-system/theming/component-style#usemultistyleconfig-api",
     "hierarchy": {
@@ -6870,7 +6870,7 @@
   },
   {
     "content": "Parameters",
-    "id": "bcd582d2-00af-4a85-83d0-08ada4f8ab50",
+    "id": "9b162a96-2e7d-4de0-b433-d4a7d30dd5c8",
     "type": "lvl4",
     "url": "/docs/styled-system/theming/component-style#parameters-1",
     "hierarchy": {
@@ -6881,7 +6881,7 @@
   },
   {
     "content": "Return Values",
-    "id": "e6beb57c-4022-4b54-8b36-1a4c8b2ce047",
+    "id": "f05eb887-6f23-447e-8a7e-4ca47f7892a0",
     "type": "lvl4",
     "url": "/docs/styled-system/theming/component-style#return-values",
     "hierarchy": {
@@ -6892,14 +6892,14 @@
   },
   {
     "content": "Customize Theme",
-    "id": "d6cd079c-0335-4b44-a323-79539a771a9c",
+    "id": "eff79339-a022-43cb-b1d0-e90b8610b8d2",
     "type": "lvl1",
     "url": "/docs/styled-system/theming/customize-theme",
     "hierarchy": { "lvl1": "Customize Theme" }
   },
   {
     "content": "Customizing theme tokens",
-    "id": "ecf7fa29-bfb9-49ea-81a9-b1711e77518f",
+    "id": "57edf730-360b-40c1-9281-8706552958ab",
     "type": "lvl2",
     "url": "/docs/styled-system/theming/customize-theme#customizing-theme-tokens",
     "hierarchy": {
@@ -6910,7 +6910,7 @@
   },
   {
     "content": "Customizing component styles",
-    "id": "e4caf1e5-77e5-463c-aa14-5394b1e2a723",
+    "id": "f022335c-6795-42e5-918d-3ac728c6669c",
     "type": "lvl2",
     "url": "/docs/styled-system/theming/customize-theme#customizing-component-styles",
     "hierarchy": {
@@ -6921,7 +6921,7 @@
   },
   {
     "content": "Customizing single components",
-    "id": "5678593c-5b9b-4a88-bd21-bad9476a4619",
+    "id": "4c248b53-5da3-4fbc-82aa-c7e62a5a2302",
     "type": "lvl3",
     "url": "/docs/styled-system/theming/customize-theme#customizing-single-components",
     "hierarchy": {
@@ -6932,7 +6932,7 @@
   },
   {
     "content": "Customizing global styles",
-    "id": "d7bbf668-942e-432a-9f75-68c1e2f89f4d",
+    "id": "8b9e4f6b-194b-4421-8da1-7caa6e345bcb",
     "type": "lvl3",
     "url": "/docs/styled-system/theming/customize-theme#customizing-global-styles",
     "hierarchy": {
@@ -6943,7 +6943,7 @@
   },
   {
     "content": "Scaling out your project",
-    "id": "ae52e5c7-6049-4601-bc46-df4c18919581",
+    "id": "6be49e06-c53e-4a3b-88a5-dd947cdaea1c",
     "type": "lvl2",
     "url": "/docs/styled-system/theming/customize-theme#scaling-out-your-project",
     "hierarchy": {
@@ -6954,7 +6954,7 @@
   },
   {
     "content": "Using Theme extensions",
-    "id": "2d142d60-0f30-422d-b3d5-0a945edc0186",
+    "id": "f7b0bedb-19aa-4c04-b196-1159c5f267df",
     "type": "lvl2",
     "url": "/docs/styled-system/theming/customize-theme#using-theme-extensions",
     "hierarchy": {
@@ -6965,7 +6965,7 @@
   },
   {
     "content": "Theme Extension: withDefaultColorScheme",
-    "id": "5c86fdfd-3182-46f3-bb16-62b948a78a74",
+    "id": "2365ae1e-4a25-4e6b-96f4-648f57f1e0ed",
     "type": "lvl2",
     "url": "/docs/styled-system/theming/customize-theme#theme-extension-withdefaultcolorscheme",
     "hierarchy": {
@@ -6976,7 +6976,7 @@
   },
   {
     "content": "Theme Extension: withDefaultSize",
-    "id": "c8098094-af4f-4ffb-bb56-13368364df7d",
+    "id": "8cbedd63-21e6-4925-9e00-5fabcdc023c6",
     "type": "lvl2",
     "url": "/docs/styled-system/theming/customize-theme#theme-extension-withdefaultsize",
     "hierarchy": {
@@ -6987,7 +6987,7 @@
   },
   {
     "content": "Theme Extension: withDefaultVariant",
-    "id": "6d0338a5-369a-4185-9a39-fac7922138d4",
+    "id": "223dc8d7-d8a9-4dd1-a3dc-127695715116",
     "type": "lvl2",
     "url": "/docs/styled-system/theming/customize-theme#theme-extension-withdefaultvariant",
     "hierarchy": {
@@ -6998,7 +6998,7 @@
   },
   {
     "content": "Theme Extension: withDefaultProps",
-    "id": "4b5c76f3-2507-4d59-acde-12dd2b4db1aa",
+    "id": "b439d2e1-020e-4460-a095-2cf2fff97bb1",
     "type": "lvl2",
     "url": "/docs/styled-system/theming/customize-theme#theme-extension-withdefaultprops",
     "hierarchy": {
@@ -7009,21 +7009,21 @@
   },
   {
     "content": "Default Theme",
-    "id": "acc34940-d67f-4b61-afee-a6be01bf4af9",
+    "id": "a0a7d40e-4c1f-4026-ab8f-ffb2dea257ca",
     "type": "lvl1",
     "url": "/docs/styled-system/theming/theme",
     "hierarchy": { "lvl1": "Default Theme" }
   },
   {
     "content": "Colors",
-    "id": "bf49bfa7-120b-4a63-91bc-52577a161904",
+    "id": "dbd79f34-ea87-461b-9a5d-d9029b74a192",
     "type": "lvl2",
     "url": "/docs/styled-system/theming/theme#colors",
     "hierarchy": { "lvl1": "Default Theme", "lvl2": "Colors", "lvl3": null }
   },
   {
     "content": "Black & White",
-    "id": "3d4a7b16-b9bf-43da-ae84-dbc101528a2c",
+    "id": "f92632bb-715f-4909-a41d-386d45b11107",
     "type": "lvl3",
     "url": "/docs/styled-system/theming/theme#black--white",
     "hierarchy": {
@@ -7034,7 +7034,7 @@
   },
   {
     "content": "Gray",
-    "id": "7b7fa9e3-76bb-41cc-9a31-04641534b227",
+    "id": "69983b23-1f3f-4e2a-8fca-d26adcbf3b6b",
     "type": "lvl3",
     "url": "/docs/styled-system/theming/theme#gray",
     "hierarchy": {
@@ -7045,77 +7045,77 @@
   },
   {
     "content": "Red",
-    "id": "9e53eb0e-de75-4b31-8f66-dae729d987b8",
+    "id": "b07dcf69-0fc8-40bc-aad3-294dfd9f14e4",
     "type": "lvl3",
     "url": "/docs/styled-system/theming/theme#red",
     "hierarchy": { "lvl1": "Default Theme", "lvl2": "Gray", "lvl3": "Red" }
   },
   {
     "content": "Orange",
-    "id": "71a71ccd-4585-4bd6-ae98-1c38e76f6816",
+    "id": "58725caa-1e88-4cd2-b7dd-ae22f18c7bd2",
     "type": "lvl3",
     "url": "/docs/styled-system/theming/theme#orange",
     "hierarchy": { "lvl1": "Default Theme", "lvl2": "Red", "lvl3": "Orange" }
   },
   {
     "content": "Yellow",
-    "id": "80b142cd-6352-4265-9a23-0ab391d3576f",
+    "id": "c6686a27-0093-4d61-96ca-9d5825b8eead",
     "type": "lvl3",
     "url": "/docs/styled-system/theming/theme#yellow",
     "hierarchy": { "lvl1": "Default Theme", "lvl2": "Orange", "lvl3": "Yellow" }
   },
   {
     "content": "Green",
-    "id": "64cc0be7-db5e-47e0-bf72-46351ea9690f",
+    "id": "2ffe3371-a5cd-4a4a-a16d-cb687e0f179d",
     "type": "lvl3",
     "url": "/docs/styled-system/theming/theme#green",
     "hierarchy": { "lvl1": "Default Theme", "lvl2": "Yellow", "lvl3": "Green" }
   },
   {
     "content": "Teal",
-    "id": "8f565f87-d080-422a-acee-86f5b328039d",
+    "id": "482dab4d-8aca-4f94-8a9f-c02780cc107a",
     "type": "lvl3",
     "url": "/docs/styled-system/theming/theme#teal",
     "hierarchy": { "lvl1": "Default Theme", "lvl2": "Green", "lvl3": "Teal" }
   },
   {
     "content": "Blue",
-    "id": "c2b42b1e-8c47-4900-abce-9d92e2ac15b6",
+    "id": "5f2aa8a7-993c-4cde-9ab9-662ebab7feea",
     "type": "lvl3",
     "url": "/docs/styled-system/theming/theme#blue",
     "hierarchy": { "lvl1": "Default Theme", "lvl2": "Teal", "lvl3": "Blue" }
   },
   {
     "content": "Cyan",
-    "id": "87b86e33-9d43-4767-bfcc-3d677f523861",
+    "id": "401f7c29-8867-452f-a7f4-c6fba846dc92",
     "type": "lvl3",
     "url": "/docs/styled-system/theming/theme#cyan",
     "hierarchy": { "lvl1": "Default Theme", "lvl2": "Blue", "lvl3": "Cyan" }
   },
   {
     "content": "Purple",
-    "id": "80c7a18c-4555-4119-9812-919e8182005f",
+    "id": "d93203fb-3e29-42c2-8587-b537b27baa71",
     "type": "lvl3",
     "url": "/docs/styled-system/theming/theme#purple",
     "hierarchy": { "lvl1": "Default Theme", "lvl2": "Cyan", "lvl3": "Purple" }
   },
   {
     "content": "Pink",
-    "id": "267fe9c0-dbd2-4684-af7c-08f0df11e9c1",
+    "id": "9454a016-5451-4941-b7c7-16c6cb0e41d4",
     "type": "lvl3",
     "url": "/docs/styled-system/theming/theme#pink",
     "hierarchy": { "lvl1": "Default Theme", "lvl2": "Purple", "lvl3": "Pink" }
   },
   {
     "content": "Typography",
-    "id": "093229f7-8e73-4b70-98e2-9ac375136a60",
+    "id": "b9054ddc-ec42-4a95-b194-ce3f31556e79",
     "type": "lvl2",
     "url": "/docs/styled-system/theming/theme#typography",
     "hierarchy": { "lvl1": "Default Theme", "lvl2": "Typography", "lvl3": null }
   },
   {
     "content": "Breakpoints",
-    "id": "0548e8f7-06c3-4935-a177-2a02d4146d0b",
+    "id": "290a3f7b-e4a8-4e9b-a62f-41352da174e5",
     "type": "lvl2",
     "url": "/docs/styled-system/theming/theme#breakpoints",
     "hierarchy": {
@@ -7126,21 +7126,21 @@
   },
   {
     "content": "Spacing",
-    "id": "7093a8ec-beea-4962-970c-d79a805d6127",
+    "id": "2759a1b4-c075-46b9-bd5c-977a5deeaa31",
     "type": "lvl2",
     "url": "/docs/styled-system/theming/theme#spacing",
     "hierarchy": { "lvl1": "Default Theme", "lvl2": "Spacing", "lvl3": null }
   },
   {
     "content": "Sizes",
-    "id": "56d56951-a14e-4343-8762-a105078d89c3",
+    "id": "366f56d9-db2a-44c5-99d9-8c6eec2655a1",
     "type": "lvl2",
     "url": "/docs/styled-system/theming/theme#sizes",
     "hierarchy": { "lvl1": "Default Theme", "lvl2": "Sizes", "lvl3": null }
   },
   {
     "content": "Border radius",
-    "id": "6b6fda6b-e898-41c2-95c2-56b9cdb5b2b3",
+    "id": "5c310c1a-1551-413a-8c28-19456e519689",
     "type": "lvl2",
     "url": "/docs/styled-system/theming/theme#border-radius",
     "hierarchy": {
@@ -7151,7 +7151,7 @@
   },
   {
     "content": "z-index values",
-    "id": "6fadcc32-88dd-4985-8464-9d264f0a5203",
+    "id": "c4136d36-5469-47af-abb1-d087b2bb0d40",
     "type": "lvl2",
     "url": "/docs/styled-system/theming/theme#z-index-values",
     "hierarchy": {
@@ -7162,42 +7162,42 @@
   },
   {
     "content": "Config",
-    "id": "dccdbb9e-ca8f-4047-98fd-b376f67b1e85",
+    "id": "b919edea-d39a-4a4c-960a-67456f9db845",
     "type": "lvl2",
     "url": "/docs/styled-system/theming/theme#config",
     "hierarchy": { "lvl1": "Default Theme", "lvl2": "Config", "lvl3": null }
   },
   {
     "content": "useBoolean",
-    "id": "7fab05e7-7888-485e-a235-1492eb834cc3",
+    "id": "0823225e-cc9f-4767-9a68-a87e87e2c8e1",
     "type": "lvl1",
     "url": "/docs/styled-system/utility-hooks/use-boolean",
     "hierarchy": { "lvl1": "useBoolean" }
   },
   {
     "content": "Import",
-    "id": "c226ad83-c745-495e-9054-7a43fd90cca0",
+    "id": "5a83bb51-8770-4900-a33f-d8ee5f444c35",
     "type": "lvl2",
     "url": "/docs/styled-system/utility-hooks/use-boolean#import",
     "hierarchy": { "lvl1": "useBoolean", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Return value",
-    "id": "8e8f7412-d628-4aba-9226-c5a8305d2ad5",
+    "id": "5129abab-52d9-4643-84f1-4c967d5bbd94",
     "type": "lvl2",
     "url": "/docs/styled-system/utility-hooks/use-boolean#return-value",
     "hierarchy": { "lvl1": "useBoolean", "lvl2": "Return value", "lvl3": null }
   },
   {
     "content": "Usage",
-    "id": "4a55f7dd-c0bc-46a1-8bfd-34aff4f4c2b2",
+    "id": "da9678cc-aa3a-43ae-b7da-53b60173a2cb",
     "type": "lvl2",
     "url": "/docs/styled-system/utility-hooks/use-boolean#usage",
     "hierarchy": { "lvl1": "useBoolean", "lvl2": "Usage", "lvl3": null }
   },
   {
     "content": "Usage of toggle method",
-    "id": "685413ef-4cfc-426c-906e-4aba45be005e",
+    "id": "d7dfcea2-fdb3-4efb-87c7-64ec4ec17824",
     "type": "lvl3",
     "url": "/docs/styled-system/utility-hooks/use-boolean#usage-of-toggle-method",
     "hierarchy": {
@@ -7208,7 +7208,7 @@
   },
   {
     "content": "Usage of on and off methods",
-    "id": "87a700a7-6281-4f5d-9493-cb8a39c7061a",
+    "id": "b7f0a959-dd11-4410-87c1-45943ecfbfdb",
     "type": "lvl3",
     "url": "/docs/styled-system/utility-hooks/use-boolean#usage-of-on-and-off-methods",
     "hierarchy": {
@@ -7219,21 +7219,21 @@
   },
   {
     "content": "Parameters",
-    "id": "4e6cd427-f1ac-4ecb-8d07-5c2a11820a5c",
+    "id": "e62b8ca9-57cf-4a03-a270-b0a2583eb8d4",
     "type": "lvl2",
     "url": "/docs/styled-system/utility-hooks/use-boolean#parameters",
     "hierarchy": { "lvl1": "useBoolean", "lvl2": "Parameters", "lvl3": null }
   },
   {
     "content": "useBreakpointValue",
-    "id": "cf0d9adf-fe97-4aa7-a406-86e9e8e84fe0",
+    "id": "4af07b70-b22e-4bfd-8b37-517150ff2b0d",
     "type": "lvl1",
     "url": "/docs/styled-system/utility-hooks/use-breakpoint-value",
     "hierarchy": { "lvl1": "useBreakpointValue" }
   },
   {
     "content": "Import",
-    "id": "18b2e2d0-77d6-413d-9e31-3cfb7a429bab",
+    "id": "6b73276e-8645-4769-a6cd-8caa0df2e11e",
     "type": "lvl2",
     "url": "/docs/styled-system/utility-hooks/use-breakpoint-value#import",
     "hierarchy": {
@@ -7244,7 +7244,7 @@
   },
   {
     "content": "Return value",
-    "id": "58150553-68dc-4078-8f56-a23454970ed5",
+    "id": "b167e191-fa00-45d9-9027-8a24c0c76f81",
     "type": "lvl2",
     "url": "/docs/styled-system/utility-hooks/use-breakpoint-value#return-value",
     "hierarchy": {
@@ -7255,28 +7255,28 @@
   },
   {
     "content": "Usage",
-    "id": "569c4314-1dff-4d71-ba83-c485fa25294c",
+    "id": "edde042b-7176-49a9-8e74-c2586b095ee0",
     "type": "lvl2",
     "url": "/docs/styled-system/utility-hooks/use-breakpoint-value#usage",
     "hierarchy": { "lvl1": "useBreakpointValue", "lvl2": "Usage", "lvl3": null }
   },
   {
     "content": "useClipboard",
-    "id": "06ca456b-65bc-4f58-914e-a7418c139af4",
+    "id": "3a64de0a-3b4f-4e5a-81c7-43d7cc003419",
     "type": "lvl1",
     "url": "/docs/styled-system/utility-hooks/use-clipboard",
     "hierarchy": { "lvl1": "useClipboard" }
   },
   {
     "content": "Arguments",
-    "id": "92e6a5f1-1480-40cf-8fad-b61acfa736d6",
+    "id": "5a594c58-5488-4d54-a39b-f61ad34b7a83",
     "type": "lvl2",
     "url": "/docs/styled-system/utility-hooks/use-clipboard#arguments",
     "hierarchy": { "lvl1": "useClipboard", "lvl2": "Arguments", "lvl3": null }
   },
   {
     "content": "Return value",
-    "id": "f42399a6-2085-4cc6-8485-5e8599d0c5a0",
+    "id": "213955ab-5e3d-48c3-a4db-d487e17ca0c4",
     "type": "lvl2",
     "url": "/docs/styled-system/utility-hooks/use-clipboard#return-value",
     "hierarchy": {
@@ -7287,49 +7287,49 @@
   },
   {
     "content": "Import",
-    "id": "4bf08b04-ac84-4ade-b7bf-1a1cb1be50ac",
+    "id": "aa460e51-1a26-4c62-835a-031ffee063f6",
     "type": "lvl2",
     "url": "/docs/styled-system/utility-hooks/use-clipboard#import",
     "hierarchy": { "lvl1": "useClipboard", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Usage",
-    "id": "724c4107-9a94-4271-8c1d-9a1b92ac254e",
+    "id": "471a4ca0-deb8-47d1-92b5-3bb97c004fb4",
     "type": "lvl2",
     "url": "/docs/styled-system/utility-hooks/use-clipboard#usage",
     "hierarchy": { "lvl1": "useClipboard", "lvl2": "Usage", "lvl3": null }
   },
   {
     "content": "useConst",
-    "id": "3dffbde7-8632-448d-9fba-5bbb5e8e702c",
+    "id": "4f2b217a-c5c9-43bf-94ee-a5eb38a0b240",
     "type": "lvl1",
     "url": "/docs/styled-system/utility-hooks/use-const",
     "hierarchy": { "lvl1": "useConst" }
   },
   {
     "content": "Import",
-    "id": "38b54561-1980-440c-b1c6-380b9903484a",
+    "id": "4e641b19-9241-489c-9249-4a8ade71a05a",
     "type": "lvl2",
     "url": "/docs/styled-system/utility-hooks/use-const#import",
     "hierarchy": { "lvl1": "useConst", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Parameters",
-    "id": "7f0e6d94-54ba-4993-8d86-61882aba8cc0",
+    "id": "352521b7-837a-45e9-9dbb-63988bb68355",
     "type": "lvl2",
     "url": "/docs/styled-system/utility-hooks/use-const#parameters",
     "hierarchy": { "lvl1": "useConst", "lvl2": "Parameters", "lvl3": null }
   },
   {
     "content": "Usage",
-    "id": "26db9384-b674-4e3f-b736-7b3f798c0a90",
+    "id": "0ff66dd9-3747-4da9-96e0-2a19782f15a8",
     "type": "lvl2",
     "url": "/docs/styled-system/utility-hooks/use-const#usage",
     "hierarchy": { "lvl1": "useConst", "lvl2": "Usage", "lvl3": null }
   },
   {
     "content": "Why not use `useMemo`?",
-    "id": "e73c82f8-6c4b-47f7-8c38-3580c092b173",
+    "id": "650dc7c1-6445-4ea5-981e-e7e5ba95a335",
     "type": "lvl2",
     "url": "/docs/styled-system/utility-hooks/use-const#why-not-use-usememo",
     "hierarchy": {
@@ -7340,7 +7340,7 @@
   },
   {
     "content": "Why not use `useState`?",
-    "id": "55f97860-8a96-4bad-afbe-bf1b6449f7b1",
+    "id": "25e413d9-9b8e-4668-a1c5-45030af9b3e5",
     "type": "lvl2",
     "url": "/docs/styled-system/utility-hooks/use-const#why-not-use-usestate",
     "hierarchy": {
@@ -7351,14 +7351,14 @@
   },
   {
     "content": "useControllableState",
-    "id": "304d299d-ff8f-4986-a4aa-b43657df971f",
+    "id": "1e0e39b8-14cb-4b41-84f9-f1deda2e0c45",
     "type": "lvl1",
     "url": "/docs/styled-system/utility-hooks/use-controllable",
     "hierarchy": { "lvl1": "useControllableState" }
   },
   {
     "content": "Import",
-    "id": "492883b6-fab3-4467-bf53-b0d33f92b74b",
+    "id": "37bd0d4d-e95a-4ea9-a77c-e40f94add25c",
     "type": "lvl2",
     "url": "/docs/styled-system/utility-hooks/use-controllable#import",
     "hierarchy": {
@@ -7369,7 +7369,7 @@
   },
   {
     "content": "useControllableProp",
-    "id": "0ea910cb-19d5-4e12-9737-b0b8bc3bb38a",
+    "id": "9eb20891-3fd7-4ae3-8d1e-d1c78d5eb549",
     "type": "lvl2",
     "url": "/docs/styled-system/utility-hooks/use-controllable#usecontrollableprop",
     "hierarchy": {
@@ -7380,7 +7380,7 @@
   },
   {
     "content": "Usage",
-    "id": "e0c5ae6a-0b58-4946-a612-f2bc7a10bc4b",
+    "id": "ec210b1a-389b-40c3-b485-cd9d25cf8865",
     "type": "lvl3",
     "url": "/docs/styled-system/utility-hooks/use-controllable#usage",
     "hierarchy": {
@@ -7391,7 +7391,7 @@
   },
   {
     "content": "useControllableState",
-    "id": "754ab4bc-964e-4107-b6db-466de9280ca2",
+    "id": "5256ce9b-994a-4bfb-9db0-255b5d19f0a6",
     "type": "lvl2",
     "url": "/docs/styled-system/utility-hooks/use-controllable#usecontrollablestate",
     "hierarchy": {
@@ -7402,7 +7402,7 @@
   },
   {
     "content": "Usage",
-    "id": "411010f4-5174-4974-8599-da3593c9e590",
+    "id": "9ee51ebe-537d-44f3-ad91-6aa7f191200a",
     "type": "lvl3",
     "url": "/docs/styled-system/utility-hooks/use-controllable#usage-1",
     "hierarchy": {
@@ -7413,7 +7413,7 @@
   },
   {
     "content": "Contextual feedback and State updates",
-    "id": "f84d5606-2fea-4a2a-896b-0c9b4ef9d8bd",
+    "id": "fc9d5a7e-ebe1-4649-80c2-f280c700119b",
     "type": "lvl3",
     "url": "/docs/styled-system/utility-hooks/use-controllable#contextual-feedback-and-state-updates",
     "hierarchy": {
@@ -7424,7 +7424,7 @@
   },
   {
     "content": "Props",
-    "id": "b279dd01-1239-49d7-a0dd-9fd7abf8c997",
+    "id": "88dc8f3f-47ff-4802-9115-7eb4f97a4bea",
     "type": "lvl2",
     "url": "/docs/styled-system/utility-hooks/use-controllable#props",
     "hierarchy": {
@@ -7435,21 +7435,21 @@
   },
   {
     "content": "useDisclosure",
-    "id": "beb824b1-6fb7-4f2c-8272-7ae3d16c75bb",
+    "id": "e14b7aa3-1cf4-4b6f-8392-14d7625cd0e9",
     "type": "lvl1",
     "url": "/docs/styled-system/utility-hooks/use-disclosure",
     "hierarchy": { "lvl1": "useDisclosure" }
   },
   {
     "content": "Import",
-    "id": "06898f69-e43f-4eff-bf53-d0365ba7e7fe",
+    "id": "b9cb8ef1-2e00-4d0e-a1ca-fcdb2ff4e80c",
     "type": "lvl2",
     "url": "/docs/styled-system/utility-hooks/use-disclosure#import",
     "hierarchy": { "lvl1": "useDisclosure", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Return value",
-    "id": "d6baf3c4-c889-4583-a865-68fbdc90246b",
+    "id": "78b2d0de-d972-40e2-8ace-962585e1bd76",
     "type": "lvl2",
     "url": "/docs/styled-system/utility-hooks/use-disclosure#return-value",
     "hierarchy": {
@@ -7460,35 +7460,35 @@
   },
   {
     "content": "Usage",
-    "id": "f705bd1a-abb6-4254-a2df-853c3a2ef2b1",
+    "id": "560a5fd7-f9d9-4e59-98d1-b281b6d7d65e",
     "type": "lvl2",
     "url": "/docs/styled-system/utility-hooks/use-disclosure#usage",
     "hierarchy": { "lvl1": "useDisclosure", "lvl2": "Usage", "lvl3": null }
   },
   {
     "content": "Parameters",
-    "id": "81f60fa8-2d69-461c-91d0-89f2f652f641",
+    "id": "b82c46da-08aa-46aa-b093-e04bae31afbf",
     "type": "lvl2",
     "url": "/docs/styled-system/utility-hooks/use-disclosure#parameters",
     "hierarchy": { "lvl1": "useDisclosure", "lvl2": "Parameters", "lvl3": null }
   },
   {
     "content": "useMediaQuery",
-    "id": "1a7729f4-6d52-48b7-aa7d-9a99ef2b0d9a",
+    "id": "092aa20c-4689-4a1e-af53-42d83af08f80",
     "type": "lvl1",
     "url": "/docs/styled-system/utility-hooks/use-media-query",
     "hierarchy": { "lvl1": "useMediaQuery" }
   },
   {
     "content": "Import",
-    "id": "26cab758-5ec5-4da1-ad47-d9fc2579f536",
+    "id": "b8a84de2-f91a-47dc-a844-5a26620c415d",
     "type": "lvl2",
     "url": "/docs/styled-system/utility-hooks/use-media-query#import",
     "hierarchy": { "lvl1": "useMediaQuery", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Return value",
-    "id": "8a63103e-4df7-400e-9aba-30e99a9d3aec",
+    "id": "a0154940-bb12-42e6-8f10-3e7077b8510c",
     "type": "lvl2",
     "url": "/docs/styled-system/utility-hooks/use-media-query#return-value",
     "hierarchy": {
@@ -7499,28 +7499,28 @@
   },
   {
     "content": "Usage",
-    "id": "5fe819aa-1b58-441f-b1dd-d997cfc18fc9",
+    "id": "4a874a25-e5f3-461f-b20a-1be82920673f",
     "type": "lvl2",
     "url": "/docs/styled-system/utility-hooks/use-media-query#usage",
     "hierarchy": { "lvl1": "useMediaQuery", "lvl2": "Usage", "lvl3": null }
   },
   {
     "content": "useMergeRefs",
-    "id": "d61cb7f4-4dcf-4b32-9616-4ed928fb088c",
+    "id": "5c143e36-7619-4b1f-bff7-9030caf05a5d",
     "type": "lvl1",
     "url": "/docs/styled-system/utility-hooks/use-merge-refs",
     "hierarchy": { "lvl1": "useMergeRefs" }
   },
   {
     "content": "Import",
-    "id": "db783ae5-15e1-4ec8-8c89-00601370bcc4",
+    "id": "419a0c1e-ba67-487e-94e4-994341855505",
     "type": "lvl2",
     "url": "/docs/styled-system/utility-hooks/use-merge-refs#import",
     "hierarchy": { "lvl1": "useMergeRefs", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Return value",
-    "id": "9718ed2d-1431-44f1-b9d5-674372a38a75",
+    "id": "86e108eb-e855-4794-85c3-8fe6863bda08",
     "type": "lvl2",
     "url": "/docs/styled-system/utility-hooks/use-merge-refs#return-value",
     "hierarchy": {
@@ -7531,14 +7531,14 @@
   },
   {
     "content": "Usage",
-    "id": "79a8428d-0820-4f67-89b5-57ff82a750eb",
+    "id": "7d3db9d2-b27a-45d7-870d-5f22c810dfe8",
     "type": "lvl2",
     "url": "/docs/styled-system/utility-hooks/use-merge-refs#usage",
     "hierarchy": { "lvl1": "useMergeRefs", "lvl2": "Usage", "lvl3": null }
   },
   {
     "content": "Usage combining with another Chakra-UI hooks",
-    "id": "518c0fb4-eafe-4d1b-a7e6-e57c5f6ec8f6",
+    "id": "5fa264ff-c635-4581-b72b-6b5f79992eec",
     "type": "lvl3",
     "url": "/docs/styled-system/utility-hooks/use-merge-refs#usage-combining-with-another-chakra-ui-hooks",
     "hierarchy": {
@@ -7549,28 +7549,28 @@
   },
   {
     "content": "useOutsideClick",
-    "id": "6bf1e1ed-5743-4bc7-9d30-1d88d46599be",
+    "id": "ec0b16e2-c158-4356-b902-8577ce0659ee",
     "type": "lvl1",
     "url": "/docs/styled-system/utility-hooks/use-outside-click",
     "hierarchy": { "lvl1": "useOutsideClick" }
   },
   {
     "content": "Import",
-    "id": "4d5328db-8cf6-4cdf-a25b-d564c86a4480",
+    "id": "eec6225b-2843-4209-8975-be7a6e17a296",
     "type": "lvl2",
     "url": "/docs/styled-system/utility-hooks/use-outside-click#import",
     "hierarchy": { "lvl1": "useOutsideClick", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Usage",
-    "id": "df27179b-ed77-473e-b128-65202b7ea257",
+    "id": "267a9f6d-ba66-4bad-8f44-2375782682bf",
     "type": "lvl2",
     "url": "/docs/styled-system/utility-hooks/use-outside-click#usage",
     "hierarchy": { "lvl1": "useOutsideClick", "lvl2": "Usage", "lvl3": null }
   },
   {
     "content": "Parameters",
-    "id": "47160c14-285d-4fd5-b1d7-adc52e11fbb5",
+    "id": "86fbc0fd-d662-4284-8e0c-168c0b0081b3",
     "type": "lvl2",
     "url": "/docs/styled-system/utility-hooks/use-outside-click#parameters",
     "hierarchy": {
@@ -7581,14 +7581,14 @@
   },
   {
     "content": "usePrefersReducedMotion",
-    "id": "c9685500-1a28-4fd1-8ea3-5c75acd3f3bf",
+    "id": "ca15707a-b870-4e1c-8128-f200d92c804c",
     "type": "lvl1",
     "url": "/docs/styled-system/utility-hooks/use-prefers-reduced-motion",
     "hierarchy": { "lvl1": "usePrefersReducedMotion" }
   },
   {
     "content": "Import",
-    "id": "af8881ce-9cb3-42a7-a557-df2bdb56a2cf",
+    "id": "1aef07f6-a4ff-4188-b89b-38166b53c475",
     "type": "lvl2",
     "url": "/docs/styled-system/utility-hooks/use-prefers-reduced-motion#import",
     "hierarchy": {
@@ -7599,7 +7599,7 @@
   },
   {
     "content": "Return value",
-    "id": "ae26c82f-7cc5-4e44-bd8d-a3b7fd9db938",
+    "id": "8610d65c-79f8-4b21-ad12-16c7d713523c",
     "type": "lvl2",
     "url": "/docs/styled-system/utility-hooks/use-prefers-reduced-motion#return-value",
     "hierarchy": {
@@ -7610,7 +7610,7 @@
   },
   {
     "content": "Usage",
-    "id": "60c8528c-889b-4660-9fef-49a3e50b2a4b",
+    "id": "bc2ee505-6809-4d92-a107-a6e99205d884",
     "type": "lvl2",
     "url": "/docs/styled-system/utility-hooks/use-prefers-reduced-motion#usage",
     "hierarchy": {
@@ -7621,70 +7621,70 @@
   },
   {
     "content": "useTheme",
-    "id": "0f5c84b4-343f-41af-a7f7-409842afafd7",
+    "id": "cfc24112-045e-401e-bf6e-d0d1fa338030",
     "type": "lvl1",
     "url": "/docs/styled-system/utility-hooks/use-theme",
     "hierarchy": { "lvl1": "useTheme" }
   },
   {
     "content": "Import",
-    "id": "190365f4-3066-46ed-9119-cf9906716d90",
+    "id": "09a7845e-3ceb-418e-aa08-b27ab898a9d9",
     "type": "lvl2",
     "url": "/docs/styled-system/utility-hooks/use-theme#import",
     "hierarchy": { "lvl1": "useTheme", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Return value",
-    "id": "4f3de0d6-76e5-49ed-a495-6da574669987",
+    "id": "6589d945-ab36-4f44-9b47-bf5d34fb44ef",
     "type": "lvl2",
     "url": "/docs/styled-system/utility-hooks/use-theme#return-value",
     "hierarchy": { "lvl1": "useTheme", "lvl2": "Return value", "lvl3": null }
   },
   {
     "content": "Usage",
-    "id": "9294903a-9357-45be-a7a2-fe25324de7da",
+    "id": "29543f42-7e6c-478b-aeaa-7d2719bb4832",
     "type": "lvl2",
     "url": "/docs/styled-system/utility-hooks/use-theme#usage",
     "hierarchy": { "lvl1": "useTheme", "lvl2": "Usage", "lvl3": null }
   },
   {
     "content": "useToken",
-    "id": "179b1494-3bfd-4c0f-8063-384fdd192e6c",
+    "id": "ffc9b0f8-8749-4f8e-ac2e-c4ee9ee43aaf",
     "type": "lvl1",
     "url": "/docs/styled-system/utility-hooks/use-token",
     "hierarchy": { "lvl1": "useToken" }
   },
   {
     "content": "Import",
-    "id": "08c693b0-3e2a-4816-b958-d21b1699fc3b",
+    "id": "1e227e7e-eec2-4f55-b9ce-d8cbdd8dd5ad",
     "type": "lvl2",
     "url": "/docs/styled-system/utility-hooks/use-token#import",
     "hierarchy": { "lvl1": "useToken", "lvl2": "Import", "lvl3": null }
   },
   {
     "content": "Return value",
-    "id": "3dff4932-a265-49d8-8607-31ef36e6a9b5",
+    "id": "878cb2ec-82c2-4966-a766-ba2bd9644ba2",
     "type": "lvl2",
     "url": "/docs/styled-system/utility-hooks/use-token#return-value",
     "hierarchy": { "lvl1": "useToken", "lvl2": "Return value", "lvl3": null }
   },
   {
     "content": "Usage",
-    "id": "02d34c2b-e1d4-4adf-8284-9540b91ecab4",
+    "id": "765803ea-6b1c-44b2-9686-7b1d86a645d5",
     "type": "lvl2",
     "url": "/docs/styled-system/utility-hooks/use-token#usage",
     "hierarchy": { "lvl1": "useToken", "lvl2": "Usage", "lvl3": null }
   },
   {
     "content": "FAQ",
-    "id": "c71ce594-df67-4a93-b305-cf7e24123d7f",
+    "id": "e57e3061-d979-4dc6-ae36-9d2f32c718a2",
     "type": "lvl1",
     "url": "/faq/",
     "hierarchy": { "lvl1": "FAQ" }
   },
   {
     "content": "Is there a Datepicker in Chakra UI?",
-    "id": "339035ba-bdf6-4d3a-aead-fee8a8ad4ee0",
+    "id": "fcce668f-b5bf-4f49-ab2e-959e510dc414",
     "type": "lvl2",
     "url": "/faq/#is-there-a-datepicker-in-chakra-ui",
     "hierarchy": {
@@ -7695,7 +7695,7 @@
   },
   {
     "content": "Tooltip does not work around disabled Button",
-    "id": "19efe4b7-0efe-41a7-aec4-94c3cf6c80e7",
+    "id": "9cadaf49-345b-40a4-a74a-cc4d7edf04a5",
     "type": "lvl2",
     "url": "/faq/#tooltip-does-not-work-around-disabled-button",
     "hierarchy": {
@@ -7706,14 +7706,14 @@
   },
   {
     "content": "Guide to creating Components",
-    "id": "5c0885d3-c669-4835-bd8a-f00fb0030217",
+    "id": "2d2e57c6-e53f-4092-aada-9cd38fe61f95",
     "type": "lvl1",
     "url": "/guides/advanced/component-guide",
     "hierarchy": { "lvl1": "Guide to creating Components" }
   },
   {
     "content": "1. Share your ideas",
-    "id": "1695e05b-c6e8-4b8f-b125-dade05ce590f",
+    "id": "f5794ec5-2a84-426a-a597-ad53562bd5e7",
     "type": "lvl2",
     "url": "/guides/advanced/component-guide#1-share-your-ideas",
     "hierarchy": {
@@ -7724,7 +7724,7 @@
   },
   {
     "content": "2. Setup the component package",
-    "id": "0220b857-becf-4093-b0c8-4583c1b82fe3",
+    "id": "d52d3a1c-9b81-4329-a146-a4d107bb281e",
     "type": "lvl2",
     "url": "/guides/advanced/component-guide#2-setup-the-component-package",
     "hierarchy": {
@@ -7735,7 +7735,7 @@
   },
   {
     "content": "3. Build the component or hook",
-    "id": "4912e605-38bb-4648-afbe-c4ed818076bd",
+    "id": "c861eb94-fe3a-46c3-bdc4-5f11b72d844e",
     "type": "lvl2",
     "url": "/guides/advanced/component-guide#3-build-the-component-or-hook",
     "hierarchy": {
@@ -7746,7 +7746,7 @@
   },
   {
     "content": "General",
-    "id": "2255186f-c931-49b6-bbf0-84ea1bdcd0f4",
+    "id": "fc43e13d-7811-4a09-a1db-12f09332c38c",
     "type": "lvl3",
     "url": "/guides/advanced/component-guide#general",
     "hierarchy": {
@@ -7757,7 +7757,7 @@
   },
   {
     "content": "Hooks",
-    "id": "e98bd76c-a102-44a7-b385-4ccd11fc12f9",
+    "id": "fa9542a0-ca73-420f-a06d-7be8b2273037",
     "type": "lvl3",
     "url": "/guides/advanced/component-guide#hooks",
     "hierarchy": {
@@ -7768,7 +7768,7 @@
   },
   {
     "content": "TypeScript",
-    "id": "8a27275e-7536-4bb3-b495-b7995ffd0463",
+    "id": "a89b905c-a9b6-4b23-9a1d-eadb61ce059e",
     "type": "lvl3",
     "url": "/guides/advanced/component-guide#typescript",
     "hierarchy": {
@@ -7779,7 +7779,7 @@
   },
   {
     "content": "4. Build and Test",
-    "id": "7f6421b9-e3b2-4fc7-903f-edb83fc43db8",
+    "id": "38dfa064-c158-4edb-ae6e-072025ff2308",
     "type": "lvl2",
     "url": "/guides/advanced/component-guide#4-build-and-test",
     "hierarchy": {
@@ -7790,7 +7790,7 @@
   },
   {
     "content": "Testing Checklist",
-    "id": "1ac98812-7d6c-44c7-a62d-fad931e3d7b6",
+    "id": "fe2f56fb-3fae-484d-bf32-97811d0fa6b5",
     "type": "lvl3",
     "url": "/guides/advanced/component-guide#testing-checklist",
     "hierarchy": {
@@ -7801,7 +7801,7 @@
   },
   {
     "content": "5. Documentation",
-    "id": "6642f06d-2919-4200-839d-b3350505c48b",
+    "id": "90ee4b70-e3e8-40c9-99b5-3e1fdfcbb862",
     "type": "lvl2",
     "url": "/guides/advanced/component-guide#5-documentation",
     "hierarchy": {
@@ -7812,7 +7812,7 @@
   },
   {
     "content": "Resources",
-    "id": "e1b6bbbe-0006-42c2-a66e-6345912016bc",
+    "id": "b8de253c-411a-4d16-8e11-392e75e266a0",
     "type": "lvl2",
     "url": "/guides/advanced/component-guide#resources",
     "hierarchy": {
@@ -7823,7 +7823,7 @@
   },
   {
     "content": "TypeScript",
-    "id": "8999d382-b87a-43d4-9a57-e3ef59332e34",
+    "id": "bce8ecfb-d55d-462c-b077-108b22e50b10",
     "type": "lvl3",
     "url": "/guides/advanced/component-guide#typescript-1",
     "hierarchy": {
@@ -7834,7 +7834,7 @@
   },
   {
     "content": "Testing",
-    "id": "cefe59a5-f783-460a-9a5e-29021cfcb3be",
+    "id": "29cbdc43-75b7-4fd1-8d29-dd8c5ffed124",
     "type": "lvl3",
     "url": "/guides/advanced/component-guide#testing",
     "hierarchy": {
@@ -7845,14 +7845,14 @@
   },
   {
     "content": "Contributing to Chakra UI",
-    "id": "918a8db0-f9e4-4784-aaee-26e6b7df3661",
+    "id": "5fb316cb-bb18-4fb4-a7bc-97b0fa0ff158",
     "type": "lvl1",
     "url": "/guides/advanced/contributing",
     "hierarchy": { "lvl1": "Contributing to Chakra UI" }
   },
   {
     "content": "Setup the Project",
-    "id": "62348e89-91d4-4504-8e8d-74df17d997ad",
+    "id": "24d73c6f-37e8-49d8-ad71-3d858c714f51",
     "type": "lvl2",
     "url": "/guides/advanced/contributing#setup-the-project",
     "hierarchy": {
@@ -7863,7 +7863,7 @@
   },
   {
     "content": "Commands",
-    "id": "00cbc9d9-6a0b-40af-afc4-3cafc5bdc70d",
+    "id": "fb5a6471-c4f2-4e0f-bdbb-075ef168f687",
     "type": "lvl3",
     "url": "/guides/advanced/contributing#commands",
     "hierarchy": {
@@ -7874,7 +7874,7 @@
   },
   {
     "content": "Updating the docs for new release",
-    "id": "8a7927a5-3e7f-49bd-a28b-7b1fa1cbf21d",
+    "id": "94fe54d2-180a-49c0-9bbf-039babbd00e3",
     "type": "lvl2",
     "url": "/guides/advanced/contributing#updating-the-docs-for-new-release",
     "hierarchy": {
@@ -7885,7 +7885,7 @@
   },
   {
     "content": "Commit Convention",
-    "id": "99c2eaf6-0065-49b5-91d4-7304e58a6bbb",
+    "id": "a709a5ad-5d1b-4d77-870d-8a411372fcc4",
     "type": "lvl3",
     "url": "/guides/advanced/contributing#commit-convention",
     "hierarchy": {
@@ -7896,7 +7896,7 @@
   },
   {
     "content": "Steps to PR",
-    "id": "3eab0bcd-e6f5-4381-9836-43960227068b",
+    "id": "4c38593d-1f59-483e-85b6-87346f7dbd50",
     "type": "lvl3",
     "url": "/guides/advanced/contributing#steps-to-pr",
     "hierarchy": {
@@ -7907,7 +7907,7 @@
   },
   {
     "content": "Want to write a blog post or tutorial",
-    "id": "4d722fc8-f343-430e-88f4-d54a3f5a7363",
+    "id": "4388f48a-2354-420f-a38e-f15152ff0fba",
     "type": "lvl2",
     "url": "/guides/advanced/contributing#want-to-write-a-blog-post-or-tutorial",
     "hierarchy": {
@@ -7918,7 +7918,7 @@
   },
   {
     "content": "Want to help improve the docs?",
-    "id": "fae542cf-80f6-46c0-9a1f-d7f87e2a36c9",
+    "id": "dc677467-0948-4e01-ba9c-d50fb36b3e0c",
     "type": "lvl2",
     "url": "/guides/advanced/contributing#want-to-help-improve-the-docs",
     "hierarchy": {
@@ -7929,7 +7929,7 @@
   },
   {
     "content": "License",
-    "id": "c877c18b-586a-45ff-9dc1-ecf5b6f7d791",
+    "id": "4127b399-03d6-4fd4-b328-974893eb8135",
     "type": "lvl2",
     "url": "/guides/advanced/contributing#license",
     "hierarchy": {
@@ -7940,14 +7940,14 @@
   },
   {
     "content": "How to Create a Guide",
-    "id": "75ceca14-87dd-4a80-908d-4058c79936b5",
+    "id": "495fd4fa-280a-4dc0-96e8-314916f25ed9",
     "type": "lvl1",
     "url": "/guides/advanced/how-to-create-a-guide",
     "hierarchy": { "lvl1": "How to Create a Guide" }
   },
   {
     "content": "Create your guide file",
-    "id": "5da2cb0c-99b8-4d7d-aac7-52730c574c88",
+    "id": "77bd1bb2-7cfd-478d-b53e-123cfa7e5e54",
     "type": "lvl2",
     "url": "/guides/advanced/how-to-create-a-guide#create-your-guide-file",
     "hierarchy": {
@@ -7958,7 +7958,7 @@
   },
   {
     "content": "Add frontmatter",
-    "id": "0daf0704-01d0-420f-9dd5-1c7e458a3467",
+    "id": "5b7f58e7-a56f-4261-8b32-df482b98c437",
     "type": "lvl2",
     "url": "/guides/advanced/how-to-create-a-guide#add-frontmatter",
     "hierarchy": {
@@ -7969,7 +7969,7 @@
   },
   {
     "content": "Write your guide content",
-    "id": "dda4e5ce-61e4-4583-a30c-a2e93d8be53e",
+    "id": "df417e2a-d706-4c74-b2b3-4143d4e38559",
     "type": "lvl2",
     "url": "/guides/advanced/how-to-create-a-guide#write-your-guide-content",
     "hierarchy": {
@@ -7980,7 +7980,7 @@
   },
   {
     "content": "Open a pull request",
-    "id": "f3d9b2a2-ceeb-46c6-b9f7-d7f575967538",
+    "id": "90bad65e-295b-438e-81a3-52306c50d436",
     "type": "lvl2",
     "url": "/guides/advanced/how-to-create-a-guide#open-a-pull-request",
     "hierarchy": {
@@ -7991,14 +7991,14 @@
   },
   {
     "content": "Chakra UI + Next.js",
-    "id": "14cc35cb-079e-4295-8cff-ffbc6800777d",
+    "id": "de32bfaa-8a98-41cf-8ebc-2d665b246426",
     "type": "lvl1",
     "url": "/guides/advanced/with-nextjs",
     "hierarchy": { "lvl1": "Chakra UI + Next.js" }
   },
   {
     "content": "Chakra",
-    "id": "d3cc617c-4058-49a7-bcac-d22045f46424",
+    "id": "499154e3-9ad3-4931-ba49-a51d08def308",
     "type": "lvl2",
     "url": "/guides/advanced/with-nextjs#chakra",
     "hierarchy": {
@@ -8009,7 +8009,7 @@
   },
   {
     "content": "Chakra providers",
-    "id": "a9978961-92b2-4703-bbcc-6dc038fe6804",
+    "id": "6a9ceb47-ff91-4228-86b9-5bdba09a6d64",
     "type": "lvl3",
     "url": "/guides/advanced/with-nextjs#chakra-providers",
     "hierarchy": {
@@ -8020,14 +8020,14 @@
   },
   {
     "content": "Comparison",
-    "id": "b6a9336e-1cd0-4857-b274-9e675d30038a",
+    "id": "fd0e3cbb-1494-4ab5-92b2-4c0b0283adee",
     "type": "lvl1",
     "url": "/guides/comparison",
     "hierarchy": { "lvl1": "Comparison" }
   },
   {
     "content": "How is Chakra different from Tailwind CSS?",
-    "id": "430609cf-565a-4969-8794-826a78713f3c",
+    "id": "f40603cc-0a3c-4873-8400-8e00fdad3cc8",
     "type": "lvl2",
     "url": "/guides/comparison#how-is-chakra-different-from-tailwind-css",
     "hierarchy": {
@@ -8038,7 +8038,7 @@
   },
   {
     "content": "Overview 🚩",
-    "id": "227d0b7b-b75b-469f-8aa2-57e35c8d9230",
+    "id": "4b58859a-8e5f-422a-8309-66b19625d942",
     "type": "lvl3",
     "url": "/guides/comparison#overview-🚩",
     "hierarchy": {
@@ -8049,7 +8049,7 @@
   },
   {
     "content": "Learning Curve 🌀",
-    "id": "c791e19c-a6e5-466e-bbc7-946ccdca0ab7",
+    "id": "d56efab8-481a-4579-93af-80fa8c3f765d",
     "type": "lvl3",
     "url": "/guides/comparison#learning-curve-🌀",
     "hierarchy": {
@@ -8060,7 +8060,7 @@
   },
   {
     "content": "Responsive Styles 📱",
-    "id": "2f458d88-2afa-4ceb-bfb5-ad4063b4331a",
+    "id": "23b01f59-e941-45e5-a7be-5a4729d4c16e",
     "type": "lvl3",
     "url": "/guides/comparison#responsive-styles-📱",
     "hierarchy": {
@@ -8071,7 +8071,7 @@
   },
   {
     "content": "Style Overrides 💫",
-    "id": "76bf6efd-9528-4e19-9220-d16cf2d49a9a",
+    "id": "a593fc15-4609-4a15-a9a6-0a601ad7d4e8",
     "type": "lvl3",
     "url": "/guides/comparison#style-overrides-💫",
     "hierarchy": {
@@ -8082,7 +8082,7 @@
   },
   {
     "content": "Accessibility ♿️",
-    "id": "cbade6c7-358a-4c24-8faf-48a093f29815",
+    "id": "3b933c3f-ad44-440e-8fa2-737bf1c7156f",
     "type": "lvl3",
     "url": "/guides/comparison#accessibility-♿️",
     "hierarchy": {
@@ -8093,7 +8093,7 @@
   },
   {
     "content": "Dark Mode 🌜",
-    "id": "e6b97568-3076-443a-b239-104c38e90ab9",
+    "id": "a861b8b5-1359-454c-89d2-96dc00fedfbe",
     "type": "lvl3",
     "url": "/guides/comparison#dark-mode-🌜",
     "hierarchy": {
@@ -8104,7 +8104,7 @@
   },
   {
     "content": "How is Chakra different from Theme UI?",
-    "id": "0240b5ba-5284-4234-9ea3-a6a300d746d1",
+    "id": "7af58382-289d-4dab-98b6-a1358bcbde70",
     "type": "lvl2",
     "url": "/guides/comparison#how-is-chakra-different-from-theme-ui",
     "hierarchy": {
@@ -8115,7 +8115,7 @@
   },
   {
     "content": "How is Chakra different from Material UI?",
-    "id": "acffc807-3ff6-46ae-8ba9-f2bc27416de3",
+    "id": "deb31282-3b30-4225-83ba-de953016f354",
     "type": "lvl2",
     "url": "/guides/comparison#how-is-chakra-different-from-material-ui",
     "hierarchy": {
@@ -8126,7 +8126,7 @@
   },
   {
     "content": "How is Chakra different from Ant Design?",
-    "id": "c12d03c6-bea8-4ec1-9357-f37e90b526c9",
+    "id": "dc462236-07d2-4fc8-acc0-3ffd415645e0",
     "type": "lvl2",
     "url": "/guides/comparison#how-is-chakra-different-from-ant-design",
     "hierarchy": {
@@ -8137,7 +8137,7 @@
   },
   {
     "content": "Styling Components",
-    "id": "ffa6d5da-a822-4cfe-94e6-affb944e819d",
+    "id": "5ad79bfa-a336-4f53-90b4-2e451d55c521",
     "type": "lvl3",
     "url": "/guides/comparison#styling-components",
     "hierarchy": {
@@ -8148,7 +8148,7 @@
   },
   {
     "content": "Theming and Customizing",
-    "id": "0a0e2aef-6444-41a8-adb2-8e175f550fce",
+    "id": "2e1154ea-f8fd-4a35-9f90-d6468e64e1e2",
     "type": "lvl3",
     "url": "/guides/comparison#theming-and-customizing",
     "hierarchy": {
@@ -8159,7 +8159,7 @@
   },
   {
     "content": "The Runtime Trade-off ⚠️",
-    "id": "fcd9f962-090a-4476-898d-4bcca2a3fae5",
+    "id": "9c2dc332-5dc4-4e8b-8939-93b1acda415d",
     "type": "lvl2",
     "url": "/guides/comparison#the-runtime-trade-off-⚠️",
     "hierarchy": {
@@ -8170,7 +8170,7 @@
   },
   {
     "content": "The Community 💖",
-    "id": "39b4eae7-63c7-4d47-923c-be41cc6d10d3",
+    "id": "307a9ddd-75cd-4253-97ee-e6a4cacd6e81",
     "type": "lvl2",
     "url": "/guides/comparison#the-community-💖",
     "hierarchy": {
@@ -8181,7 +8181,7 @@
   },
   {
     "content": "Community Remarks 💬",
-    "id": "668b257f-8034-498c-b1a6-044357b85471",
+    "id": "1a40f7fc-500d-49b6-86a2-24bb82b0287e",
     "type": "lvl2",
     "url": "/guides/comparison#community-remarks-💬",
     "hierarchy": {
@@ -8192,14 +8192,14 @@
   },
   {
     "content": "First Steps",
-    "id": "41246fe1-3c10-448f-a999-144bf14c4faa",
+    "id": "80a473f6-b471-452f-b221-b256b6a95e57",
     "type": "lvl1",
     "url": "/guides/first-steps",
     "hierarchy": { "lvl1": "First Steps" }
   },
   {
     "content": "Watch the Egghead Course",
-    "id": "7ef0acf0-a77f-4e99-8b63-d2279042de5f",
+    "id": "1866687b-7f54-41c0-abc3-d1c79b27d618",
     "type": "lvl2",
     "url": "/guides/first-steps#watch-the-egghead-course",
     "hierarchy": {
@@ -8210,7 +8210,7 @@
   },
   {
     "content": "Framework Guide",
-    "id": "d72b7b12-93c7-4947-a695-f840da02c189",
+    "id": "775eb9b9-e7c1-4335-bff7-9becebe27c72",
     "type": "lvl2",
     "url": "/guides/first-steps#framework-guide",
     "hierarchy": {
@@ -8221,28 +8221,28 @@
   },
   {
     "content": "Contributing",
-    "id": "afb1d001-1d69-44e6-9c04-eeb695d59b93",
+    "id": "8599b80d-c925-46f2-a5fc-cf6a39436af7",
     "type": "lvl2",
     "url": "/guides/first-steps#contributing",
     "hierarchy": { "lvl1": "First Steps", "lvl2": "Contributing", "lvl3": null }
   },
   {
     "content": "Blitz JS",
-    "id": "a9ec81a0-21dc-4f74-9fe7-da0c0c5b7549",
+    "id": "0c150baf-30fe-40fc-b3de-d9db1cfc5cbf",
     "type": "lvl1",
     "url": "/guides/getting-started/blitzjs-guide",
     "hierarchy": { "lvl1": "Blitz JS" }
   },
   {
     "content": "1. Installation",
-    "id": "61993f68-77d5-4edc-acb7-0f083caa9519",
+    "id": "f7ebc723-ba31-4b46-b964-957cc148dbb0",
     "type": "lvl3",
     "url": "/guides/getting-started/blitzjs-guide#1-installation",
     "hierarchy": { "lvl1": "Blitz JS", "lvl2": null, "lvl3": "1. Installation" }
   },
   {
     "content": "ChakraProvider Props",
-    "id": "7f8b6c4f-c8c1-42aa-87be-e216879f8a36",
+    "id": "bfd6be3d-cf3b-4611-9eea-d3627bdc13aa",
     "type": "lvl3",
     "url": "/guides/getting-started/blitzjs-guide#chakraprovider-props",
     "hierarchy": {
@@ -8253,7 +8253,7 @@
   },
   {
     "content": "2. Optional Setup",
-    "id": "327d0b6f-0aaa-4dfd-b360-0c41c982f635",
+    "id": "71db57b2-f7a4-461e-ae07-befe62cef70e",
     "type": "lvl4",
     "url": "/guides/getting-started/blitzjs-guide#2-optional-setup",
     "hierarchy": {
@@ -8264,7 +8264,7 @@
   },
   {
     "content": "Notes on TypeScript 🚨",
-    "id": "3a03d55b-e82d-485e-ad48-3412097ca2c1",
+    "id": "c7590c30-ffca-4f6e-9fea-c6cc0961e5d1",
     "type": "lvl4",
     "url": "/guides/getting-started/blitzjs-guide#notes-on-typescript-🚨",
     "hierarchy": {
@@ -8275,14 +8275,14 @@
   },
   {
     "content": "Create React App",
-    "id": "ecea31c3-4a77-4076-ac97-b58f4a944575",
+    "id": "8804b4e2-406c-4b7f-a503-8efab54b40e7",
     "type": "lvl1",
     "url": "/guides/getting-started/cra-guide",
     "hierarchy": { "lvl1": "Create React App" }
   },
   {
     "content": "Automatic Installation",
-    "id": "4888a4d5-e4d0-4fa0-9e8f-1371cce01462",
+    "id": "58365287-4ecd-4508-8b6d-cd60e357bf71",
     "type": "lvl2",
     "url": "/guides/getting-started/cra-guide#automatic-installation",
     "hierarchy": {
@@ -8293,7 +8293,7 @@
   },
   {
     "content": "Usage",
-    "id": "425c9dcf-7aaf-4174-9a87-c443efa66fa4",
+    "id": "22a32545-9904-4e0e-938f-11e83e58b1b6",
     "type": "lvl3",
     "url": "/guides/getting-started/cra-guide#usage",
     "hierarchy": {
@@ -8304,7 +8304,7 @@
   },
   {
     "content": "What's included",
-    "id": "8f248cf7-139f-40e4-93bf-0ee42465385f",
+    "id": "43d65676-7a71-4896-8255-a867c9559d39",
     "type": "lvl3",
     "url": "/guides/getting-started/cra-guide#whats-included",
     "hierarchy": {
@@ -8315,7 +8315,7 @@
   },
   {
     "content": "Pre-install dependencies",
-    "id": "39d82dbc-02f2-4e85-aef1-a376b7ed897f",
+    "id": "30a4a6ec-70c2-415c-8c15-7f564f9c270b",
     "type": "lvl4",
     "url": "/guides/getting-started/cra-guide#pre-install-dependencies",
     "hierarchy": {
@@ -8326,7 +8326,7 @@
   },
   {
     "content": "Chakra-specific functionality",
-    "id": "6b48e948-e630-42d1-bd8f-35095e1c94e4",
+    "id": "bced8243-dae4-4d8b-9260-345d18df34c4",
     "type": "lvl4",
     "url": "/guides/getting-started/cra-guide#chakra-specific-functionality",
     "hierarchy": {
@@ -8337,7 +8337,7 @@
   },
   {
     "content": "Manual Installation",
-    "id": "f84fd3e4-eebf-42d6-a42c-04cec61c0779",
+    "id": "968ad24e-2e45-44e4-8e5a-193748d6d0a6",
     "type": "lvl2",
     "url": "/guides/getting-started/cra-guide#manual-installation",
     "hierarchy": {
@@ -8348,7 +8348,7 @@
   },
   {
     "content": "1. Installation",
-    "id": "4def4c9d-e820-4431-94ba-7936a0a03772",
+    "id": "ef413f81-7507-4b53-8ea2-644013ec612b",
     "type": "lvl3",
     "url": "/guides/getting-started/cra-guide#1-installation",
     "hierarchy": {
@@ -8359,7 +8359,7 @@
   },
   {
     "content": "2. Provider Setup",
-    "id": "7e446851-4c19-4beb-89ab-9f4581d0b4fe",
+    "id": "b3431fff-3b79-4181-b888-101a7c3e3ace",
     "type": "lvl3",
     "url": "/guides/getting-started/cra-guide#2-provider-setup",
     "hierarchy": {
@@ -8370,7 +8370,7 @@
   },
   {
     "content": "ChakraProvider Props",
-    "id": "257d8574-585c-46c1-9bea-a59dfa8fa284",
+    "id": "e67010da-4fd3-411d-9833-9a292e069d20",
     "type": "lvl3",
     "url": "/guides/getting-started/cra-guide#chakraprovider-props",
     "hierarchy": {
@@ -8381,7 +8381,7 @@
   },
   {
     "content": "3. Optional Setup",
-    "id": "81fc6eca-9a87-432f-835a-02a2c926ff56",
+    "id": "dcbdbedc-edd6-4c39-a1a6-ae5e072046f5",
     "type": "lvl3",
     "url": "/guides/getting-started/cra-guide#3-optional-setup",
     "hierarchy": {
@@ -8392,7 +8392,7 @@
   },
   {
     "content": "Notes on TypeScript 🚨",
-    "id": "02768959-a3b4-432e-a650-c15c1d7c65a0",
+    "id": "dbc01542-d867-4b45-8669-4aa75dc3c4f6",
     "type": "lvl4",
     "url": "/guides/getting-started/cra-guide#notes-on-typescript-🚨",
     "hierarchy": {
@@ -8403,35 +8403,35 @@
   },
   {
     "content": "Gatsby",
-    "id": "f6a3c0a3-7a9f-421e-8580-6bb331e992d5",
+    "id": "6bc44e2e-379d-4352-b4a0-9b7d21c8b209",
     "type": "lvl1",
     "url": "/guides/getting-started/gatsby-guide",
     "hierarchy": { "lvl1": "Gatsby" }
   },
   {
     "content": "Installation",
-    "id": "2c9c52d3-d02a-4dee-bb23-5695bbe91374",
+    "id": "fb37ad79-1110-4a57-8080-7367ba576323",
     "type": "lvl2",
     "url": "/guides/getting-started/gatsby-guide#installation",
     "hierarchy": { "lvl1": "Gatsby", "lvl2": "Installation", "lvl3": null }
   },
   {
     "content": "Usage",
-    "id": "f58cdaa1-234f-4fed-bf49-da4834a0ab11",
+    "id": "2421b3af-f7b5-474c-abd7-74e9fc66152f",
     "type": "lvl2",
     "url": "/guides/getting-started/gatsby-guide#usage",
     "hierarchy": { "lvl1": "Gatsby", "lvl2": "Usage", "lvl3": null }
   },
   {
     "content": "Migration Notes",
-    "id": "5a20e6ce-dad6-428e-96a1-dd15f6c0ca18",
+    "id": "2502df80-b9a4-4010-a6c3-b26cbb465b38",
     "type": "lvl2",
     "url": "/guides/getting-started/gatsby-guide#migration-notes",
     "hierarchy": { "lvl1": "Gatsby", "lvl2": "Migration Notes", "lvl3": null }
   },
   {
     "content": "From v1.x to v2.x",
-    "id": "8b85d1fc-829c-4075-9710-c85df233b79e",
+    "id": "04b79960-fa42-4642-a37e-55b58de9c7c6",
     "type": "lvl3",
     "url": "/guides/getting-started/gatsby-guide#from-v1x-to-v2x",
     "hierarchy": {
@@ -8442,7 +8442,7 @@
   },
   {
     "content": "From v0.8.x to v1.x",
-    "id": "78877d56-71f5-4e46-9e37-59551eadab30",
+    "id": "81f26eb5-836c-433c-94b1-6996237415c7",
     "type": "lvl3",
     "url": "/guides/getting-started/gatsby-guide#from-v08x-to-v1x",
     "hierarchy": {
@@ -8453,14 +8453,14 @@
   },
   {
     "content": "Getting Started with Nextjs",
-    "id": "4688fe9e-103c-4be7-99ca-386446e1e7e4",
+    "id": "70afd367-13c8-4844-a886-09637b687955",
     "type": "lvl1",
     "url": "/guides/getting-started/nextjs-guide",
     "hierarchy": { "lvl1": "Getting Started with Nextjs" }
   },
   {
     "content": "Installation",
-    "id": "86d12fe4-ba87-4e95-ae98-0543d35d8432",
+    "id": "b5bdd97a-4510-451c-9371-67ee57a7aeb7",
     "type": "lvl3",
     "url": "/guides/getting-started/nextjs-guide#installation",
     "hierarchy": {
@@ -8471,7 +8471,7 @@
   },
   {
     "content": "Provider Setup",
-    "id": "8d4c247d-1ec8-46c0-b671-1b3d655182a8",
+    "id": "1248ea48-5179-44e4-a30b-f4606cbc8ee0",
     "type": "lvl3",
     "url": "/guides/getting-started/nextjs-guide#provider-setup",
     "hierarchy": {
@@ -8482,7 +8482,7 @@
   },
   {
     "content": "Customizing theme",
-    "id": "2d979363-af96-4c4b-91f6-13024a402cb3",
+    "id": "18224538-8aa5-45ff-ab67-83052f6b74d5",
     "type": "lvl3",
     "url": "/guides/getting-started/nextjs-guide#customizing-theme",
     "hierarchy": {
@@ -8493,7 +8493,7 @@
   },
   {
     "content": "Color Mode Script",
-    "id": "c6376dbd-ee88-4a3a-a48c-162175c179a0",
+    "id": "e3dd2410-2b24-4b87-9e61-6ff802b40534",
     "type": "lvl3",
     "url": "/guides/getting-started/nextjs-guide#color-mode-script",
     "hierarchy": {
@@ -8504,7 +8504,7 @@
   },
   {
     "content": "Notes on TypeScript 🚨",
-    "id": "259c3a18-0bd5-4cee-8731-06675c9e60d7",
+    "id": "58c5e794-8a6b-4569-802e-51bc431b1db9",
     "type": "lvl4",
     "url": "/guides/getting-started/nextjs-guide#notes-on-typescript-🚨",
     "hierarchy": {
@@ -8515,7 +8515,7 @@
   },
   {
     "content": "ChakraProvider Props",
-    "id": "6834a139-2dda-4edc-a6ec-31de58ea0fc5",
+    "id": "5f7031f1-145b-47ca-a8dd-ae6d1b0335f9",
     "type": "lvl3",
     "url": "/guides/getting-started/nextjs-guide#chakraprovider-props",
     "hierarchy": {
@@ -8526,14 +8526,14 @@
   },
   {
     "content": "Redwood JS",
-    "id": "a327a77d-c121-4952-a0f9-a895d4ac2143",
+    "id": "88387c9b-a58b-4edc-acaa-5cdaa5f44f2b",
     "type": "lvl1",
     "url": "/guides/getting-started/redwoodjs-guide",
     "hierarchy": { "lvl1": "Redwood JS" }
   },
   {
     "content": "1. Installation",
-    "id": "be471d17-535a-49f7-b8e7-3882afb2db96",
+    "id": "8f9e1d22-67be-4591-b0e5-38e89d7febbc",
     "type": "lvl3",
     "url": "/guides/getting-started/redwoodjs-guide#1-installation",
     "hierarchy": {
@@ -8544,7 +8544,7 @@
   },
   {
     "content": "2. Provider Setup",
-    "id": "62d5077a-a8ca-4352-a43e-1a046996c255",
+    "id": "2aa9b8e5-d5ef-48f3-a22f-97ea139b6b34",
     "type": "lvl3",
     "url": "/guides/getting-started/redwoodjs-guide#2-provider-setup",
     "hierarchy": {
@@ -8555,7 +8555,7 @@
   },
   {
     "content": "ChakraProvider Props",
-    "id": "1b8d4615-f8a1-4cda-b71a-26146f49d8b7",
+    "id": "556214ef-d7e1-4425-8df6-da83d7179c08",
     "type": "lvl3",
     "url": "/guides/getting-started/redwoodjs-guide#chakraprovider-props",
     "hierarchy": {
@@ -8566,7 +8566,7 @@
   },
   {
     "content": "3. Optional Setup",
-    "id": "1b455460-52db-4f05-9a60-6d8922c4e476",
+    "id": "46d604c3-35ca-4d15-bd7a-c2a97a9c3649",
     "type": "lvl3",
     "url": "/guides/getting-started/redwoodjs-guide#3-optional-setup",
     "hierarchy": {
@@ -8577,7 +8577,7 @@
   },
   {
     "content": "Notes on TypeScript 🚨",
-    "id": "d974537e-d44b-42c3-b52a-66386b89ac13",
+    "id": "da6fd1c3-791c-402b-9eab-1ef3cf9ff132",
     "type": "lvl4",
     "url": "/guides/getting-started/redwoodjs-guide#notes-on-typescript-🚨",
     "hierarchy": {
@@ -8588,21 +8588,21 @@
   },
   {
     "content": "Remix",
-    "id": "08a72822-8636-4b9c-9a9b-977d8af73819",
+    "id": "48796ffa-c5c8-4b21-9894-6a391182c342",
     "type": "lvl1",
     "url": "/guides/getting-started/remix-guide",
     "hierarchy": { "lvl1": "Remix" }
   },
   {
     "content": "1. Installation",
-    "id": "c480395b-2410-495a-a6db-f95c4b0125bc",
+    "id": "0a372b3b-d4ea-45f4-a3f3-7c1f4817a23b",
     "type": "lvl3",
     "url": "/guides/getting-started/remix-guide#1-installation",
     "hierarchy": { "lvl1": "Remix", "lvl2": null, "lvl3": "1. Installation" }
   },
   {
     "content": "2. Provider Setup",
-    "id": "fc4bfeff-187b-418a-bb8a-82d25a1659e6",
+    "id": "59629f8a-4575-4ac0-9f0d-48ea450bc094",
     "type": "lvl3",
     "url": "/guides/getting-started/remix-guide#2-provider-setup",
     "hierarchy": {
@@ -8613,14 +8613,14 @@
   },
   {
     "content": "ChakraProvider Props",
-    "id": "ca83666b-dd64-4c5f-b862-8ca791df6e89",
+    "id": "fae5c99e-342f-4784-80bf-34c6e81beda9",
     "type": "lvl4",
     "url": "/guides/getting-started/remix-guide#chakraprovider-props",
     "hierarchy": { "lvl1": "Remix", "lvl2": "2. Provider Setup", "lvl3": null }
   },
   {
     "content": "3. Optional Setup",
-    "id": "5136f2d2-7258-46b3-8eb0-899bc0a0b5f1",
+    "id": "b110452c-ea07-48b3-9960-027964319f42",
     "type": "lvl3",
     "url": "/guides/getting-started/remix-guide#3-optional-setup",
     "hierarchy": {
@@ -8631,14 +8631,14 @@
   },
   {
     "content": "Notes on TypeScript 🚨",
-    "id": "3451839d-5b52-4639-b21d-2276feda1864",
+    "id": "5ba08d7d-7709-4c10-bd3c-6b37e6b2ecc1",
     "type": "lvl4",
     "url": "/guides/getting-started/remix-guide#notes-on-typescript-🚨",
     "hierarchy": { "lvl1": "Remix", "lvl2": "3. Optional Setup", "lvl3": null }
   },
   {
     "content": "4. Community boilerplates",
-    "id": "9d0f2a31-4100-4818-b183-6f7bfdd15e84",
+    "id": "13c1777c-8c2c-4a88-a561-a9cfccdf369e",
     "type": "lvl3",
     "url": "/guides/getting-started/remix-guide#4-community-boilerplates",
     "hierarchy": {
@@ -8649,42 +8649,42 @@
   },
   {
     "content": "Chakra UI + Capsize",
-    "id": "ed3dc60e-09f3-46a8-9813-ca57b69073b3",
+    "id": "f4c3c8ea-a497-4f7f-8d3a-10feda865d63",
     "type": "lvl1",
     "url": "/guides/integrations/with-capsize",
     "hierarchy": { "lvl1": "Chakra UI + Capsize" }
   },
   {
     "content": "Chakra UI + Formik",
-    "id": "5ca943ac-02c9-4621-9a8a-a01603ac54a5",
+    "id": "5f20fe3a-f582-4462-b85a-6904b59f3c48",
     "type": "lvl1",
     "url": "/guides/integrations/with-formik",
     "hierarchy": { "lvl1": "Chakra UI + Formik" }
   },
   {
     "content": "Chakra UI + Framer Motion",
-    "id": "c4116fac-dc80-464e-9fc5-891a3349e7cc",
+    "id": "2628c0a4-4f29-42b7-b475-1c6ae0615721",
     "type": "lvl1",
     "url": "/guides/integrations/with-framer",
     "hierarchy": { "lvl1": "Chakra UI + Framer Motion" }
   },
   {
     "content": "Chakra UI + React Hook Form",
-    "id": "2fb08c55-1a2d-4c3f-ac12-e5d4ba56ab8f",
+    "id": "818c4468-ca92-4930-9cb6-f6b2b9aaa80e",
     "type": "lvl1",
     "url": "/guides/integrations/with-hook-form",
     "hierarchy": { "lvl1": "Chakra UI + React Hook Form" }
   },
   {
     "content": "Chakra UI + React Table",
-    "id": "05916faf-a900-4829-8beb-b4240d4e27d2",
+    "id": "ecfae3fd-1056-4aa6-8f3c-c417c968bc8b",
     "type": "lvl1",
     "url": "/guides/integrations/with-react-table",
     "hierarchy": { "lvl1": "Chakra UI + React Table" }
   },
   {
     "content": "Imports",
-    "id": "f4950d4b-7bc0-4711-b0a3-a1c2cf9acbb0",
+    "id": "5c630106-d001-4d36-b6c0-b1277ba339c1",
     "type": "lvl2",
     "url": "/guides/integrations/with-react-table#imports",
     "hierarchy": {
@@ -8695,7 +8695,7 @@
   },
   {
     "content": "Usage",
-    "id": "84be694f-2887-4fc1-b9a5-32eb186b5759",
+    "id": "b1cfd117-795d-42a8-9a4b-d249c1268dc2",
     "type": "lvl2",
     "url": "/guides/integrations/with-react-table#usage",
     "hierarchy": {
@@ -8706,14 +8706,14 @@
   },
   {
     "content": "Chakra UI + Storybook",
-    "id": "abe9ea3f-a001-421f-b5e1-7ac8fb25896a",
+    "id": "03354705-8eec-4065-938b-f2d418fe48fa",
     "type": "lvl1",
     "url": "/guides/integrations/with-storybook",
     "hierarchy": { "lvl1": "Chakra UI + Storybook" }
   },
   {
     "content": "Installation",
-    "id": "a11aa508-12f6-4c00-9198-d154d278642a",
+    "id": "28d256b0-0ba5-43f6-8a84-0f4785549b67",
     "type": "lvl2",
     "url": "/guides/integrations/with-storybook#installation",
     "hierarchy": {
@@ -8724,7 +8724,7 @@
   },
   {
     "content": "Usage",
-    "id": "62975585-c542-4d77-8497-1283e0da65a0",
+    "id": "d1805a5c-f9e3-4504-9fcc-254dc095e3ed",
     "type": "lvl2",
     "url": "/guides/integrations/with-storybook#usage",
     "hierarchy": {
@@ -8735,14 +8735,14 @@
   },
   {
     "content": "Upgrading to v1",
-    "id": "1359d16c-394e-4215-9554-48eb36df9ea0",
+    "id": "941604ac-4f0e-446f-883e-c02a6a6958ef",
     "type": "lvl1",
     "url": "/guides/migration",
     "hierarchy": { "lvl1": "Upgrading to v1" }
   },
   {
     "content": "Highlights",
-    "id": "a60d9c26-8b06-40b2-bce7-a3c6118dee2b",
+    "id": "685ad8ff-9833-4a44-b014-db7056e6ac9a",
     "type": "lvl2",
     "url": "/guides/migration#highlights",
     "hierarchy": {
@@ -8753,7 +8753,7 @@
   },
   {
     "content": "Upgrade steps",
-    "id": "625016ac-999d-44a9-8942-7dfd980ef167",
+    "id": "f586aaa0-ad11-4808-bead-95b092680689",
     "type": "lvl2",
     "url": "/guides/migration#upgrade-steps",
     "hierarchy": {
@@ -8764,7 +8764,7 @@
   },
   {
     "content": "1. Update your dependencies",
-    "id": "4a032973-9dc5-45a7-b84a-6676605d5488",
+    "id": "e3636780-d408-4b75-bd85-cb2a93771ca7",
     "type": "lvl3",
     "url": "/guides/migration#1-update-your-dependencies",
     "hierarchy": {
@@ -8775,7 +8775,7 @@
   },
   {
     "content": "Notes on Icons",
-    "id": "e677aee9-d2ca-4a0e-81e5-8fb1e718743d",
+    "id": "fc7507c4-1fa2-49ce-a470-0fdd55be5eb8",
     "type": "lvl4",
     "url": "/guides/migration#notes-on-icons",
     "hierarchy": {
@@ -8786,7 +8786,7 @@
   },
   {
     "content": "2. Update the ThemeProvider",
-    "id": "928fd5f5-90c8-4529-8088-1ff30f465c8f",
+    "id": "ae59fe02-f86f-46fd-a726-a6c09bd33143",
     "type": "lvl3",
     "url": "/guides/migration#2-update-the-themeprovider",
     "hierarchy": {
@@ -8797,7 +8797,7 @@
   },
   {
     "content": "3. Rename `variantColor` to `colorScheme`",
-    "id": "269c4169-865e-4703-9cb1-5021c58d1deb",
+    "id": "cb442deb-da0c-4dcd-bf67-6669927c2697",
     "type": "lvl3",
     "url": "/guides/migration#3-rename-variantcolor-to-colorscheme",
     "hierarchy": {
@@ -8808,7 +8808,7 @@
   },
   {
     "content": "4. Update layout `size` prop",
-    "id": "8194b900-4094-4ec8-b919-1f63d31ceca9",
+    "id": "f4902ef1-f2ab-4107-a717-0d123a938ce3",
     "type": "lvl3",
     "url": "/guides/migration#4-update-layout-size-prop",
     "hierarchy": {
@@ -8819,7 +8819,7 @@
   },
   {
     "content": "5. Replace elements",
-    "id": "beb7fd84-3971-4705-b31f-d234f78ae368",
+    "id": "3e7a458c-df22-4ee7-8597-4ec4dbc064d4",
     "type": "lvl3",
     "url": "/guides/migration#5-replace-elements",
     "hierarchy": {
@@ -8830,7 +8830,7 @@
   },
   {
     "content": "PseudoBox",
-    "id": "50c77cf2-4bb3-407f-9fd8-95660d6b58a0",
+    "id": "996c0394-d2b6-4f39-a3e5-5cb8fddf1cb5",
     "type": "lvl4",
     "url": "/guides/migration#pseudobox",
     "hierarchy": {
@@ -8841,7 +8841,7 @@
   },
   {
     "content": "Callout",
-    "id": "83d2b2ab-dd76-4cd7-baef-d5147323aaa8",
+    "id": "a238a70c-d146-499b-941e-61fd714c7eb6",
     "type": "lvl4",
     "url": "/guides/migration#callout",
     "hierarchy": {
@@ -8852,7 +8852,7 @@
   },
   {
     "content": "6. Update theme breakpoints",
-    "id": "f3cc5439-17aa-481c-a62c-ab4cb9c76335",
+    "id": "9fdc723a-bc0f-4c98-aa94-778cd840d263",
     "type": "lvl3",
     "url": "/guides/migration#6-update-theme-breakpoints",
     "hierarchy": {
@@ -8863,7 +8863,7 @@
   },
   {
     "content": "7. ColorModeScript (optional)",
-    "id": "3c092c9b-e51e-4812-b0c7-72a7c7b329e2",
+    "id": "896a658c-8a3b-4dff-bfac-b21e9e19582e",
     "type": "lvl3",
     "url": "/guides/migration#7-colormodescript-optional",
     "hierarchy": {
@@ -8874,7 +8874,7 @@
   },
   {
     "content": "Component Updates",
-    "id": "b0f513b9-30c4-4694-a836-855cfa151d6e",
+    "id": "954551b7-aeb3-42d3-9037-b04259df7a4b",
     "type": "lvl2",
     "url": "/guides/migration#component-updates",
     "hierarchy": {
@@ -8885,7 +8885,7 @@
   },
   {
     "content": "Accordion",
-    "id": "28c8ba6c-6263-4386-93de-15189d45c79d",
+    "id": "343f6623-654b-4fd8-9b21-1162a28fffa5",
     "type": "lvl3",
     "url": "/guides/migration#accordion",
     "hierarchy": {
@@ -8896,7 +8896,7 @@
   },
   {
     "content": "AspectRatioBox",
-    "id": "fdd5cded-6f7c-4ebf-9665-e84db6c931ae",
+    "id": "79bb7ad0-9f96-4706-ae02-871c2adc9dc1",
     "type": "lvl3",
     "url": "/guides/migration#aspectratiobox",
     "hierarchy": {
@@ -8907,7 +8907,7 @@
   },
   {
     "content": "Breadcrumb",
-    "id": "29af0d51-3c42-4388-b802-6f84dc040ca8",
+    "id": "1a08d5d1-5289-47f3-9e8a-5d2297c02977",
     "type": "lvl3",
     "url": "/guides/migration#breadcrumb",
     "hierarchy": {
@@ -8918,7 +8918,7 @@
   },
   {
     "content": "Button",
-    "id": "fc797600-638f-4c4e-a9c6-cd4f109aa531",
+    "id": "25d55d7f-e317-414f-9733-9e4a6c699a8f",
     "type": "lvl3",
     "url": "/guides/migration#button",
     "hierarchy": {
@@ -8929,7 +8929,7 @@
   },
   {
     "content": "Checkbox",
-    "id": "6d0a18ac-ee61-4205-a521-e8b653ab8380",
+    "id": "a0d6843f-dfe5-4cb3-aa70-2e2482ecff8d",
     "type": "lvl3",
     "url": "/guides/migration#checkbox",
     "hierarchy": {
@@ -8940,7 +8940,7 @@
   },
   {
     "content": "ColorMode",
-    "id": "4bf15ab6-9c03-44a5-9645-9aec6c9db6ac",
+    "id": "dc587282-65d0-4ea7-94f2-ad1cc66f1d84",
     "type": "lvl3",
     "url": "/guides/migration#colormode",
     "hierarchy": {
@@ -8951,14 +8951,14 @@
   },
   {
     "content": "Changes",
-    "id": "209b76fa-0b2c-4a7a-9e76-f1172e601c87",
+    "id": "4ef11b73-fc88-459d-9898-cdeca73e13a8",
     "type": "lvl2",
     "url": "/guides/migration#changes",
     "hierarchy": { "lvl1": "Upgrading to v1", "lvl2": "Changes", "lvl3": null }
   },
   {
     "content": "Editable",
-    "id": "9e9d4d6f-077f-483f-9731-408c6d5b796e",
+    "id": "d1ef047f-b0d1-4f15-923e-7a62a52e041f",
     "type": "lvl3",
     "url": "/guides/migration#editable",
     "hierarchy": {
@@ -8969,7 +8969,7 @@
   },
   {
     "content": "Icons",
-    "id": "fe338599-3764-4ac4-84c0-74ca71177055",
+    "id": "6667648a-6201-45c0-948a-ff830bf21a6c",
     "type": "lvl3",
     "url": "/guides/migration#icons",
     "hierarchy": {
@@ -8980,7 +8980,7 @@
   },
   {
     "content": "Icon Button",
-    "id": "d60b26d8-153e-4723-90dc-687c2451bf52",
+    "id": "7fc80d45-ecf0-4d90-a800-8f6b75767461",
     "type": "lvl3",
     "url": "/guides/migration#icon-button",
     "hierarchy": {
@@ -8991,7 +8991,7 @@
   },
   {
     "content": "Skeleton",
-    "id": "c24c1c98-9e09-4e50-9eb5-6151787f58d1",
+    "id": "531ebf18-f757-4057-ba42-90f362a08cd6",
     "type": "lvl3",
     "url": "/guides/migration#skeleton",
     "hierarchy": {
@@ -9002,7 +9002,7 @@
   },
   {
     "content": "Image",
-    "id": "92ad6c0e-b251-464c-8f40-6436ee9422c3",
+    "id": "648dbac2-d50e-4f86-8c32-89eb1de0482b",
     "type": "lvl3",
     "url": "/guides/migration#image",
     "hierarchy": {
@@ -9013,28 +9013,28 @@
   },
   {
     "content": "Input",
-    "id": "60a287ee-366e-446d-8d43-6c6f815f1806",
+    "id": "d825cf4a-74bb-4f98-aa0e-aa12c9d2eb9b",
     "type": "lvl3",
     "url": "/guides/migration#input",
     "hierarchy": { "lvl1": "Upgrading to v1", "lvl2": "Image", "lvl3": "Input" }
   },
   {
     "content": "Link",
-    "id": "2aed0b81-c265-4b56-8fce-2439b518655e",
+    "id": "8cb91284-2eae-40ba-871c-4c9742c3dade",
     "type": "lvl3",
     "url": "/guides/migration#link",
     "hierarchy": { "lvl1": "Upgrading to v1", "lvl2": "Input", "lvl3": "Link" }
   },
   {
     "content": "List",
-    "id": "da079da7-9815-4543-aa5e-968053dceb6a",
+    "id": "221d860c-1795-411d-af99-347f494032a9",
     "type": "lvl3",
     "url": "/guides/migration#list",
     "hierarchy": { "lvl1": "Upgrading to v1", "lvl2": "Link", "lvl3": "List" }
   },
   {
     "content": "ListIcon",
-    "id": "70cbe78b-057e-4d7f-b81e-b76199bb920d",
+    "id": "daf2ffab-5bf6-4284-993a-8b4c9aed13c1",
     "type": "lvl3",
     "url": "/guides/migration#listicon",
     "hierarchy": {
@@ -9045,7 +9045,7 @@
   },
   {
     "content": "Stack",
-    "id": "fd5eb3c7-cacd-41a6-8a66-a0218161064d",
+    "id": "906c5b97-147a-4129-bcae-68ef2ea0dfed",
     "type": "lvl3",
     "url": "/guides/migration#stack",
     "hierarchy": {
@@ -9056,21 +9056,21 @@
   },
   {
     "content": "Menu",
-    "id": "7d51ea50-5a5a-4525-8dcf-cf508e675a41",
+    "id": "4af0c5cd-56bd-4a7f-bc17-7f751ceff1b3",
     "type": "lvl3",
     "url": "/guides/migration#menu",
     "hierarchy": { "lvl1": "Upgrading to v1", "lvl2": "Stack", "lvl3": "Menu" }
   },
   {
     "content": "Modal",
-    "id": "5a2e7f80-c9ce-4547-b1d9-bc314c40a1b9",
+    "id": "6157b0c2-87ae-4eb5-9287-0e5a85540d61",
     "type": "lvl3",
     "url": "/guides/migration#modal",
     "hierarchy": { "lvl1": "Upgrading to v1", "lvl2": "Menu", "lvl3": "Modal" }
   },
   {
     "content": "Progress",
-    "id": "19067ea0-284a-4077-a0a0-68d5d1e41576",
+    "id": "ec1b1770-9a62-494d-8420-aba0914d48c4",
     "type": "lvl3",
     "url": "/guides/migration#progress",
     "hierarchy": {
@@ -9081,7 +9081,7 @@
   },
   {
     "content": "CircularProgress",
-    "id": "d9beabe4-beda-42c9-bb82-b038a0590ec5",
+    "id": "4293a2fa-5953-4358-a44e-191d2aeecb6e",
     "type": "lvl3",
     "url": "/guides/migration#circularprogress",
     "hierarchy": {
@@ -9092,7 +9092,7 @@
   },
   {
     "content": "Radio",
-    "id": "559c07fa-7324-4818-b766-30fd2638f245",
+    "id": "0eef731a-32bd-479b-8582-a4cda5fb2c6a",
     "type": "lvl3",
     "url": "/guides/migration#radio",
     "hierarchy": {
@@ -9103,7 +9103,7 @@
   },
   {
     "content": "RadioGroup",
-    "id": "c0863084-ca5c-4598-ae61-e4ad59f19525",
+    "id": "5b0c3ca7-7b23-4866-bbda-056462f56e12",
     "type": "lvl3",
     "url": "/guides/migration#radiogroup",
     "hierarchy": {
@@ -9114,14 +9114,14 @@
   },
   {
     "content": "Slider",
-    "id": "eed6ad5a-db5a-4e14-8337-0b460c57d837",
+    "id": "548ac823-0231-4d23-bc6a-0f88e0a543a1",
     "type": "lvl2",
     "url": "/guides/migration#slider",
     "hierarchy": { "lvl1": "Upgrading to v1", "lvl2": "Slider", "lvl3": null }
   },
   {
     "content": "Switch",
-    "id": "470d91e2-070e-4d62-82a0-93b980d2480a",
+    "id": "89dccf2a-b225-47c6-b789-4be26bc290af",
     "type": "lvl3",
     "url": "/guides/migration#switch",
     "hierarchy": {
@@ -9132,28 +9132,28 @@
   },
   {
     "content": "Tabs",
-    "id": "8634815a-3660-41cc-a177-dd9477533885",
+    "id": "0009bb59-0710-4117-ae0a-180d03c5082c",
     "type": "lvl3",
     "url": "/guides/migration#tabs",
     "hierarchy": { "lvl1": "Upgrading to v1", "lvl2": "Switch", "lvl3": "Tabs" }
   },
   {
     "content": "Tags",
-    "id": "8723a9cd-3c1b-433f-ae07-aa9deae0291b",
+    "id": "f0ca6633-5d5d-40c5-8593-781cb18fe6d7",
     "type": "lvl3",
     "url": "/guides/migration#tags",
     "hierarchy": { "lvl1": "Upgrading to v1", "lvl2": "Tabs", "lvl3": "Tags" }
   },
   {
     "content": "Toast",
-    "id": "5e0d88a5-f221-4fff-a6ac-65e4bc57bdb3",
+    "id": "e976c101-c537-4d13-a4cc-d1ad4f1e38bd",
     "type": "lvl3",
     "url": "/guides/migration#toast",
     "hierarchy": { "lvl1": "Upgrading to v1", "lvl2": "Tags", "lvl3": "Toast" }
   },
   {
     "content": "Wrap (for `rc` versions)",
-    "id": "7db228ab-1598-4b33-bc97-380b46375e0e",
+    "id": "b4555bf6-e474-4cca-8882-595e4b8fc0c9",
     "type": "lvl3",
     "url": "/guides/migration#wrap-for-rc-versions",
     "hierarchy": {
@@ -9164,7 +9164,7 @@
   },
   {
     "content": "Transition Components",
-    "id": "83803164-1b66-461a-b4eb-c89cb9dbc5cb",
+    "id": "1cb00e91-19f6-494c-b965-4f4eda84ee68",
     "type": "lvl3",
     "url": "/guides/migration#transition-components",
     "hierarchy": {
@@ -9175,7 +9175,7 @@
   },
   {
     "content": "CSS Reset",
-    "id": "132e1cde-77c0-4498-a7f8-ab939c4ebd52",
+    "id": "5517ca35-bea9-4653-a7fd-cfd772c61d86",
     "type": "lvl3",
     "url": "/guides/migration#css-reset",
     "hierarchy": {
@@ -9186,7 +9186,7 @@
   },
   {
     "content": "Hooks",
-    "id": "15649e93-708f-438a-a808-9da6ea7b92f8",
+    "id": "de6f28ce-3116-462a-8cc7-6a066f213857",
     "type": "lvl3",
     "url": "/guides/migration#hooks",
     "hierarchy": {
@@ -9197,14 +9197,14 @@
   },
   {
     "content": "Design Principles",
-    "id": "17428b65-747a-4c7f-8145-5f1b7ba0712b",
+    "id": "25e35616-8534-4888-a4fa-989f5f988626",
     "type": "lvl1",
     "url": "/guides/principles",
     "hierarchy": { "lvl1": "Design Principles" }
   },
   {
     "content": "Atlaskit editable",
-    "id": "567d026d-29a1-4a5f-b979-2b703bc38062",
+    "id": "cc14c980-4295-40f0-a59a-54e805a79730",
     "type": "lvl1",
     "url": "/guides/recipes/atlaskit-editable",
     "hierarchy": { "lvl1": "Atlaskit editable" }

--- a/pages/changelog/index.mdx
+++ b/pages/changelog/index.mdx
@@ -1,14 +1,12 @@
 ---
 title: Changelog
 description: The changelog for Chakra UI React
-slug: "/changelog"
+slug: '/changelog'
 ---
 
 The Changelog gives an overview of the meaningful changes we've made to Chakra
 UI as we keep driving for better performance and best-in-class developer
 experience.
-
-
 
 ## 28-02-2022
 
@@ -27,7 +25,7 @@ experience.
   to handle multi line text input in an editable context.
 
 ```tsx live=false
-<Editable defaultValue="Change me" onChange={console.log}>
+<Editable defaultValue='Change me' onChange={console.log}>
   <EditablePreview />
   <EditableTextarea />
 </Editable>
@@ -444,34 +442,34 @@ Semantic tokens provide the ability to create css variables which can change
 with a CSS condition.
 
 ```tsx live=false
-import { ChakraProvider, extendTheme } from "@chakra-ui/react"
+import { ChakraProvider, extendTheme } from '@chakra-ui/react'
 
 const customTheme = extendTheme({
   colors: {
-    900: "#171923",
+    900: '#171923',
   },
 })
 
 const App = () => (
   <ChakraProvider theme={customTheme}>
-    <Text color="gray.900">will always be gray.900</Text>
+    <Text color='gray.900'>will always be gray.900</Text>
   </ChakraProvider>
 )
 ```
 
 ```tsx live=false
-import { ChakraProvider, extendTheme } from "@chakra-ui/react"
+import { ChakraProvider, extendTheme } from '@chakra-ui/react'
 
 const customTheme = extendTheme({
   colors: {
-    50: "#F7FAFC",
-    900: "#171923",
+    50: '#F7FAFC',
+    900: '#171923',
   },
   semanticTokens: {
     colors: {
       text: {
-        default: "gray.900",
-        _dark: "gray.50",
+        default: 'gray.900',
+        _dark: 'gray.50',
       },
     },
   },
@@ -479,7 +477,7 @@ const customTheme = extendTheme({
 
 const App = () => (
   <ChakraProvider theme={customTheme}>
-    <Text color="text">
+    <Text color='text'>
       will be gray.900 in light mode and gray.50 in dark mode
     </Text>
   </ChakraProvider>
@@ -487,31 +485,31 @@ const App = () => (
 ```
 
 ```tsx live=false
-import { extendTheme } from "@chakra-ui/react"
+import { extendTheme } from '@chakra-ui/react'
 
 const theme = extendTheme({
   colors: {
     red: {
-      100: "#ff0010",
-      400: "#ff0040",
-      500: "#ff0050",
-      700: "#ff0070",
-      800: "#ff0080",
+      100: '#ff0010',
+      400: '#ff0040',
+      500: '#ff0050',
+      700: '#ff0070',
+      800: '#ff0080',
     },
   },
   semanticTokens: {
     colors: {
-      error: "red.500", // create a token alias
-      success: "red.100",
+      error: 'red.500', // create a token alias
+      success: 'red.100',
       primary: {
         // set variable conditionally with pseudo selectors like `_dark` and `_light`
         // use `default` to define fallback value
-        default: "red.500",
-        _dark: "red.400",
+        default: 'red.500',
+        _dark: 'red.400',
       },
       secondary: {
-        default: "red.800",
-        _dark: "red.700",
+        default: 'red.800',
+        _dark: 'red.700',
       },
     },
   },
@@ -529,34 +527,34 @@ Semantic tokens provide the ability to create css variables which can change
 with a CSS condition.
 
 ```tsx live=false
-import { ChakraProvider, extendTheme } from "@chakra-ui/react"
+import { ChakraProvider, extendTheme } from '@chakra-ui/react'
 
 const customTheme = extendTheme({
   colors: {
-    900: "#171923",
+    900: '#171923',
   },
 })
 
 const App = () => (
   <ChakraProvider theme={customTheme}>
-    <Text color="gray.900">will always be gray.900</Text>
+    <Text color='gray.900'>will always be gray.900</Text>
   </ChakraProvider>
 )
 ```
 
 ```tsx live=false
-import { ChakraProvider, extendTheme } from "@chakra-ui/react"
+import { ChakraProvider, extendTheme } from '@chakra-ui/react'
 
 const customTheme = extendTheme({
   colors: {
-    50: "#F7FAFC",
-    900: "#171923",
+    50: '#F7FAFC',
+    900: '#171923',
   },
   semanticTokens: {
     colors: {
       text: {
-        default: "gray.900",
-        _dark: "gray.50",
+        default: 'gray.900',
+        _dark: 'gray.50',
       },
     },
   },
@@ -564,7 +562,7 @@ const customTheme = extendTheme({
 
 const App = () => (
   <ChakraProvider theme={customTheme}>
-    <Text color="text">
+    <Text color='text'>
       will be gray.900 in light mode and gray.50 in dark mode
     </Text>
   </ChakraProvider>
@@ -572,31 +570,31 @@ const App = () => (
 ```
 
 ```tsx live=false
-import { extendTheme } from "@chakra-ui/react"
+import { extendTheme } from '@chakra-ui/react'
 
 const theme = extendTheme({
   colors: {
     red: {
-      100: "#ff0010",
-      400: "#ff0040",
-      500: "#ff0050",
-      700: "#ff0070",
-      800: "#ff0080",
+      100: '#ff0010',
+      400: '#ff0040',
+      500: '#ff0050',
+      700: '#ff0070',
+      800: '#ff0080',
     },
   },
   semanticTokens: {
     colors: {
-      error: "red.500", // create a token alias
-      success: "red.100",
+      error: 'red.500', // create a token alias
+      success: 'red.100',
       primary: {
         // set variable conditionally with pseudo selectors like `_dark` and `_light`
         // use `default` to define fallback value
-        default: "red.500",
-        _dark: "red.400",
+        default: 'red.500',
+        _dark: 'red.400',
       },
       secondary: {
-        default: "red.800",
-        _dark: "red.700",
+        default: 'red.800',
+        _dark: 'red.700',
       },
     },
   },
@@ -609,7 +607,7 @@ const theme = extendTheme({
 
 ```jsx live=false
 // Now you can use only colors from the theme
-import colors from "@chakra-ui/theme/foundations/colors"
+import colors from '@chakra-ui/theme/foundations/colors'
 ```
 
 Here's a table of the theme parts and entrypoints
@@ -637,34 +635,34 @@ Semantic tokens provide the ability to create css variables which can change
 with a CSS condition.
 
 ```tsx live=false
-import { ChakraProvider, extendTheme } from "@chakra-ui/react"
+import { ChakraProvider, extendTheme } from '@chakra-ui/react'
 
 const customTheme = extendTheme({
   colors: {
-    900: "#171923",
+    900: '#171923',
   },
 })
 
 const App = () => (
   <ChakraProvider theme={customTheme}>
-    <Text color="gray.900">will always be gray.900</Text>
+    <Text color='gray.900'>will always be gray.900</Text>
   </ChakraProvider>
 )
 ```
 
 ```tsx live=false
-import { ChakraProvider, extendTheme } from "@chakra-ui/react"
+import { ChakraProvider, extendTheme } from '@chakra-ui/react'
 
 const customTheme = extendTheme({
   colors: {
-    50: "#F7FAFC",
-    900: "#171923",
+    50: '#F7FAFC',
+    900: '#171923',
   },
   semanticTokens: {
     colors: {
       text: {
-        default: "gray.900",
-        _dark: "gray.50",
+        default: 'gray.900',
+        _dark: 'gray.50',
       },
     },
   },
@@ -672,7 +670,7 @@ const customTheme = extendTheme({
 
 const App = () => (
   <ChakraProvider theme={customTheme}>
-    <Text color="text">
+    <Text color='text'>
       will be gray.900 in light mode and gray.50 in dark mode
     </Text>
   </ChakraProvider>
@@ -680,31 +678,31 @@ const App = () => (
 ```
 
 ```tsx live=false
-import { extendTheme } from "@chakra-ui/react"
+import { extendTheme } from '@chakra-ui/react'
 
 const theme = extendTheme({
   colors: {
     red: {
-      100: "#ff0010",
-      400: "#ff0040",
-      500: "#ff0050",
-      700: "#ff0070",
-      800: "#ff0080",
+      100: '#ff0010',
+      400: '#ff0040',
+      500: '#ff0050',
+      700: '#ff0070',
+      800: '#ff0080',
     },
   },
   semanticTokens: {
     colors: {
-      error: "red.500", // create a token alias
-      success: "red.100",
+      error: 'red.500', // create a token alias
+      success: 'red.100',
       primary: {
         // set variable conditionally with pseudo selectors like `_dark` and `_light`
         // use `default` to define fallback value
-        default: "red.500",
-        _dark: "red.400",
+        default: 'red.500',
+        _dark: 'red.400',
       },
       secondary: {
-        default: "red.800",
-        _dark: "red.700",
+        default: 'red.800',
+        _dark: 'red.700',
       },
     },
   },
@@ -758,7 +756,7 @@ const theme = extendTheme({
 - Add helper function `flatten`
 
 ```ts
-import { flatten } from "@chakra-ui/utils"
+import { flatten } from '@chakra-ui/utils'
 
 flatten({ space: [0, 1, 2, 4, 8, 16, 32] })
 /** =>
@@ -810,9 +808,9 @@ template area.
 
 ```jsx live=false
 <Grid templateAreas='"one two three"'>
-   <GridItem area='one'>one</Grid>
-   <GridItem area='two'>two</Grid>
-   <GridItem area='three'>three</Grid>
+  <GridItem area='one'>one</GridItem>
+  <GridItem area='two'>two</GridItem>
+  <GridItem area='three'>three</GridItem>
 </Grid>
 ```
 
@@ -837,8 +835,8 @@ with `.peer` or `data-peer`) attribute.
 
 ```jsx live=false
 <>
-  <input type="checkbox" data-peer />
-  <Box bg="white" _peerFocus={{ bg: "green.400" }} />
+  <input type='checkbox' data-peer />
+  <Box bg='white' _peerFocus={{ bg: 'green.400' }} />
 </>
 ```
 
@@ -940,7 +938,7 @@ Add the addon to your configuration in `.storybook/main.js`:
 
 ```js live=false
 module.exports = {
-  addons: ["@chakra-ui/storybook-addon"],
+  addons: ['@chakra-ui/storybook-addon'],
 }
 ```
 
@@ -1039,7 +1037,7 @@ module.exports = {
   </PopoverTrigger>
   {/* popover will be positioned relative to this */}
   <PopoverAnchor>
-    <Box width="40px" height="40px" />
+    <Box width='40px' height='40px' />
   </PopoverAnchor>
   <PopoverContent>Hello World</PopoverContent>
 </Popover>
@@ -1068,10 +1066,10 @@ module.exports = {
 function Example() {
   // Via instantiation
   const toast = useToast({
-    position: "top",
-    title: "Container style is customizable",
+    position: 'top',
+    title: 'Container style is customizable',
     containerStyle: {
-      maxWidth: "100%",
+      maxWidth: '100%',
     },
   })
 
@@ -1081,7 +1079,7 @@ function Example() {
       onClick={() => {
         toast({
           containerStyle: {
-            maxWidth: "100%",
+            maxWidth: '100%',
           },
         })
       }}
@@ -1112,8 +1110,8 @@ function Example() {
 
 ```jsx live=false
 const HeartIcon = createIcon({
-  displayName: "HeartIcon",
-  path: [<path stroke="none" d="..." fill="none" />, <path d="..." />],
+  displayName: 'HeartIcon',
+  path: [<path stroke='none' d='...' fill='none' />, <path d='...' />],
 })
 ```
 
@@ -1179,10 +1177,10 @@ Here's how to resolve it:
 
 ```jsx live=false
 // Won't work 🎇
-import { useOutsideClick } from "@chakra-ui/hooks/dist/use-outside-click"
+import { useOutsideClick } from '@chakra-ui/hooks/dist/use-outside-click'
 
 // Works ✅
-import { useOutsideClick } from "@chakra-ui/hooks"
+import { useOutsideClick } from '@chakra-ui/hooks'
 ```
 
 If this affected your project, we recommend that you import hooks, functions or
@@ -1592,10 +1590,10 @@ theme but we promise to revisit the typings and API very soon.
 Creating a CSS variable in the theme
 
 ```jsx live=false
-import { cssVar, calc } from "@chakra-ui/theme-tools"
+import { cssVar, calc } from '@chakra-ui/theme-tools'
 
-const $width = cssVar("slider-width")
-const $height = cssVar("slider-height")
+const $width = cssVar('slider-width')
+const $height = cssVar('slider-height')
 
 const $diff = calc($width).subtract($height).toString()
 
@@ -1665,7 +1663,7 @@ type-safe, multipart component styles.
   root FormControl element to be themed.
 
 ```jsx live=false
-import { extendTheme } from "@chakra-ui/react"
+import { extendTheme } from '@chakra-ui/react'
 
 export const theme = extendTheme({
   components: {
@@ -1675,8 +1673,8 @@ export const theme = extendTheme({
         custom: {
           // style the root `FormControl` element
           container: {
-            color: "white",
-            bg: "blue.900",
+            color: 'white',
+            bg: 'blue.900',
           },
         },
       },
@@ -1858,7 +1856,7 @@ export or an export named `theme`.
 
 ```jsx live=false
 // chakra-theme-package/src/index.js
-import { extendTheme } from "@chakra-ui/react"
+import { extendTheme } from '@chakra-ui/react'
 
 const theme = extendTheme({})
 
@@ -1990,7 +1988,7 @@ To use this API, you'll need to set `transform` to `auto` or `auto-gpu` (for the
 GPU accelerated version).
 
 ```jsx live=false
-<Circle transform="auto" translateX="4" _hover={{ translateX: "8" }}>
+<Circle transform='auto' translateX='4' _hover={{ translateX: '8' }}>
   <CheckIcon />
 </Circle>
 ```
@@ -2202,35 +2200,35 @@ import {
   withDefaultSize,
   withDefaultVariant,
   withDefaultProps,
-} from "@chakra-ui/react"
+} from '@chakra-ui/react'
 
 const customTheme = extendTheme(
   {
     colors: {
       brand: {
         // ...
-        500: "#b4d455",
+        500: '#b4d455',
         // ...
       },
     },
   },
-  withDefaultColorScheme({ colorScheme: "brand" }),
+  withDefaultColorScheme({ colorScheme: 'brand' }),
   withDefaultSize({
-    size: "lg",
-    components: ["Input", "NumberInput", "PinInput"],
+    size: 'lg',
+    components: ['Input', 'NumberInput', 'PinInput'],
   }),
   withDefaultVariant({
-    variant: "outline",
-    components: ["Input", "NumberInput", "PinInput"],
+    variant: 'outline',
+    components: ['Input', 'NumberInput', 'PinInput'],
   }),
   // or all in one:
   withDefaultProps({
     defaultProps: {
-      colorScheme: "brand",
-      variant: "outline",
-      size: "lg",
+      colorScheme: 'brand',
+      variant: 'outline',
+      size: 'lg',
     },
-    components: ["Input", "NumberInput", "PinInput"],
+    components: ['Input', 'NumberInput', 'PinInput'],
   }),
   // optional:
   yourCustomBaseTheme, // defaults to our chakra default theme
@@ -2277,7 +2275,7 @@ const customTheme = extendTheme(
   `end`.
 
 ```jsx live=false
-<Button isLoading spinnerPlacement="end">
+<Button isLoading spinnerPlacement='end'>
   Click me
 </Button>
 ```
@@ -2537,7 +2535,7 @@ Popover
 - Use `--popover-bg` css property to control popover and arrow background.
 
 ```jsx live=false
-<PopoverContent style={{ "--popover-bg": "purple" }}>
+<PopoverContent style={{ '--popover-bg': 'purple' }}>
   <PopoverArrow />
 </PopoverContent>
 ```
@@ -2656,9 +2654,9 @@ Update text align attribute to use end instead of right for RTL.
 ```jsx live=false
 <Box
   sx={{
-    "--banner-color": "colors.red.200",
-    "& .banner": {
-      bg: "var(--banner-color)",
+    '--banner-color': 'colors.red.200',
+    '& .banner': {
+      bg: 'var(--banner-color)',
     },
   }}
 />
@@ -2875,7 +2873,7 @@ Update text align attribute to use end instead of right for RTL.
   `extendTheme` function even further.
 
 ```jsx live=false
-import { extendTheme } from "@chakra-ui/react"
+import { extendTheme } from '@chakra-ui/react'
 
 export const customTheme = extendTheme({
   // here you get autocomplete for
@@ -2917,13 +2915,13 @@ You can get typesafe access to your custom theme like this:
 const theme = {
   textStyles: {
     caps: {
-      fontWeight: "bold",
-      fontSize: "24px",
+      fontWeight: 'bold',
+      fontSize: '24px',
     },
   },
 }
 
-const styles = css({ textStyle: "caps" })(theme)
+const styles = css({ textStyle: 'caps' })(theme)
 ```
 
 This also works for the component theme as well.

--- a/pages/changelog/index.mdx
+++ b/pages/changelog/index.mdx
@@ -12,8 +12,6 @@ experience.
 
 ## 28-02-2022
 
-`@chakra-ui/react@1.8.6`
-
 **Anatomy** `v1.3.0`
 
 - Add `textarea` part to `editableAnatomy`
@@ -812,9 +810,9 @@ template area.
 
 ```jsx live=false
 <Grid templateAreas='"one two three"'>
-   <GridItem area='one'>one</GridItem>
-   <GridItem area='two'>two</GridItem>
-   <GridItem area='three'>three</GridItem>
+   <GridItem area='one'>one</Grid>
+   <GridItem area='two'>two</Grid>
+   <GridItem area='three'>three</Grid>
 </Grid>
 ```
 

--- a/scripts/get-changelog.ts
+++ b/scripts/get-changelog.ts
@@ -18,7 +18,7 @@ export async function main() {
   content = content.replace('<!-- CHANGELOG:INSERT -->', '')
 
   fs.writeFileSync(
-    path.join(process.cwd(), 'pages', 'changelog', 'content.mdx'),
+    path.join(process.cwd(), 'pages', 'changelog', 'index.mdx'),
     content,
   )
 }


### PR DESCRIPTION
## 📝 Description

The Changelog search meta URL was pointing to `/changelog/content` because the changelog contents were kept in the `content.mdx` file. I renamed the `content.mdx` to `index.mdx` to avoid the `/content` segment when generating the search meta.

## ⛳️ Current behavior (updates)

The Changelog entry in the Search is pointing to `/changelog/content`, and it goes to the 404 page.

## 🚀 New behavior

The Changelog entry now points to just `/changelog` and no 404 happens.

## 💣 Is this a breaking change (Yes/No):

No