### PR TITLE
Update RedwoodJS integration tutorial

### DIFF
--- a/configs/guides-sidebar.json
+++ b/configs/guides-sidebar.json
@@ -42,7 +42,7 @@
               "path": "/guides/getting-started/blitzjs-guide"
             },
             {
-              "title": "Redwood JS",
+              "title": "RedwoodJS",
               "path": "/guides/getting-started/redwoodjs-guide"
             },
             {

--- a/pages/guides/getting-started/redwoodjs-guide.mdx
+++ b/pages/guides/getting-started/redwoodjs-guide.mdx
@@ -82,20 +82,18 @@ const colors = {
 const theme = extendTheme({ colors })
 
 // 3. Pass the `theme` prop to the `ChakraProvider`
-function App() {
-  return (
-    <FatalErrorBoundary page={FatalErrorPage}>
-      <RedwoodProvider titleTemplate="%PageTitle | %AppTitle">
-        <ColorModeScript />
-        <ChakraProvider>
-          <RedwoodApolloProvider>
-            <Routes />
-          </RedwoodApolloProvider>
-        </ChakraProvider>
-      </RedwoodProvider>
-    </FatalErrorBoundary>
-  )
-}
+const App = () => (
+  <FatalErrorBoundary page={FatalErrorPage}>
+    <RedwoodProvider titleTemplate="%PageTitle | %AppTitle">
+      <ColorModeScript />
+      <ChakraProvider theme={theme}>
+        <RedwoodApolloProvider>
+          <Routes />
+        </RedwoodApolloProvider>
+      </ChakraProvider>
+    </RedwoodProvider>
+  </FatalErrorBoundary>
+)
 ```
 
 > To further customize components or build your own design system, the

--- a/pages/guides/getting-started/redwoodjs-guide.mdx
+++ b/pages/guides/getting-started/redwoodjs-guide.mdx
@@ -108,16 +108,6 @@ const App = () => (
 > `theme-tools` package includes useful utilities. Install
 > `@chakra-ui/theme-tools`.
 
-- Using Chakra Icons
-
-Chakra provides a set of commonly used interface icons you can use in your
-project.
-
-If you want to use the icons from Chakra UI, install `@chakra-ui/icons`.
-
-> Follow this guide for customizing Chakra Icons
-> [Using Chakra UI Icons](/docs/components/media-and-icons/icon).
-
 #### Notes on TypeScript 🚨
 
 Please note that when adding Chakra UI to a TypeScript project, a minimum

--- a/pages/guides/getting-started/redwoodjs-guide.mdx
+++ b/pages/guides/getting-started/redwoodjs-guide.mdx
@@ -151,7 +151,9 @@ Enable them in `web/config/storybook.preview.js` like this:
 
 | Name             | Type             | Default               | Description                                         |
 | ---------------- | ---------------- | --------------------- | --------------------------------------------------- |
-| resetCSS         | `boolean`        | `true`                | automatically includes `<CSSReset />`               |
-| theme            | `Theme`          | `@chakra-ui/theme`    | optional custom theme                               |
-| colorModeManager | `StorageManager` | `localStorageManager` | manager to persist a users color mode preference in |
-| portalZIndex     | `number`         | `undefined`           | common z-index to use for `Portal`                  |
+| colorModeManager | `StorageManager` | `localStorageManager` | Manager to persist a user's color mode preference in |
+| cssVarsRoot      | `string`         | `:root`               | The root element that Chakra attaches the CSS variables to |
+| environment      | `Environment`    | Depends on context    | The environment (`window` and `document`) to be used by all components and hooks. By default, we smartly determine the ownerDocument and defaultView based on where `ChakraProvider` is rendered. |
+| portalZIndex     | `number`         | `undefined`           | Common z-index to use for `Portal`                  |
+| resetCSS         | `boolean`        | `true`                | Automatically includes `<CSSReset />`               |
+| theme            | `Theme`          | `@chakra-ui/theme`    | Optional custom theme                               |

--- a/pages/guides/getting-started/redwoodjs-guide.mdx
+++ b/pages/guides/getting-started/redwoodjs-guide.mdx
@@ -1,5 +1,5 @@
 ---
-title: Redwood JS
+title: RedwoodJS
 description: A guide for installing Chakra UI with redwoodjs projects
 tags: ['redwoodjs']
 author: estheragbaje, philzen

--- a/pages/guides/getting-started/redwoodjs-guide.mdx
+++ b/pages/guides/getting-started/redwoodjs-guide.mdx
@@ -5,7 +5,9 @@ tags: ['redwoodjs']
 author: estheragbaje, philzen
 ---
 
-### Automatic Installation
+## Installation
+
+### Automatic
 
 RedwoodJS provides a convenient setup script via its [CLI tool](https://redwoodjs.com/docs/cli-commands#setup-ui) 
 to enable Chakra UI in your project with a single command. In your project folder, simply enter:
@@ -19,7 +21,7 @@ which are basically the same as outlined in manual installation steps below.
 
 See [below](#optional-customize-theme) for additional (optional) setup steps.
 
-### Manual Installation
+### Manual
 
 1. Inside your `Redwoodjs` project , cd into `web`, then, install Chakra UI by
 running either of the following:
@@ -57,28 +59,16 @@ of your application.  Go to `App.js` and add the `ChakraProvider` like this:
 > Boom! You're good to go with steps 1 and 2 🚀🚀🚀 However, if you'd love to
 > take it a step further, check out the optional steps [outlined below](#optional-customize-theme).
 
-### ChakraProvider Props
+### Notes on TypeScript 🚨
 
-| Name             | Type             | Default               | Description                                         |
-| ---------------- | ---------------- | --------------------- | --------------------------------------------------- |
-| resetCSS         | `boolean`        | `true`                | automatically includes `<CSSReset />`               |
-| theme            | `Theme`          | `@chakra-ui/theme`    | optional custom theme                               |
-| colorModeManager | `StorageManager` | `localStorageManager` | manager to persist a users color mode preference in |
-| portalZIndex     | `number`         | `undefined`           | common z-index to use for `Portal`                  |
+Please note that when adding Chakra UI to a TypeScript project, a minimum
+TypeScript version of `4.1.0` is required.
 
-### Optional: Customize Theme
+## Optional: Customize Theme
 
-<<<<<<< HEAD
-If you intend to customize the default theme object to match your design
-requirements, you can extend the `theme` from `@chakra-ui/react`.
-
-Chakra UI provides an `extendTheme` function that deep merges the default theme
-with your customizations.
-=======
-If you intend to [customise the default theme](/docs/styled-system/theming/customize-theme), 
+If you intend to [customize the default theme](/docs/styled-system/theming/customize-theme), 
 you will need to pass your extended theme object as a prop 
 to `ChakraProvider` as follows:
->>>>>>> 9a7fc6458 (Add link to customisation page and condense that section)
 
 ```jsx live=false
 // 1. Import the extendTheme function
@@ -110,7 +100,11 @@ const App = () => (
 )
 ```
 
-#### Notes on TypeScript 🚨
+## ChakraProvider Props
 
-Please note that when adding Chakra UI to a TypeScript project, a minimum
-TypeScript version of `4.1.0` is required.
+| Name             | Type             | Default               | Description                                         |
+| ---------------- | ---------------- | --------------------- | --------------------------------------------------- |
+| resetCSS         | `boolean`        | `true`                | automatically includes `<CSSReset />`               |
+| theme            | `Theme`          | `@chakra-ui/theme`    | optional custom theme                               |
+| colorModeManager | `StorageManager` | `localStorageManager` | manager to persist a users color mode preference in |
+| portalZIndex     | `number`         | `undefined`           | common z-index to use for `Portal`                  |

--- a/pages/guides/getting-started/redwoodjs-guide.mdx
+++ b/pages/guides/getting-started/redwoodjs-guide.mdx
@@ -68,11 +68,17 @@ of your application.  Go to `App.js` and add the `ChakraProvider` like this:
 
 ### Optional: Customize Theme
 
+<<<<<<< HEAD
 If you intend to customize the default theme object to match your design
 requirements, you can extend the `theme` from `@chakra-ui/react`.
 
 Chakra UI provides an `extendTheme` function that deep merges the default theme
 with your customizations.
+=======
+If you intend to [customise the default theme](/docs/styled-system/theming/customize-theme), 
+you will need to pass your extended theme object as a prop 
+to `ChakraProvider` as follows:
+>>>>>>> 9a7fc6458 (Add link to customisation page and condense that section)
 
 ```jsx live=false
 // 1. Import the extendTheme function
@@ -103,10 +109,6 @@ const App = () => (
   </FatalErrorBoundary>
 )
 ```
-
-> To further customize components or build your own design system, the
-> `theme-tools` package includes useful utilities. Install
-> `@chakra-ui/theme-tools`.
 
 #### Notes on TypeScript 🚨
 

--- a/pages/guides/getting-started/redwoodjs-guide.mdx
+++ b/pages/guides/getting-started/redwoodjs-guide.mdx
@@ -2,47 +2,60 @@
 title: Redwood JS
 description: A guide for installing Chakra UI with redwoodjs projects
 tags: ['redwoodjs']
-author: estheragbaje
+author: estheragbaje, philzen
 ---
 
-### 1. Installation
+### Automatic Installation
 
-Inside your `Redwoodjs` project , cd into `web`, then, install Chakra UI by
+RedwoodJS provides a convenient setup script via its [CLI tool](https://redwoodjs.com/docs/cli-commands#setup-ui) 
+to enable Chakra UI in your project with a single command. In your project folder, simply enter:
+
+```bash
+yarn redwood setup ui chakra-ui
+```
+
+This will make the necessary modifications to your `App.tsx` (or `App.js`, respectively) 
+which are basically the same as outlined in manual installation steps below.
+
+See [below](#optional-customize-theme) for additional (optional) setup steps.
+
+### Manual Installation
+
+1. Inside your `Redwoodjs` project , cd into `web`, then, install Chakra UI by
 running either of the following:
 
-```bash
-npm i @chakra-ui/react @emotion/react@^11 @emotion/styled@^11 framer-motion@^6
-```
+   ```bash
+   npm i @chakra-ui/react @emotion/react@^11 @emotion/styled@^11 framer-motion@^6
+   ```
 
-```bash
-yarn add @chakra-ui/react @emotion/react@^11 @emotion/styled@^11 framer-motion@^6
-```
+   ```bash
+   yarn add @chakra-ui/react @emotion/react@^11 @emotion/styled@^11 framer-motion@^6
+   ```
 
-### 2. Provider Setup
+2. After installing Chakra UI, you need to set up the `ChakraProvider` at the root
+of your application.  Go to `App.js` and add the `ChakraProvider` like this:
 
-After installing Chakra UI, you need to set up the `ChakraProvider` at the root
-of your application.
+   ```jsx live=false
+   import { ChakraProvider, ColorModeScript } from '@chakra-ui/react'
 
-Go to `App.js` and add the `ChakraProvider` like this:
+   const App = () => (
+     <FatalErrorBoundary page={FatalErrorPage}>
+       <RedwoodProvider titleTemplate="%PageTitle | %AppTitle">
+         <ColorModeScript />
+         <ChakraProvider>
+           <RedwoodApolloProvider>
+             <Routes />
+           </RedwoodApolloProvider>
+         </ChakraProvider>
+       </RedwoodProvider>
+     </FatalErrorBoundary>
+   )
 
-```jsx live=false
-import { ChakraProvider, ColorModeScript } from '@chakra-ui/react'
+   export default App
+   ```
 
-const App = () => (
-  <FatalErrorBoundary page={FatalErrorPage}>
-    <RedwoodProvider titleTemplate="%PageTitle | %AppTitle">
-      <ColorModeScript />
-      <ChakraProvider>
-        <RedwoodApolloProvider>
-          <Routes />
-        </RedwoodApolloProvider>
-      </ChakraProvider>
-    </RedwoodProvider>
-  </FatalErrorBoundary>
-)
-
-export default MyApp
-```
+> Boom! You're good to go with steps 1 and 2 🚀🚀🚀 However, if you'd love to
+> take it a step further, check out the optional steps [outlined below](#optional-customize-theme).
 
 ### ChakraProvider Props
 
@@ -53,14 +66,9 @@ export default MyApp
 | colorModeManager | `StorageManager` | `localStorageManager` | manager to persist a users color mode preference in |
 | portalZIndex     | `number`         | `undefined`           | common z-index to use for `Portal`                  |
 
-> Boom! You're good to go with steps 1 and 2 🚀🚀🚀 However, if you'd love to
-> take it a step further, check out step 3.
+### Optional: Customize Theme
 
-### 3. Optional Setup
-
-- Customizing Theme
-
-If you intend to customise the default theme object to match your design
+If you intend to customize the default theme object to match your design
 requirements, you can extend the `theme` from `@chakra-ui/react`.
 
 Chakra UI provides an `extendTheme` function that deep merges the default theme
@@ -107,7 +115,7 @@ project.
 
 If you want to use the icons from Chakra UI, install `@chakra-ui/icons`.
 
-> Follow this guide for customising Chakra Icons
+> Follow this guide for customizing Chakra Icons
 > [Using Chakra UI Icons](/docs/components/media-and-icons/icon).
 
 #### Notes on TypeScript 🚨

--- a/pages/guides/getting-started/redwoodjs-guide.mdx
+++ b/pages/guides/getting-started/redwoodjs-guide.mdx
@@ -26,16 +26,19 @@ of your application.
 Go to `App.js` and add the `ChakraProvider` like this:
 
 ```jsx live=false
-import { ChakraProvider } from '@chakra-ui/react'
+import { ChakraProvider, ColorModeScript } from '@chakra-ui/react'
 
 const App = () => (
-  <ChakraProvider>
-    <FatalErrorBoundary page={FatalErrorPage}>
-      <RedwoodApolloProvider>
-        <Routes />
-      </RedwoodApolloProvider>
-    </FatalErrorBoundary>
-  </ChakraProvider>
+  <FatalErrorBoundary page={FatalErrorPage}>
+    <RedwoodProvider titleTemplate="%PageTitle | %AppTitle">
+      <ColorModeScript />
+      <ChakraProvider>
+        <RedwoodApolloProvider>
+          <Routes />
+        </RedwoodApolloProvider>
+      </ChakraProvider>
+    </RedwoodProvider>
+  </FatalErrorBoundary>
 )
 
 export default MyApp
@@ -81,13 +84,16 @@ const theme = extendTheme({ colors })
 // 3. Pass the `theme` prop to the `ChakraProvider`
 function App() {
   return (
-    <ChakraProvider theme={theme}>
-      <FatalErrorBoundary page={FatalErrorPage}>
-        <RedwoodApolloProvider>
-          <Routes />
-        </RedwoodApolloProvider>
-      </FatalErrorBoundary>
-    </ChakraProvider>
+    <FatalErrorBoundary page={FatalErrorPage}>
+      <RedwoodProvider titleTemplate="%PageTitle | %AppTitle">
+        <ColorModeScript />
+        <ChakraProvider>
+          <RedwoodApolloProvider>
+            <Routes />
+          </RedwoodApolloProvider>
+        </ChakraProvider>
+      </RedwoodProvider>
+    </FatalErrorBoundary>
   )
 }
 ```

--- a/pages/guides/getting-started/redwoodjs-guide.mdx
+++ b/pages/guides/getting-started/redwoodjs-guide.mdx
@@ -19,7 +19,8 @@ yarn redwood setup ui chakra-ui
 This will make the necessary modifications to your `App.tsx` (or `App.js`, respectively) 
 which are basically the same as outlined in manual installation steps below.
 
-See [below](#optional-customize-theme) for additional (optional) setup steps.
+See [additional setup](#additional-setup) (such as including 
+theme customizations and Storybook integration) below.
 
 ### Manual
 
@@ -57,14 +58,16 @@ of your application.  Go to `App.js` and add the `ChakraProvider` like this:
    ```
 
 > Boom! You're good to go with steps 1 and 2 🚀🚀🚀 However, if you'd love to
-> take it a step further, check out the optional steps [outlined below](#optional-customize-theme).
+> take it a step further, check out the additional steps [outlined below](#additional-setup).
 
 ### Notes on TypeScript 🚨
 
 Please note that when adding Chakra UI to a TypeScript project, a minimum
 TypeScript version of `4.1.0` is required.
 
-## Optional: Customize Theme
+## Additional setup
+
+### Customize Theme
 
 If you intend to [customize the default theme](/docs/styled-system/theming/customize-theme), 
 you will need to pass your extended theme object as a prop 
@@ -99,6 +102,50 @@ const App = () => (
   </FatalErrorBoundary>
 )
 ```
+
+### Storybook Integration
+
+RedwoodJS ships with Storybook included. To automatically wrap your 
+your stories with the `<ChakraProvider />` and add a color mode toggle, follow 
+the steps below.
+
+> The steps outlined here are semantically identical to 
+our [Storybook integration Guide](/guides/integrations/with-storybook), 
+only the install commands and file locations differ.
+
+1. Install the official Storybook Addon for Chakra UI:
+   ```bash
+   yarn workspace web add -D @chakra-ui/storybook-addon
+   yarn workspace web add @chakra-ui/icons
+   ```
+   
+2. Add the addon to your configuration in `web/config/storybook.config.js`:
+   ```jsx live=false
+   module.exports = {
+     addons: [
+       // ...
+       '@chakra-ui/storybook-addon'
+     ],
+   }
+   ```
+
+3. Additional configuration:  
+   In case you are using any [Theme customizations](/docs/styled-system/theming/customize-theme),
+you will want to see them applied in Storybook as well. 
+Enable them in `web/config/storybook.preview.js` like this:
+
+   ```jsx live=false
+   const theme = require('../path/to/your/theme')
+
+   export const parameters = {
+     // ...
+     chakra: {
+       theme,
+     },
+   }
+   ```
+
+   The `chakra` object accepts the same [props](#chakraprovider-props) as `ChakraProvider` (without `children`).
 
 ## ChakraProvider Props
 


### PR DESCRIPTION
Refers to https://github.com/chakra-ui/chakra-ui/discussions/5785
Closes #499 

## 📝 Description

This updates the RedwoodJS integration tutorial to state of the art – in order to 
rectify / avoid any confusion that may arise when comparing the integration 
tutorial with the way RedwoodJS integrates Chakra UI out-of-the-box. 


## ⛳️ Current behavior (updates)

The current doc seems out outdated. @TimKolberger themself [contributed a
script](https://github.com/redwoodjs/redwood/pull/3715) to RedwoodJS that 
creates a component structure a little different from what the tutorial advises.

## 🚀 New behavior

This PR synchronizes the doc with the way RedwoodJS sets up projects for 
ChakraUI. Also added a reference to the console command to achieve that.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

https://github.com/chakra-ui/chakra-ui/discussions/5785

Maintainers, pls feels free to fixup or amend my commits at your discretion.