### PR TITLE
docs: delete unnecessary import in remix template

### DIFF
--- a/pages/guides/getting-started/remix-guide.mdx
+++ b/pages/guides/getting-started/remix-guide.mdx
@@ -98,7 +98,6 @@ import { CacheProvider } from '@emotion/react'
 import createEmotionServer from '@emotion/server/create-instance'
 import { RemixServer } from 'remix'
 import type { EntryContext } from 'remix'
-import 'dotenv/config'
 
 import { ServerStyleContext } from './context'
 import createEmotionCache from './createEmotionCache'


### PR DESCRIPTION
## 📝 Description

There is a description to import dotenv in the entry.server.tsx template, but this is not necessary.

![スクリーンショット 2022-03-22 午後4 25 42](https://user-images.githubusercontent.com/6711766/159504415-d8b57395-98b3-414b-891e-22624b7d6a13.png)

- This does not affect the rendering of chakra-ui.
- For chakra-ui beginners, it may be a useless guess that some implicit environment variable definitions are necessary.
    - Yes, I had an evil guess.
- If the runtime is cloudflare, it cannot be built because it is not Node and process cannot be referenced.

## 💣 Is this a breaking change (Yes/No): NO

