### PR TITLE
fix(react-live-block): remove `whiteSpace: pre` from `LiveCodePreview` baseStyle

### DIFF
--- a/src/components/mdx-components/codeblock/react-live-block.tsx
+++ b/src/components/mdx-components/codeblock/react-live-block.tsx
@@ -15,7 +15,6 @@ const LiveCodePreview = chakra(LivePreview, {
     borderWidth: 1,
     borderRadius: '12px',
     overflowX: 'auto',
-    whiteSpace: 'pre',
   },
 })
 


### PR DESCRIPTION


<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #505 

## 📝 Description

With the merge of PR #496 the intended purpose of including `whiteSpace: pre` with the addition of `overflowX: auto` in the `LiveCodePreview` component was to retain white-space when horizontal scroll occurs in live code example previews, so text content was not compressed. Unfortunately, an overlooked side effect is other previously unaffected examples forcing text content out of view with no ability to scroll, or creating new overflow. This PR simply removes the `whiteSpace` prop

## ⛳️ Current behavior (updates)

Examples like those in the [`Alert` docs](https://chakra-ui.com/docs/components/feedback/alert) have text content forced out of view in the preview window and no ability for horizontal scroll.

Examples like the [`Popover` basic usage](https://chakra-ui.com/docs/components/feedback/alert) have text content that overflows their parent components.

## 🚀 New behavior

Examples that had parent component with relative width values will allow the text content to wrap and stay within the initial view of the container

## 💣 Is this a breaking change (Yes/No):

No
