### PR TITLE
docs(menu): update "Customizing the button" section and add link to `forwardRef`

### DIFF
--- a/pages/docs/components/overlay/menu.mdx
+++ b/pages/docs/components/overlay/menu.mdx
@@ -94,10 +94,14 @@ Using the `as` prop of the `MenuButton`, you can render a custom component
 instead of the default `MenuButton`. For instance, you can use Chakra's `Button`
 component, or your own custom component.
 
-> Custom components must take a `ref` prop which is assigned to the React
-> component that triggers the menu opening. This is so that the `MenuList`
-> popover can be positioned correctly. Without this, the `MenuList` will render
-> in an undefined position.
+> If you decide to pass your own component to `MenuButton`, it needs to accept a
+> `ref` so that the `MenuList` can be positioned correctly. You can use Chakra's
+> `forwardRef` to supply the `ref` along with being able to use Chakra props.
+> Without a `ref`, the `MenuList` will render in an undefined position.
+
+(See the documentation on setting up the
+[forwardRef](/docs/components/recipes/as-prop#option-1-using-forwardref-from-chakra-uireact)
+with your custom component.)
 
 ### Letter Navigation
 
@@ -325,13 +329,13 @@ options. Use the `MenuOptionGroup` and `MenuItemOption` components.
 
 ### MenuButton Props
 
-`MenuButton` composes [Box](/docs/components/layout/box) so you can pass all `Box` props to
-change its style.
+`MenuButton` composes [Box](/docs/components/layout/box) so you can pass all
+`Box` props to change its style.
 
 ### MenuList Props
 
-`MenuList` composes [Box](/docs/components/layout/box) so you can pass all `Box` props to
-change its style.
+`MenuList` composes [Box](/docs/components/layout/box) so you can pass all `Box`
+props to change its style.
 
 <PropsTable of='MenuList' />
 
@@ -341,8 +345,8 @@ change its style.
 
 ### MenuGroup Props
 
-`MenuGroup` composes [Box](/docs/components/layout/box) so you can pass all `Box` props to
-change its style.
+`MenuGroup` composes [Box](/docs/components/layout/box) so you can pass all
+`Box` props to change its style.
 
 ### MenuOptionGroup Props
 
@@ -350,7 +354,7 @@ change its style.
 
 ### MenuItemOption Props
 
-`MenuItemOption` composes [Box](/docs/components/layout/box) so you can pass all box props
-in addition to these:
+`MenuItemOption` composes [Box](/docs/components/layout/box) so you can pass all
+box props in addition to these:
 
 <PropsTable of='MenuItemOption' />


### PR DESCRIPTION


<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Update details of the "Customizing the button" section of the `Menu` docs to reference the Chakra `forwardRef` function.

## ⛳️ Current behavior (updates)

Current documentation mentions that a `ref` is needed to be supplied to a custom component when using it in the `MenuButton` so that the styling of the popover is maintained. But to a new user of Chakra, they may not necessarily know how to do that in the context of Chakra.

## 🚀 New behavior

Reword the details to provide the suggestion of creating the custom component using `forwardRef` as a way to supply the `ref`, along with allowing the custom component to be flexible within Chakra.
