### PR TITLE
docs(use-disclosure): create details for the getter methods

### DIFF
--- a/pages/docs/styled-system/utility-hooks/use-disclosure.mdx
+++ b/pages/docs/styled-system/utility-hooks/use-disclosure.mdx
@@ -46,11 +46,11 @@ The component that uses `getDisclosureProps` receives the following props:
 
 The button that uses `getButtonProps` for toggling receives the following props:
 
-- An optional custom `id` provided as a prop to the hook.
 - A dynamically rendered `aria-expanded` attribute to let a screen reader know
   whether the disclosure component is visible.
-- The `aria-controls` attribute to let a screen reader know which disclosure
-  component is controlled by the button.
+- The `aria-controls` attribute using the custom `id` provided as a prop to the
+  hook. This lets a screen reader know which disclosure component is controlled
+  by the button.
 - An onClick handler that uses the `onToggle` callback along with any other
   click events passed as an `onClick` prop to `getButtonProps`;
 

--- a/pages/docs/styled-system/utility-hooks/use-disclosure.mdx
+++ b/pages/docs/styled-system/utility-hooks/use-disclosure.mdx
@@ -74,6 +74,13 @@ function Basic() {
 }
 ```
 
+If you need more control over the disclosure behavior, you can use a combination
+of the getter props along with the other methods and values returned by the
+hook.
+
+Below is use of the return fields of the hook without a getter to control the
+`Drawer` component on button toggle.
+
 ```jsx
 function Example() {
   const { isOpen, onOpen, onClose } = useDisclosure()

--- a/pages/docs/styled-system/utility-hooks/use-disclosure.mdx
+++ b/pages/docs/styled-system/utility-hooks/use-disclosure.mdx
@@ -20,12 +20,14 @@ import { useDisclosure } from '@chakra-ui/react'
 
 The `useDisclosure` hook returns an object with the following fields:
 
-| Name       | Type       | Default | Description                                                         |
-| ---------- | ---------- | ------- | ------------------------------------------------------------------- |
-| `isOpen`   | `boolean`  | `false` | If `true`, it sets the controlled component to its visible state.   |
-| `onClose`  | `function` |         | Callback function to set a falsy value for the `isOpen` parameter.  |
-| `onOpen`   | `function` |         | Callback function to set a truthy value for the `isOpen` parameter. |
-| `onToggle` | `function` |         | Callback function to toggle the value of the `isOpen` parameter.    |
+| Name                 | Type       | Default | Description                                                                               |
+| -------------------- | ---------- | ------- | ----------------------------------------------------------------------------------------- |
+| `isOpen`             | `boolean`  | `false` | If `true`, it sets the controlled component to its visible state.                         |
+| `onClose`            | `function` |         | Callback function to set a falsy value for the `isOpen` parameter.                        |
+| `onOpen`             | `function` |         | Callback function to set a truthy value for the `isOpen` parameter.                       |
+| `onToggle`           | `function` |         | Callback function to toggle the value of the `isOpen` parameter.                          |
+| `getDisclosureProps` | `function` |         | Callback function to retrieve a set of props for the controlled component.                |
+| `getButtonProps`     | `function` |         | Callback function to retrieve a set of props for the button that triggers the disclosure. |
 
 ## Usage
 

--- a/pages/docs/styled-system/utility-hooks/use-disclosure.mdx
+++ b/pages/docs/styled-system/utility-hooks/use-disclosure.mdx
@@ -42,7 +42,7 @@ The component that uses `getDisclosureProps` receives the following props:
 - An optional custom `id` provided as a prop to the hook.
 - A dynamically rendered `hidden` attribute.
 
-This getter can directly accept any additional props for the component.
+`getDisclosureProps` can directly accept any additional props for the component.
 
 The button that uses `getButtonProps` for toggling receives the following props:
 
@@ -54,7 +54,7 @@ The button that uses `getButtonProps` for toggling receives the following props:
 - An onClick handler that uses the `onToggle` callback along with any other
   click events passed as an `onClick` prop to `getButtonProps`;
 
-This getter can also directly accept any additional props for the button.
+`getButtonProps` can also directly accept any additional props for the button.
 
 ```jsx
 function Basic() {

--- a/pages/docs/styled-system/utility-hooks/use-disclosure.mdx
+++ b/pages/docs/styled-system/utility-hooks/use-disclosure.mdx
@@ -32,54 +32,10 @@ The `useDisclosure` hook returns an object with the following fields:
 
 ## Usage
 
-For simple disclosures, you can use the `getDisclosureProps` and
-`getButtonProps` methods returned by the hook to provide the needed attributes
-and handlers to the respective component and button for basic toggling behavior
-and accessibility.
+You can use a combination of the methods and values returned by the hook for
+various control of the components affected by the disclosure.
 
-The component that uses `getDisclosureProps` receives the following props:
-
-- An `id` (provided optionally as a custom prop to the hook).
-- A dynamically rendered `hidden` attribute.
-
-`getDisclosureProps` can directly accept any additional props for the component.
-
-The button that uses `getButtonProps` for toggling receives the following props:
-
-- A dynamically rendered `aria-expanded` attribute to let a screen reader know
-  whether the disclosure component is visible.
-- The `aria-controls` attribute using the `id` (provided optionally as a custom
-  prop to the hook). This lets a screen reader know which component is
-  controlled by the button.
-- An onClick handler that uses the `onToggle` callback along with any other
-  click events passed as an `onClick` prop to `getButtonProps`;
-
-`getButtonProps` can also directly accept any additional props for the button.
-
-```jsx
-function Basic() {
-  const { getDisclosureProps, getButtonProps } = useDisclosure()
-
-  const buttonProps = getButtonProps()
-  const disclosureProps = getDisclosureProps()
-  return (
-    <>
-      <Button {...buttonProps}>Toggle Me</Button>
-      <Text {...disclosureProps} mt={4}>
-        This text is being visibly toggled hidden and shown by the button.
-        <br />
-        (Inspect these components to see the rendered attributes)
-      </Text>
-    </>
-  )
-}
-```
-
-If you need more control over the disclosure behavior, you can use a combination
-of the getter props along with the other methods and values returned by the
-hook.
-
-Below is use of the return fields of the hook without a getter to control the
+Below is the use of returned fields of the hook without a getter to control the
 `Drawer` component on button toggle.
 
 ```jsx
@@ -100,6 +56,49 @@ function Example() {
           </DrawerBody>
         </DrawerContent>
       </Drawer>
+    </>
+  )
+}
+```
+
+Using the `getDisclosureProps` and `getButtonProps` methods returned by the hook
+provides the needed attributes and handlers to the respective component and
+button for visibility toggling and accessibility.
+
+The component that uses `getDisclosureProps` receives the following props:
+
+- An `id` (can optionally pass this in as a prop to the hook to render a custom
+  value).
+- A dynamically rendered `hidden` attribute.
+
+`getDisclosureProps` can directly accept any additional props for the component.
+
+The button that uses `getButtonProps` for toggling receives the following props:
+
+- A dynamically rendered `aria-expanded` attribute to let a screen reader know
+  whether the disclosure component is visible.
+- The `aria-controls` attribute using the `id` (can optionally pass `id` in as a
+  prop to the hook to render a custom value). This lets a screen reader know
+  which component is controlled by the button.
+- An onClick handler that uses the `onToggle` callback along with any other
+  click events passed as an `onClick` prop to `getButtonProps`
+
+`getButtonProps` can also directly accept any additional props for the button.
+
+```jsx
+function Basic() {
+  const { getDisclosureProps, getButtonProps } = useDisclosure()
+
+  const buttonProps = getButtonProps()
+  const disclosureProps = getDisclosureProps()
+  return (
+    <>
+      <Button {...buttonProps}>Toggle Me</Button>
+      <Text {...disclosureProps} mt={4}>
+        This text is being visibly toggled hidden and shown by the button.
+        <br />
+        (Inspect these components to see the rendered attributes)
+      </Text>
     </>
   )
 }

