### PR TITLE
docs(drawer): update usability in size code example for mobile

### DIFF
--- a/pages/docs/components/overlay/drawer.mdx
+++ b/pages/docs/components/overlay/drawer.mdx
@@ -205,7 +205,7 @@ Pass the `size` prop if you need to adjust the size of the drawer. Values can be
 
 ```jsx
 function SizeExample() {
-  const [size, setSize] = React.useState('md')
+  const [size, setSize] = React.useState('')
   const { isOpen, onOpen, onClose } = useDisclosure()
 
   const handleClick = (newSize) => {
@@ -228,11 +228,18 @@ function SizeExample() {
       <Drawer onClose={onClose} isOpen={isOpen} size={size}>
         <DrawerOverlay />
         <DrawerContent>
+          <DrawerCloseButton />
           <DrawerHeader>{`${size} drawer contents`}</DrawerHeader>
           <DrawerBody>
-            {size === 'full'
-              ? `You're trapped 😆 , refresh the page to leave or press 'Esc' key.`
-              : null}
+            <p>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+              eiusmod tempor incididunt ut labore et dolore magna aliqua.
+              Consequat nisl vel pretium lectus quam id. Semper quis lectus
+              nulla at volutpat diam ut venenatis. Dolor morbi non arcu risus
+              quis varius quam quisque. Massa ultricies mi quis hendrerit dolor
+              magna eget est lorem. Erat imperdiet sed euismod nisi porta.
+              Lectus vestibulum mattis ullamcorper velit.
+            </p>
           </DrawerBody>
         </DrawerContent>
       </Drawer>


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Improve usability of the "Drawer Widths" section code example by providing the ability to toggle the drawer closed via a close button.

## ⛳️ Current behavior (updates)

There is no close button rendered for the different size drawers. This diminishes UX of the example on mobile with the drawers that cover the entire screen, as they force the user to refresh the page to close them.

## 🚀 New behavior

Add close button for each rendered drawer. Also tweak the overall presentation of the example.
