### PR TITLE
fix(with-framer): update factory example and details

### DIFF
--- a/configs/sandpack-contents/framer-motion-examples/chakra-factory.js
+++ b/configs/sandpack-contents/framer-motion-examples/chakra-factory.js
@@ -3,6 +3,10 @@ module.exports = {
   import { motion, isValidMotionProp } from 'framer-motion';
     
   const ChakraBox = chakra(motion.div, {
+    /**
+     * Allow motion props and the children prop to be forwarded.
+     * All other chakra props not matching the motion props will still be forwarded.
+     */
     shouldForwardProp: (prop) => isValidMotionProp(prop) || prop === 'children',
   });
     

--- a/configs/sandpack-contents/framer-motion-examples/chakra-factory.js
+++ b/configs/sandpack-contents/framer-motion-examples/chakra-factory.js
@@ -1,47 +1,51 @@
 module.exports = {
   App: `import { Container, chakra } from '@chakra-ui/react';
-import { motion, isValidMotionProp } from 'framer-motion';
-  
-const ChakraBox = chakra(motion.div, {
-  shouldForwardProp: isValidMotionProp,
-});
-  
-export default function App() {
-  return (
-    <Container h="100vh" d="flex" alignItems="center" justifyContent="center">
-      <ChakraBox
-        animate={{
-          scale: [1, 2, 2, 1, 1],
-          rotate: [0, 0, 270, 270, 0],
-          borderRadius: ["20%", "20%", "50%", "50%", "20%"],
-        }}
-        // @ts-ignore no problem in operation, although type error appears.
-        transition={{
-          duration: 2,
-          ease: "easeInOut",
-          repeat: Infinity,
-          repeatType: "loop",
-        }}
-        padding="2"
-        bgGradient="linear(to-l, #7928CA, #FF0080)"
-        width="12"
-        height="12"
-        display="flex"
-      />
-    </Container>
-  )
-}`,
+  import { motion, isValidMotionProp } from 'framer-motion';
+    
+  const ChakraBox = chakra(motion.div, {
+    shouldForwardProp: (prop) => isValidMotionProp(prop) || prop === 'children',
+  });
+    
+  export default function App() {
+    return (
+      <Container h="100vh" d="flex" alignItems="center" justifyContent="center">
+        <ChakraBox
+          animate={{
+            scale: [1, 2, 2, 1, 1],
+            rotate: [0, 0, 270, 270, 0],
+            borderRadius: ["20%", "20%", "50%", "50%", "20%"],
+          }}
+          // @ts-ignore no problem in operation, although type error appears.
+          transition={{
+            duration: 3,
+            ease: "easeInOut",
+            repeat: Infinity,
+            repeatType: "loop",
+          }}
+          padding="2"
+          bgGradient="linear(to-l, #7928CA, #FF0080)"
+          display="flex"
+          justifyContent="center"
+          alignItems="center"
+          width="100px"
+          height="100px"
+        >
+          I'm Dizzy!
+        </ChakraBox>
+      </Container>
+    )
+  }`,
   Index: `import * as React from "react";
-import { render } from "react-dom";
-import { ChakraProvider } from "@chakra-ui/react";
-  
-import App from "./App";
-  
-const rootElement = document.getElementById("root");
-render(
-  <ChakraProvider>
-    <App />
-  </ChakraProvider>,
-  rootElement
-);`,
+  import { render } from "react-dom";
+  import { ChakraProvider } from "@chakra-ui/react";
+    
+  import App from "./App";
+    
+  const rootElement = document.getElementById("root");
+  render(
+    <ChakraProvider>
+      <App />
+    </ChakraProvider>,
+    rootElement
+  );`,
 }

--- a/pages/guides/integrations/with-framer.mdx
+++ b/pages/guides/integrations/with-framer.mdx
@@ -49,7 +49,8 @@ import {
 
 > `shouldForwardProp` is needed to allow framer props to be used instead of the
 > matching props from Chakra. If you do not include "children", then you will
-> not be able to use child components. All other Chakra props can still be used.
+> not be able to use child components. Either way, all other Chakra props can
+> still be used.
 
 ### as prop
 

--- a/pages/guides/integrations/with-framer.mdx
+++ b/pages/guides/integrations/with-framer.mdx
@@ -47,6 +47,10 @@ import {
   }}
 />
 
+> `shouldForwardProp` is needed to allow framer props to be used instead of the
+> matching props from Chakra. If you do not include "children", then you will
+> not be able to use child components. All other Chakra props can still be used.
+
 ### as prop
 
 You can also use `as` prop to add animations and interactions.


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #541

## 📝 Description

This is an update to the Chakra Factory example for [Chakra + Framer](https://chakra-ui.com/guides/integrations/with-framer#usage), where it shows the inclusion of the `children` prop in `shouldForwardProps`

## ⛳️ Current behavior (updates)

Currently, `shouldForwardProp` only passes in `isValidMotionProp` so that the Framer animations are active and not overridden by matching props from Chakra. However, you can't use child components because the `children` props ends up being ignored, despite all other chakra props still available for use. This is not notated for users to be aware of.

## 🚀 New behavior

The inclusion of forwarding the `children` prop in `shouldForwardProps` is provided in the example with a comment underneath. All other chakra props not matching the motion props can still be used.

The overall example is updated to reflect the `children` prop being included.
