### PR TITLE
fix(toast): replace `Stack` parent component with `Wrap` in "Closing Toasts" example

### DIFF
--- a/pages/docs/components/feedback/toast.mdx
+++ b/pages/docs/components/feedback/toast.mdx
@@ -107,7 +107,7 @@ function ClosingToastExample() {
   }
 
   return (
-    <Stack isInline spacing={2}>
+    <Wrap>
       <Button onClick={addToast} type='button'>
         Toast
       </Button>
@@ -119,7 +119,7 @@ function ClosingToastExample() {
       <Button onClick={closeAll} type='button' variant='outline'>
         Close all toasts
       </Button>
-    </Stack>
+    </Wrap>
   )
 }
 ```


### PR DESCRIPTION


<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Use a `Wrap` component instead of `Stack` surrounding the buttons in the "Closing Toasts" section example so the button text never compresses and allow the buttons to stack in mobile view, down to `375px` screen width

## ⛳️ Current behavior (updates)

The buttons in the "Closing Toasts" example stay inline via `Stack` and it's `isInline` prop wrapping the buttons, which compress the button text when shown on a mobile device.

## 🚀 New behavior

Replace `Stack` with `Wrap` and no props to allow the text content to not overflow the button and allow the buttons to stack when the width of the container is too small.
