### PR TITLE
Update number-index.mdx | TypeScript throws error

### DIFF
--- a/pages/docs/components/form/number-input.mdx
+++ b/pages/docs/components/form/number-input.mdx
@@ -294,7 +294,6 @@ function HookUsage() {
       min: 1,
       max: 6,
       precision: 2,
-      isReadOnly: true,
     })
 
   const inc = getIncrementButtonProps()

--- a/pages/docs/components/form/number-input.mdx
+++ b/pages/docs/components/form/number-input.mdx
@@ -294,11 +294,12 @@ function HookUsage() {
       min: 1,
       max: 6,
       precision: 2,
+      isReadOnly: true,
     })
 
   const inc = getIncrementButtonProps()
   const dec = getDecrementButtonProps()
-  const input = getInputProps({ readOnly: true })
+  const input = getInputProps()
 
   return (
     <HStack maxW='320px'>

--- a/pages/docs/components/form/number-input.mdx
+++ b/pages/docs/components/form/number-input.mdx
@@ -298,7 +298,7 @@ function HookUsage() {
 
   const inc = getIncrementButtonProps()
   const dec = getDecrementButtonProps()
-  const input = getInputProps({ isReadOnly: true })
+  const input = getInputProps({ readOnly: true })
 
   return (
     <HStack maxW='320px'>


### PR DESCRIPTION
TypeScript throws errors if we use `isReadOnly: true` in the `getInputProps()` function. Although, if we pass `isReadOnly` does work, there seems to be a type error. However, when using `getInputProps({ readOnly: true });` both TypeScript and functionalities work. So, there is not a change. You just have a stricter type system.

Maybe, change the initial types of the `getInputProps()` parameters?

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

> Add a brief description

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information