--- a/pages/docs/styled-system/utility-hooks/use-disclosure.mdx
+++ b/pages/docs/styled-system/utility-hooks/use-disclosure.mdx
@@ -31,6 +31,49 @@ The `useDisclosure` hook returns an object with the following fields:
 
 ## Usage
 
+For simple disclosures, you can use the `getDisclosureProps` and
+`getButtonProps` methods returned by the hook to provide the needed attributes
+and handlers to the respective component and button for basic toggling behavior
+and accessibility.
+
+The component that uses `getDisclosureProps` receives the following props:
+
+- An optional custom `id` provided as a prop to the hook.
+- A dynamically rendered `hidden` attribute.
+
+This getter can directly accept any additional props for the component.
+
+The button that uses `getButtonProps` for toggling receives the following props:
+
+- An optional custom `id` provided as a prop to the hook.
+- A dynamically rendered `aria-expanded` attribute to let a screen reader know
+  whether the disclosure component is visible.
+- The `aria-controls` attribute to let a screen reader know which disclosure
+  component is controlled by the button.
+- An onClick handler that uses the `onToggle` callback along with any other
+  click events passed as an `onClick` prop to `getButtonProps`;
+
+This getter can also directly accept any additional props for the button.
+
+```jsx
+function Basic() {
+  const { getDisclosureProps, getButtonProps } = useDisclosure()
+
+  const buttonProps = getButtonProps()
+  const disclosureProps = getDisclosureProps()
+  return (
+    <>
+      <Button {...buttonProps}>Toggle Me</Button>
+      <Text {...disclosureProps} mt={4}>
+        This text is being visibly toggled hidden and shown by the button.
+        <br />
+        (Inspect these components to see the rendered attributes)
+      </Text>
+    </>
+  )
+}
+```
+
 ```jsx
 function Example() {
   const { isOpen, onOpen, onClose } = useDisclosure()

--- a/pages/docs/styled-system/utility-hooks/use-disclosure.mdx
+++ b/pages/docs/styled-system/utility-hooks/use-disclosure.mdx
@@ -39,7 +39,7 @@ and accessibility.
 
 The component that uses `getDisclosureProps` receives the following props:
 
-- An optional custom `id` provided as a prop to the hook.
+- An `id` (provided optionally as a custom prop to the hook).
 - A dynamically rendered `hidden` attribute.
 
 `getDisclosureProps` can directly accept any additional props for the component.
@@ -48,9 +48,9 @@ The button that uses `getButtonProps` for toggling receives the following props:
 
 - A dynamically rendered `aria-expanded` attribute to let a screen reader know
   whether the disclosure component is visible.
-- The `aria-controls` attribute using the custom `id` provided as a prop to the
-  hook. This lets a screen reader know which disclosure component is controlled
-  by the button.
+- The `aria-controls` attribute using the `id` (provided optionally as a custom
+  prop to the hook). This lets a screen reader know which component is
+  controlled by the button.
 - An onClick handler that uses the `onToggle` callback along with any other
   click events passed as an `onClick` prop to `getButtonProps`;
 

--- a/pages/docs/styled-system/utility-hooks/use-disclosure.mdx
+++ b/pages/docs/styled-system/utility-hooks/use-disclosure.mdx
@@ -7,7 +7,8 @@ description:
 
 `useDisclosure` is a custom hook used to help handle common `open`, `close`, or
 `toggle` scenarios. It can be used to control feedback component such as
-[Modal](/docs/components/overlay/modal), [AlertDialog](/docs/components/overlay/alert-dialog),
+[Modal](/docs/components/overlay/modal),
+[AlertDialog](/docs/components/overlay/alert-dialog),
 [Drawer](/docs/components/overlay/drawer), etc.
 
 ## Import


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #563 

## 📝 Description

Add documentation for the getter methods returned in the `useDisclosure` hook, and update the rest of the docs for better accuracy of overall usage of the hook.

## ⛳️ Current behavior (updates)

Documentation only provides examples of the functions and boolean value returned by the hook

## 🚀 New behavior

Adds the getter methods with their own example, showing their usage as the most basic with the hook. Updates the original example by providing detail on how the other methods and boolean value returned from the hook are used to provide more control.

## 📝 Additional Information

Until the docsite dependencies are bumped, the `getButtonProps` will still return a static `aria-expanded` value if the user inspects the example button via devtools. Fixed in PR [#5940](https://github.com/chakra-ui/chakra-ui/pull/5940).