### PR TITLE
fix: adding pipe for bumping chakra ui versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
           git diff --staged --quiet || git commit -m "docs(changelog): $GITHUB_SHA"
 
       - name: Bump Chakra UI version
-        run: /
+        run: |
           yarn upgrade @chakra-ui/react --latest
           yarn upgrade @chakra-ui/cli --latest
           yarn upgrade @chakra-ui/props-docs --latest


### PR DESCRIPTION
Closes # /

Sibling PR to review: 
https://github.com/chakra-ui/chakra-ui/pull/5834

## 📝 Description
The issue was if we are running multiple yarn commands, we should add a pipe (|) instead of slash (/)

## ⛳️ Current behavior (updates)
The github action failed.

## 🚀 New behavior
The github action is actually fixed and will bump the Chakra version.

## 💣 Is this a breaking change (Yes/No):
No.
