### PR TITLE
fix(algolia-search): adjust color contrast to search button

### DIFF
--- a/src/components/algolia-search.tsx
+++ b/src/components/algolia-search.tsx
@@ -80,7 +80,7 @@ export const SearchButton = React.forwardRef(function SearchButton(
           <VisuallyHidden>
             {t('component.algolia-search.press')}{' '}
           </VisuallyHidden>
-          <Kbd color='gray.500' rounded='2px'>
+          <Kbd rounded='2px'>
             <chakra.div
               as='abbr'
               title={actionKey[1]}
@@ -90,9 +90,7 @@ export const SearchButton = React.forwardRef(function SearchButton(
             </chakra.div>
           </Kbd>
           <VisuallyHidden> {t('component.algolia-search.and')} </VisuallyHidden>
-          <Kbd color='gray.500' rounded='2px'>
-            K
-          </Kbd>
+          <Kbd rounded='2px'>K</Kbd>
           <VisuallyHidden>
             {' '}
             {t('component.algolia-search.to-search')}

--- a/src/components/algolia-search.tsx
+++ b/src/components/algolia-search.tsx
@@ -50,6 +50,8 @@ export const SearchButton = React.forwardRef(function SearchButton(
     }
   }, [])
 
+  const searchTextColor = useColorModeValue('gray.600', 'gray.400')
+
   return (
     <chakra.button
       flex='1'
@@ -62,7 +64,7 @@ export const SearchButton = React.forwardRef(function SearchButton(
       whiteSpace='nowrap'
       display={{ base: 'none', sm: 'flex' }}
       alignItems='center'
-      color='gray.400'
+      color={searchTextColor}
       py='3'
       px='4'
       outline='0'


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

This PR updates the color contrast in the `AlgoliaSearch` button component so all text content is WCAG compliant.

The `color` prop is removed from the `Kbd` components that render `Crtl` and `K` text.

The `color` prop in the parent button receives a `useColorModeValue` value of either `gray.600` or `gray.400` which comply with light and dark mode contrast respectively and pass it's value down to the children.

## ⛳️ Current behavior (updates)

In dark mode, the `Crtl` and `K` textual inputs fail accessibility with a contrast ratio of 2.99.

In light mode, all text and the search icon fail accessibility with contrast ratios of 2.26 to 3.56.

## 🚀 New behavior

In dark mode, all text pass accessibility with a contrast ratio of 5.32.

In light mode, all text pass accessibility with contrast ratios of 6.68 to 7.53.

## 📝 Additional Information

_This partially addresses issue [#5886](https://github.com/chakra-ui/chakra-ui/issues/5886) from the ChakraUI main repo._