### PR TITLE
docs: fix Getting Started > Remix `react` imports

### DIFF
--- a/pages/guides/getting-started/remix-guide.mdx
+++ b/pages/guides/getting-started/remix-guide.mdx
@@ -23,7 +23,7 @@ We’ll create a `context.tsx` in the `app` folder.
 
 ```jsx live=false
 // context.tsx
-import React, { createContext } as React from "react"
+import React, { createContext } from 'react'
 
 export interface ServerStyleContextData {
   key: string
@@ -57,7 +57,7 @@ client and the server. We'll use our createEmotionCache function here.
 
 ```jsx live=false
 // entry.client.tsx
-import React, { useState } as React from 'react'
+import React, { useState } from 'react'
 import { hydrate } from 'react-dom'
 import { CacheProvider } from '@emotion/react'
 import { RemixBrowser } from 'remix'


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes N/A (no existing issue)

## 📝 Description

This PR fixes the imports in the Remix Getting Started guide.

## ⛳️ Current behavior (updates)

As far as I know, the `... as React` is used when we import all named exports using `*`, e.g.:

```ts
import * as React from 'react';
```

Instead, here, previously what we did was:

```ts
import React, { createContext } as React from "react"
```

This causes syntax errors in the IDE. In the later sections, we can see that the imports are specified differently than the ones above (which I think, this is the correct one).

```ts
// root.tsx
import React, { useContext, useEffect } from 'react';
```

## 🚀 New behavior

1. Remove the `as React` part of the line of code
2. Small update: use a single quote instead of double (to make it consistent with the later sections).

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

If the previous one's syntax was valid, please let me know and I'll close this PR. Thanks!