### PR TITLE
docs: remove deprecated createBreakpoints function

### DIFF
--- a/pages/docs/styled-system/features/responsive-styles.mdx
+++ b/pages/docs/styled-system/features/responsive-styles.mdx
@@ -14,15 +14,13 @@ Responsive syntax relies on the breakpoints defined in the theme object. Chakra
 UI provides default breakpoints, here's what it looks like:
 
 ```js
-import { createBreakpoints } from '@chakra-ui/theme-tools'
-
-const breakpoints = createBreakpoints({
+const breakpoints = {
   sm: '30em',
   md: '48em',
   lg: '62em',
   xl: '80em',
   '2xl': '96em',
-})
+}
 ```
 
 To make styles responsive, you can use either the array or object syntax.
@@ -54,16 +52,14 @@ To interpret array responsive values, Chakra UI converts the values defined in
 values defined in the array to the breakpoints
 
 ```js
-import { createBreakpoints } from '@chakra-ui/theme-tools'
-
-// This is the default breakpoint
-const breakpoints = createBreakpoints({
+// These are the default breakpoints
+const breakpoints = {
   sm: '30em',
   md: '48em',
   lg: '62em',
   xl: '80em',
   '2xl': '96em',
-})
+}
 
 // Internally, we transform to this
 const breakpoints = ['0em', '30em', '48em', '62em', '80em', '96em']
@@ -176,8 +172,7 @@ In some scenarios, you might need to define custom breakpoints for your
 application. We recommended using common aliases like `sm`, `md`, `lg`, and
 `xl`.
 
-To define custom breakpoints, install `@chakra-ui/theme-tools`, and use the
-`createBreakpoints` utility we provide.
+To define custom breakpoints, just pass them as an object into the theme.
 
 > Note: Ensure the css unit of your breakpoints are the same. Use all `px` or
 > all `em`, don't mix them.
@@ -185,16 +180,15 @@ To define custom breakpoints, install `@chakra-ui/theme-tools`, and use the
 ```jsx live=false
 // 1. Import the utilities
 import { extendTheme } from '@chakra-ui/react'
-import { createBreakpoints } from '@chakra-ui/theme-tools'
 
 // 2. Update the breakpoints as key-value pairs
-const breakpoints = createBreakpoints({
+const breakpoints = {
   sm: '320px',
   md: '768px',
   lg: '960px',
   xl: '1200px',
   '2xl': '1536px',
-})
+}
 
 // 3. Extend the theme
 const theme = extendTheme({ breakpoints })

--- a/pages/docs/styled-system/theming/theme.mdx
+++ b/pages/docs/styled-system/theming/theme.mdx
@@ -126,8 +126,10 @@ To manage Typography options, the theme object supports the following keys:
 - `letterSpacings`
 
 ```js
-// example theme object
-export default {
+import { extendTheme } from '@chakra-ui/react'
+
+// example theme
+const theme = extendTheme({
   colors: {...},
   fonts: {
     body: "system-ui, sans-serif",
@@ -185,7 +187,7 @@ export default {
     wider: "0.05em",
     widest: "0.1em",
   },
-};
+});
 ```
 
 ## Breakpoints
@@ -216,7 +218,9 @@ your project. By default these spacing value can be referenced by the `padding`,
 `margin`, and `top`, `left`, `right`, `bottom` styles.
 
 ```js
-export default {
+import { extendTheme } from '@chakra-ui/react'
+
+const spacing = {
   space: {
     px: '1px',
     0.5: '0.125rem',
@@ -253,6 +257,8 @@ export default {
     96: '24rem',
   },
 }
+
+const theme = extendTheme({ spacing, ... })
 ```
 
 By default, Chakra includes a comprehensive numeric spacing scale inspired by
@@ -304,7 +310,9 @@ build for your project. By default these sizes value can be referenced by the
 `width`, `height`, and `maxWidth`, `minWidth`, `maxHeight`, `minHeight` styles.
 
 ```js
-export default {
+import { extendTheme } from '@chakra-ui/react'
+
+const sizes = {
   sizes: {
     ...theme.space,
     max: 'max-content',
@@ -332,6 +340,8 @@ export default {
     },
   },
 }
+
+const theme = extendTheme({ sizes, ...})
 ```
 
 A component like this: `<Box w={4} h={3} />` will generate an empty `div` with
