### PR TITLE
fix(react-live-block): allow horizontal scroll of preview in mobile screens

### DIFF
--- a/src/components/mdx-components/codeblock/react-live-block.tsx
+++ b/src/components/mdx-components/codeblock/react-live-block.tsx
@@ -14,6 +14,8 @@ const LiveCodePreview = chakra(LivePreview, {
     p: 3,
     borderWidth: 1,
     borderRadius: '12px',
+    overflowX: 'auto',
+    whiteSpace: 'pre',
   },
 })
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

`overflowX: auto` and `whiteSpace: pre` are applied to the `LiveCodePreview` component to constrain the live code examples within the preview container, allow for horizontal scroll, and preserve the intended white space from the example.

## ⛳️ Current behavior (updates)

Some current live previews are overflowing the preview container when viewed in a mobile device, breaking the page layout.

## 🚀 New behavior

Hide the overflow and allow for horizontal scrolling with `overflowX: auto` applied to the `LiveCodePreview` component.

Also apply `whiteSpace: pre` to preserve white space of any text content and prevent the text from getting compressed, depending on the created code example.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

This PR provides a simpler, more global, and less confusing fix than PR #488.