### PR TITLE
docs(link-overlay): remove view theme source link

### DIFF
--- a/pages/docs/components/navigation/link-overlay.mdx
+++ b/pages/docs/components/navigation/link-overlay.mdx
@@ -22,7 +22,6 @@ The `LinkOverlay` component aims to solve this by overlaying one link on top of
 the component or card, and then elevating the remaining links on top of it.
 
 <ComponentLinks
-  theme={{ componentName: 'link-overlay' }}
   github={{ package: 'layout' }}
   npm={{ package: '@chakra-ui/layout' }}
 />


### PR DESCRIPTION
Closes #473 

## 📝 Description

Removing the "View Theme Source" link from [Link Overlay](https://chakra-ui.com/docs/components/navigation/link-overlay) page.

## ⛳️ Current behavior (updates)

"View Theme Source" 404s.

## 🚀 New behavior

Removed "View Theme Source" button because the LinkOverlay does not have a theme source.

## 💣 Is this a breaking change (Yes/No):

No