### PR TITLE
fix(get-search-meta): fix bug where local directory path is not being removed from url property in Windows 10

### DIFF
--- a/scripts/get-search-meta.ts
+++ b/scripts/get-search-meta.ts
@@ -35,8 +35,8 @@ async function getMDXMeta(file: string) {
   const tableOfContent = toc(content)
   const json = tableOfContent.json as TOCResultItem[]
   const slug = fileToPath(file)
-    .replace(`/${websiteRoot}`, '')
-    .replace(process.cwd(), '')
+    .replace(`${websiteRoot}`, '')
+    .replace(fileToPath(process.cwd()), '')
 
   const result: ResultType[] = []
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #438 

## 📝 Description

On Windows 10, running `yarn search-meta:gen` script to generate an updated `search-meta.json` file will render the local directory path in the `url` property. This request wraps the `fileToPath` function around `process.cwd()` when trimming the slug to ensure the same slash characters in the filepath from the string passed through the `file` param of `getMDXMeta` and the current working directory string from node process.

## ⛳️ Current behavior (updates)

Running `yarn search-meta:gen` renders in the `url` property the full local directory path in Windows 10...

i.e. `C:/Users/user/path/to/file/<page>`

where the meta file string passed to the `getMDXMeta` function contains forward slash characters, and `process.cwd()` returns a local directory path containing back slash characters.

## 🚀 New behavior

Passing `process.cwd()` to `fileToPath` when removing the local directory from the slug ensures that the slashes will match.

## 💣 Is this a breaking change (Yes/No):

No
