### PR TITLE
docs: use useDisclosure in alert AlertDialog example

### DIFF
--- a/pages/docs/components/overlay/alert-dialog.mdx
+++ b/pages/docs/components/overlay/alert-dialog.mdx
@@ -51,13 +51,12 @@ to prevent users from accidentally confirming the destructive action.
 
 ```jsx
 function AlertDialogExample() {
-  const [isOpen, setIsOpen] = React.useState(false)
-  const onClose = () => setIsOpen(false)
+  const { isOpen, onOpen, onClose } = useDisclosure()
   const cancelRef = React.useRef()
 
   return (
     <>
-      <Button colorScheme='red' onClick={() => setIsOpen(true)}>
+      <Button colorScheme='red' onClick={onOpen}>
         Delete Customer
       </Button>
 


### PR DESCRIPTION
## 📝 Description

Use the useDisclosure hook in first AlertDialog examle instead of useState.

## ⛳️ Current behavior (updates)

The current first example for the Alert Dialog uses useState to determine whether the component should be visible or not. All other examples use the custom useDisclosure hook.

## 🚀 New behavior

The first example now uses the useDisclosure hook, too.

## 💣 Is this a breaking change (Yes/No):

No