### PR TITLE
docs(flex): update spacer live example for mobile view

### DIFF
--- a/pages/docs/components/layout/flex.mdx
+++ b/pages/docs/components/layout/flex.mdx
@@ -118,18 +118,23 @@ different widths differently.
 A good use case for `Spacer` is to create a navbar with a signup/login button
 aligned to the right.
 
+Since `Spacer` renders a `div`, any `gap` value provided to the parent is
+applied to both sides of this component, and therefore make the gap appear
+doubled when the spacer is completely collapsed.
+
+> The example below is not responsive on purpose as you might switch to a
+> collapsed menu on mobile.
+
 ```jsx
-<Flex>
+<Flex minWidth='max-content' alignItems='center' gap='2'>
   <Box p='2'>
     <Heading size='md'>Chakra App</Heading>
   </Box>
   <Spacer />
-  <Box>
-    <Button colorScheme='teal' mr='4'>
-      Sign Up
-    </Button>
+  <ButtonGroup gap='2'>
+    <Button colorScheme='teal'>Sign Up</Button>
     <Button colorScheme='teal'>Log in</Button>
-  </Box>
+  </ButtonGroup>
 </Flex>
 ```
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Updates the section regarding the `Spacer` component and update the live code example to have a better view on a mobile device.

## ⛳️ Current behavior (updates)

The layout of the example code at mobile view (smallest view of `375px`) looks broken, with a compressed "logo" text and tightly stacked buttons.

## 🚀 New behavior

Added documentation mentions the behavior of the `Spacer` with a parent using the `gap` prop.

The example code is refactored so that the buttons are appropriately wrapped in a `ButtonGroup` component, and the entire example does not collapse, with the intention that this example is meant for desktop view and not mobile view. Added a note about the latter.
