### PR TITLE
docs(style-props): add missing paddingY, paddingX, marginY and marginX style properties

### DIFF
--- a/pages/docs/styled-system/features/style-props.mdx
+++ b/pages/docs/styled-system/features/style-props.mdx
@@ -38,8 +38,8 @@ import { Box } from "@chakra-ui/react"
 | `mb`, `marginBottom`  | `margin-bottom`                               | `space`   |
 | `ml`, `marginLeft`    | `margin-left`                                 | `space`   |
 | `ms`, `marginStart`   | `margin-inline-start`                         | `space`   |
-| `mx`                  | `margin-inline-start` + `margin-inline-end`   | `space`   |
-| `my`                  | `margin-top` + `margin-bottom`                | `space`   |
+| `mx`, `marginX`       | `margin-inline-start` + `margin-inline-end`   | `space`   |
+| `my`, `marginY`       | `margin-top` + `margin-bottom`                | `space`   |
 | `p`, `padding`        | `padding`                                     | `space`   |
 | `pt`, `paddingTop`    | `padding-top`                                 | `space`   |
 | `pr`, `paddingRight`  | `padding-right`                               | `space`   |
@@ -47,8 +47,8 @@ import { Box } from "@chakra-ui/react"
 | `pb`, `paddingBottom` | `padding-bottom`                              | `space`   |
 | `pl`, `paddingLeft`   | `padding-left`                                | `space`   |
 | `ps`, `paddingStart`  | `padding-inline-start`                        | `space`   |
-| `px`                  | `padding-inline-start` + `padding-inline-end` | `space`   |
-| `py`                  | `padding-top` + `padding-bottom`              | `space`   |
+| `px`, `paddingX`      | `padding-inline-start` + `padding-inline-end` | `space`   |
+| `py`, `paddingY`      | `padding-top` + `padding-bottom`              | `space`   |
 
 > For `mx` and `px` props, we use `margin-inline-start` and `margin-inline-end`
 > to ensure the generated styles are RTL-friendly


### PR DESCRIPTION
Closes https://github.com/chakra-ui/chakra-ui-docs/issues/433

## 📝 Description

Add missing paddingY, paddingX, marginY and marginX style properties to the dedicated margin/padding table in style properties documentation page

## 💣 Is this a breaking change (Yes/No):

No