@@ -342,7 +352,9 @@ width set to `1rem` or `16px` and height set to `0.75rem` or `12px`.
 Chakra provides a set of smooth corner radius values.
 
 ```js
-export default {
+import { extendTheme } from '@chakra-ui/react'
+
+const borderRadius = {
   radii: {
     none: '0',
     sm: '0.125rem',
@@ -355,6 +367,8 @@ export default {
     full: '9999px',
   },
 }
+
+const theme = extendTheme({ borderRadius, ...})
 ```
 
 ## z-index values
@@ -367,7 +381,9 @@ Chakra provides a minimal set of z-Indices out of the box to help control the
 stacking order of components.
 
 ```js
-export default {
+import { extendTheme } from '@chakra-ui/react'
+
+const zIndices = {
   zIndices: {
     hide: -1,
     auto: 'auto',
@@ -384,6 +400,7 @@ export default {
     tooltip: 1800,
   },
 }
+const theme = extendTheme({ zIndices, ...})
 ```
 
 ## Config
@@ -401,6 +418,8 @@ You can leverage the `extendTheme` function to override a specific theme config
 property.
 
 ```jsx live=false
+import { extendTheme } from '@chakra-ui/react'
+
 const theme = extendTheme({
   config: {
     cssVarPrefix: 'ck',

--- a/pages/docs/styled-system/theming/theme.mdx
+++ b/pages/docs/styled-system/theming/theme.mdx
@@ -196,16 +196,17 @@ Chakra UI comes with a predefined set of commonly used breakpoints.
 > [Responsive Styles and Customizing Breakpoints](/docs/styled-system/features/responsive-styles).
 
 ```js
-// theme.js
-import { createBreakpoints } from '@chakra-ui/theme-tools'
+import { extendTheme } from '@chakra-ui/react'
 
-export default createBreakpoints({
+const breakpoints = {
   sm: '30em',
   md: '48em',
   lg: '62em',
   xl: '80em',
   '2xl': '96em',
-})
+}
+
+const theme = extendTheme({ breakpoints, ... })
 ```
 
 ## Spacing

--- a/pages/guides/migration.mdx
+++ b/pages/guides/migration.mdx
@@ -179,21 +179,17 @@ only one prop to manage this, you can rename it to `boxSize`.
 
 **You may skip this if you didn't customize your breakpoints.**
 
-To provide easier extensibility and typesafety, breakpoints should now be
-created through `createBreakpoints` by passing an object:
+To provide easier extensibility, breakpoints should now be passed as an object:
 
 ```diff
 + import { extendTheme } from "@chakra-ui/react"
-+ import { createBreakpoints } from "@chakra-ui/theme-tools"
 
-
-+ const breakpoints = createBreakpoints({
++ const breakpoints = {
 +   sm: "30em",
 +   md: "48em",
 +   lg: "62em",
 +   xl: "80em",
-+ })
-
++ }
 
 const overrides = {
 - breakpoints: ["30em", "48em", "62em", "80em"]
@@ -206,9 +202,9 @@ const overrides = {
 **Please note that unless you plan overriding all components, `sm` to `xl` are
 required.**
 
-You may of course add for example `xxl` or other breakpoints in between -
-`createBreakpoints` will sort in ascending order. It is advisable to not mix css
-units.
+You may of course add for example `xxl` or other breakpoints in between - they
+will be ordered automatically by their value. Therefore it is advisable to not
+mix css units.
 
 > **Reason:** Previously, breakpoints on a theme had to be an array with your
 > breakpoints in ascending order which made it hard to reference which value was


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes -> no current issue

## 📝 Description

- Removes the `createBreakpoints` function from the docs due to deprecation, like described in [create-breakpoints.ts](https://github.com/chakra-ui/chakra-ui/blob/8e201b9f84a914e58cdc9ee90b3e03269fabf4d7/packages/theme-tools/src/create-breakpoints.ts#L20)
- Adds imports and hints for usage on the default theme page

## ⛳️ Current behavior (updates)

usage of deprecated function in the docs

## 🚀 New behavior

removed deprecated function

## 💣 Is this a breaking change (Yes/No):

No