### PR TITLE
docs: fix typo in grouping buttons

### DIFF
--- a/pages/docs/components/form/button.mdx
+++ b/pages/docs/components/form/button.mdx
@@ -203,7 +203,7 @@ use the `ButtonGroup` component, it allows you to:
 
 - Set the `size` and `variant` of all buttons within it.
 - Add `spacing` between the buttons.
-- Flush the buttons together by removing the border radius of the its children
+- Flush the buttons together by removing the border radius of their children
   as needed.
 
 ```jsx


### PR DESCRIPTION
fix typo in `pages/docs/components/form/button.mdx`