### PR TITLE
docs: changed remix server import location

### DIFF
--- a/pages/guides/getting-started/remix-guide.mdx
+++ b/pages/guides/getting-started/remix-guide.mdx
@@ -96,7 +96,7 @@ hydrate(
 import { renderToString } from 'react-dom/server'
 import { CacheProvider } from '@emotion/react'
 import createEmotionServer from '@emotion/server/create-instance'
-import { RemixServer } from '@remix-run/server'
+import { RemixServer } from '@remix-run/react'
 import type { EntryContext } from '@remix-run/node' // Depends on the runtime you choose
 
 import { ServerStyleContext } from './context'


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

> Fixed import of RemixServer component location

## ⛳️ Current behavior (updates)

> Receiving following error when setting chakra up to remix:
`Error: Cannot find module '@remix-run/server'`

## 🚀 New behavior

> Avoids users to have an error when setting up chakra-ui with Remix

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information
