### PR TITLE
fix(alert): remove `CloseButton` component from basic usage example

### DIFF
--- a/pages/docs/components/feedback/alert.mdx
+++ b/pages/docs/components/feedback/alert.mdx
@@ -41,9 +41,8 @@ import {
 ```jsx
 <Alert status='error'>
   <AlertIcon />
-  <AlertTitle mr={2}>Your browser is outdated!</AlertTitle>
+  <AlertTitle>Your browser is outdated!</AlertTitle>
   <AlertDescription>Your Chakra experience may be degraded.</AlertDescription>
-  <CloseButton position='absolute' right='8px' top='8px' />
 </Alert>
 ```
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #522 

## 📝 Description

On certain smaller mobile screens, the content within the live example code of the [Usage]() section overlaps the close button due to the close button being absolutely positioned and no other adjustment to wrap the text before reaching this component.

Along with this, it is not considered "basic usage" of the `Alert` component to have a close button that is not a part of the component package.

Therefore, this PR simply removes the `CloseButton` component.

## ⛳️ Current behavior (updates)

At certain mobile screen sizes roughly 500px and below, the content from `AlertDescription` overlaps the `CloseButton` component.

## 🚀 New behavior

`CloseButton` component is removed and the `AlertDescription` component behaves as normal.
