### PR TITLE
docs(container): update "Container Size" section

### DIFF
--- a/pages/docs/components/layout/container.mdx
+++ b/pages/docs/components/layout/container.mdx
@@ -61,7 +61,7 @@ values or changing the size tokens defined in
     "550px" Container
   </Container>
   <Container maxW='container.sm' bg='green.400' color='#262626'>
-    "small" Container
+    "container.sm" Container
   </Container>
 </VStack>
 ```

--- a/pages/docs/components/layout/container.mdx
+++ b/pages/docs/components/layout/container.mdx
@@ -46,10 +46,15 @@ tokens defined in
 
 ```jsx
 <VStack>
-  <Container maxW='container.xl'>Extra-Large Container</Container>
-  <Container maxW='container.lg'>Large Container</Container>
-  <Container maxW='container.md'>Medium Container</Container>
-  <Container maxW='container.sm'>Small Container</Container>
+  <Container maxW='md' bg='blue.600' color='white'>
+    "md" Container
+  </Container>
+  <Container maxW='550px' bg='purple.600' color='white'>
+    "550px" Container
+  </Container>
+  <Container maxW='container.sm' bg='green.400' color='#262626'>
+    "small" Container
+  </Container>
 </VStack>
 ```
 

--- a/pages/docs/components/layout/container.mdx
+++ b/pages/docs/components/layout/container.mdx
@@ -39,9 +39,9 @@ To contain any piece of content, wrap it in the `Container` component.
 
 ## Container Size
 
-By default, it sets the `max-width` of the content to 60 characters (`60ch`) but
-you can customize this by passing custom `maxWidth` values or changing the size
-tokens defined in
+By default, the `Container` component sets the `maxWidth` of the content to 60
+characters (`60ch`) but you can customize this by passing custom `maxWidth`
+values or changing the size tokens defined in
 [theme.sizes](https://chakra-ui.com/docs/styled-system/theming/theme#sizes).
 
 ```jsx

--- a/pages/docs/components/layout/container.mdx
+++ b/pages/docs/components/layout/container.mdx
@@ -42,7 +42,7 @@ To contain any piece of content, wrap it in the `Container` component.
 By default, the `Container` component sets the `maxWidth` of the content to 60
 characters (`60ch`) but you can customize this by passing custom `maxWidth`
 values or changing the size tokens defined in
-[theme.sizes](https://chakra-ui.com/docs/styled-system/theming/theme#sizes).
+[theme.sizes.container](https://chakra-ui.com/docs/styled-system/theming/theme#sizes).
 
 > - About the default value: The `ch` unit is a relative unit defined by the
 >   rendered typeface's "0" character width. This width varies by the shape and

--- a/pages/docs/components/layout/container.mdx
+++ b/pages/docs/components/layout/container.mdx
@@ -44,6 +44,14 @@ characters (`60ch`) but you can customize this by passing custom `maxWidth`
 values or changing the size tokens defined in
 [theme.sizes](https://chakra-ui.com/docs/styled-system/theming/theme#sizes).
 
+> - About the default value: The `ch` unit is a relative unit defined by the
+>   rendered typeface's "0" character width. This width varies by the shape and
+>   style of the font.
+> - If you are curious about the reason for this default value of `60`
+>   characters, consider this explanation about
+>   [line length](https://betterwebtype.com/articles/2019/06/16/5-keys-to-accessible-web-typography/#line-length)
+>   from Better Web Type.
+
 ```jsx
 <VStack>
   <Container maxW='md' bg='blue.600' color='white'>

--- a/pages/docs/components/layout/container.mdx
+++ b/pages/docs/components/layout/container.mdx
@@ -10,10 +10,6 @@ description:
 Containers are used to constrain a content's width to the current breakpoint,
 while keeping it fluid.
 
-By default, it sets the `max-width` of the content to 60 characters (`60ch`) but
-you can customize this by passing custom `maxWidth` values or changing the
-container size tokens defined in `theme.sizes.container`.
-
 <ComponentLinks
   theme={{ componentName: 'container' }}
   github={{ package: 'layout' }}
@@ -43,7 +39,10 @@ To contain any piece of content, wrap it in the `Container` component.
 
 ## Container Size
 
-To set the size of a Container, use the `maxW` attribute.
+By default, it sets the `max-width` of the content to 60 characters (`60ch`) but
+you can customize this by passing custom `maxWidth` values or changing the size
+tokens defined in
+[theme.sizes](https://chakra-ui.com/docs/styled-system/theming/theme#sizes).
 
 ```jsx
 <VStack>


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes Issue #401

## 📝 Description

Moves the details about `maxWidth` to the section [Container Size](http://localhost:3000/docs/components/layout/container#container-size) and update the description and examples

## ⛳️ Current behavior (updates)

- The detail about the default `maxWidth` sits at the top of the page away from the size section
- The container size live code example has no color to be able to easily visualize the different maxWidth values rendered to the `Container` components.
- Per discussion in issue #401, there is no explanation on the page given about the default value of `60ch`. Not everyone knows about this unit value or knows why this particular value might be used. (This is related to UX/UI best/suggested practice)

## 🚀 New behavior

- The details about the default `maxWidth` are moved to the sizes section and updated to include notes about the default value, providing a definition about the unit value used and a source to view to consider the purpose of the given default value of `60` characters.
- The live code example is simplified to show an example of each type a value that can be used:
  - a `size` token
  - a `size.container` token
  - an explicit unit value
- Change the text `theme.sizes.container` in the details to `theme.sizes`, and convert it to a link to the style props section in the docs.

## 💣 Is this a breaking change (Yes/No):

No
