### PR TITLE
fix(changelog): turn off live previews to affected jsx examples

### DIFF
--- a/pages/changelog/index.mdx
+++ b/pages/changelog/index.mdx
@@ -1,14 +1,12 @@
 ---
 title: Changelog
 description: The changelog for Chakra UI React
-slug: "/changelog"
+slug: '/changelog'
 ---
 
 The Changelog gives an overview of the meaningful changes we've made to Chakra
 UI as we keep driving for better performance and best-in-class developer
 experience.
-
-
 
 ## 12-05-2022
 
@@ -35,7 +33,7 @@ experience.
 
 - The `AlertIcon` component accepts custom icons as React children
 
-```jsx
+```jsx live=false
 <AlertIcon>
   <MyCustomIcon />
 </AlertIcon>
@@ -59,7 +57,7 @@ mismatch issues with emotion:
 
 ```js live=false
 module.exports = {
-  addons: ["@chakra-ui/storybook-addon"],
+  addons: ['@chakra-ui/storybook-addon'],
   features: {
     emotionAlias: false,
   },
@@ -75,15 +73,15 @@ which are present in your Chakra UI Theme.
 
 ```tsx
 // button.stories.tsx
-import { getThemingArgTypes } from "@chakra-ui/storybook-addon"
-import { theme } from "<your-theme>"
+import { getThemingArgTypes } from '@chakra-ui/storybook-addon'
+import { theme } from '<your-theme>'
 
 export default {
-  title: "Components / Forms / Button",
-  argTypes: getThemingArgTypes(theme, "Button"),
+  title: 'Components / Forms / Button',
+  argTypes: getThemingArgTypes(theme, 'Button'),
 }
 
-interface StoryProps extends ThemingProps<"Button"> {}
+interface StoryProps extends ThemingProps<'Button'> {}
 
 export const Basic: StoryFn<StoryProps> = (props) => (
   <Button {...props}>Button</Button>
@@ -110,22 +108,22 @@ one React root in your application.
 #### @chakra-ui/react v1
 
 ```ts
-import { createStandaloneToast } from "@chakra-ui/toast"
+import { createStandaloneToast } from '@chakra-ui/toast'
 
 const toast = createStandaloneToast()
-toast({ title: "Chakra UI" })
+toast({ title: 'Chakra UI' })
 ```
 
 #### @chakra-ui/react v2
 
 ```tsx
-import * as ReactDOM from "react-dom/client"
-import { createStandaloneToast } from "@chakra-ui/toast"
+import * as ReactDOM from 'react-dom/client'
+import { createStandaloneToast } from '@chakra-ui/toast'
 
 const { ToastContainer, toast } = createStandaloneToast()
 
 // render the ToastContainer in your React root
-const rootElement = document.getElementById("root")
+const rootElement = document.getElementById('root')
 ReactDOM.createRoot(yourRootElement).render(
   <>
     <App />
@@ -133,7 +131,7 @@ ReactDOM.createRoot(yourRootElement).render(
   </>,
 )
 
-toast({ title: "Chakra UI" })
+toast({ title: 'Chakra UI' })
 ```
 
 - Added support for custom icons in a toast:
@@ -144,8 +142,8 @@ return (
   <Button
     onClick={() => {
       toast({
-        title: "Message me",
-        icon: "💬",
+        title: 'Message me',
+        icon: '💬',
       })
     }}
   >
@@ -246,8 +244,8 @@ return (
 Allow user configure the storage key for the provider and script. We now export
 a `createLocalStorageManager` and `createCookieStorageManager` functions.
 
-```jsx
-const manager = createLocalStorageManager("{storageKey}")
+```jsx live=false
+const manager = createLocalStorageManager('{storageKey}')
 
 function App({ Component, pageProps }) {
   return (
@@ -263,8 +261,8 @@ cookie script, you can set `type=cookie`.
 
 > Pro tip: You can also configure the `storageKey` from script as well
 
-```jsx
-import { ColorModeScript } from "@chakra-ui/react"
+```jsx live=false
+import { ColorModeScript } from '@chakra-ui/react'
 function Document() {
   return (
     <Html>
@@ -272,7 +270,7 @@ function Document() {
         <title>App</title>
       </Head>
       <Body>
-        <ColorModeScript type="cookie" />
+        <ColorModeScript type='cookie' />
         <Main />
       </Body>
     </Html>
@@ -667,7 +665,7 @@ field is optional.
 - Add support for vertical and horizontal spacing options in the Wrap component.
 
 ```jsx live=false
-<Wrap spacingX="2" spacingY="4">
+<Wrap spacingX='2' spacingY='4'>
   <Box />
   <Box />
   <Box />
@@ -756,7 +754,7 @@ field is optional.
   to handle multi line text input in an editable context.
 
 ```tsx live=false
-<Editable defaultValue="Change me" onChange={console.log}>
+<Editable defaultValue='Change me' onChange={console.log}>
   <EditablePreview />
   <EditableTextarea />
 </Editable>
@@ -1033,34 +1031,34 @@ Semantic tokens provide the ability to create css variables which can change
 with a CSS condition.
 
 ```tsx live=false
-import { ChakraProvider, extendTheme } from "@chakra-ui/react"
+import { ChakraProvider, extendTheme } from '@chakra-ui/react'
 
 const customTheme = extendTheme({
   colors: {
-    900: "#171923",
+    900: '#171923',
   },
 })
 
 const App = () => (
   <ChakraProvider theme={customTheme}>
-    <Text color="gray.900">will always be gray.900</Text>
+    <Text color='gray.900'>will always be gray.900</Text>
   </ChakraProvider>
 )
 ```
 
 ```tsx live=false
-import { ChakraProvider, extendTheme } from "@chakra-ui/react"
+import { ChakraProvider, extendTheme } from '@chakra-ui/react'
 
 const customTheme = extendTheme({
   colors: {
-    50: "#F7FAFC",
-    900: "#171923",
+    50: '#F7FAFC',
+    900: '#171923',
   },
   semanticTokens: {
     colors: {
       text: {
-        default: "gray.900",
-        _dark: "gray.50",
+        default: 'gray.900',
+        _dark: 'gray.50',
       },
     },
   },
@@ -1068,7 +1066,7 @@ const customTheme = extendTheme({
 
 const App = () => (
   <ChakraProvider theme={customTheme}>
-    <Text color="text">
+    <Text color='text'>
       will be gray.900 in light mode and gray.50 in dark mode
     </Text>
   </ChakraProvider>
@@ -1076,31 +1074,31 @@ const App = () => (
 ```
 
 ```tsx live=false
-import { extendTheme } from "@chakra-ui/react"
+import { extendTheme } from '@chakra-ui/react'
 
 const theme = extendTheme({
   colors: {
     red: {
-      100: "#ff0010",
-      400: "#ff0040",
-      500: "#ff0050",
-      700: "#ff0070",
-      800: "#ff0080",
+      100: '#ff0010',
+      400: '#ff0040',
+      500: '#ff0050',
+      700: '#ff0070',
+      800: '#ff0080',
     },
   },
   semanticTokens: {
     colors: {
-      error: "red.500", // create a token alias
-      success: "red.100",
+      error: 'red.500', // create a token alias
+      success: 'red.100',
       primary: {
         // set variable conditionally with pseudo selectors like `_dark` and `_light`
         // use `default` to define fallback value
-        default: "red.500",
-        _dark: "red.400",
+        default: 'red.500',
+        _dark: 'red.400',
       },
       secondary: {
-        default: "red.800",
-        _dark: "red.700",
+        default: 'red.800',
+        _dark: 'red.700',
       },
     },
   },
@@ -1118,34 +1116,34 @@ Semantic tokens provide the ability to create css variables which can change
 with a CSS condition.
 
 ```tsx live=false
-import { ChakraProvider, extendTheme } from "@chakra-ui/react"
+import { ChakraProvider, extendTheme } from '@chakra-ui/react'
 
 const customTheme = extendTheme({
   colors: {
-    900: "#171923",
+    900: '#171923',
   },
 })
 
 const App = () => (
   <ChakraProvider theme={customTheme}>
-    <Text color="gray.900">will always be gray.900</Text>
+    <Text color='gray.900'>will always be gray.900</Text>
   </ChakraProvider>
 )
 ```
 
 ```tsx live=false
-import { ChakraProvider, extendTheme } from "@chakra-ui/react"
+import { ChakraProvider, extendTheme } from '@chakra-ui/react'
 
 const customTheme = extendTheme({
   colors: {
-    50: "#F7FAFC",
-    900: "#171923",
+    50: '#F7FAFC',
+    900: '#171923',
   },
   semanticTokens: {
     colors: {
       text: {
-        default: "gray.900",
-        _dark: "gray.50",
+        default: 'gray.900',
+        _dark: 'gray.50',
       },
     },
   },
@@ -1153,7 +1151,7 @@ const customTheme = extendTheme({
 
 const App = () => (
   <ChakraProvider theme={customTheme}>
-    <Text color="text">
+    <Text color='text'>
       will be gray.900 in light mode and gray.50 in dark mode
     </Text>
   </ChakraProvider>
@@ -1161,31 +1159,31 @@ const App = () => (
 ```
 
 ```tsx live=false
-import { extendTheme } from "@chakra-ui/react"
+import { extendTheme } from '@chakra-ui/react'
 
 const theme = extendTheme({
   colors: {
     red: {
-      100: "#ff0010",
-      400: "#ff0040",
-      500: "#ff0050",
-      700: "#ff0070",
-      800: "#ff0080",
+      100: '#ff0010',
+      400: '#ff0040',
+      500: '#ff0050',
+      700: '#ff0070',
+      800: '#ff0080',
     },
   },
   semanticTokens: {
     colors: {
-      error: "red.500", // create a token alias
-      success: "red.100",
+      error: 'red.500', // create a token alias
+      success: 'red.100',
       primary: {
         // set variable conditionally with pseudo selectors like `_dark` and `_light`
         // use `default` to define fallback value
-        default: "red.500",
-        _dark: "red.400",
+        default: 'red.500',
+        _dark: 'red.400',
       },
       secondary: {
-        default: "red.800",
-        _dark: "red.700",
+        default: 'red.800',
+        _dark: 'red.700',
       },
     },
   },
@@ -1198,7 +1196,7 @@ const theme = extendTheme({
 
 ```jsx live=false
 // Now you can use only colors from the theme
-import colors from "@chakra-ui/theme/foundations/colors"
+import colors from '@chakra-ui/theme/foundations/colors'
 ```
 
 Here's a table of the theme parts and entrypoints
@@ -1226,34 +1224,34 @@ Semantic tokens provide the ability to create css variables which can change
 with a CSS condition.
 
 ```tsx live=false
-import { ChakraProvider, extendTheme } from "@chakra-ui/react"
+import { ChakraProvider, extendTheme } from '@chakra-ui/react'
 
 const customTheme = extendTheme({
   colors: {
-    900: "#171923",
+    900: '#171923',
   },
 })
 
 const App = () => (
   <ChakraProvider theme={customTheme}>
-    <Text color="gray.900">will always be gray.900</Text>
+    <Text color='gray.900'>will always be gray.900</Text>
   </ChakraProvider>
 )
 ```
 
 ```tsx live=false
-import { ChakraProvider, extendTheme } from "@chakra-ui/react"
+import { ChakraProvider, extendTheme } from '@chakra-ui/react'
 
 const customTheme = extendTheme({
   colors: {
-    50: "#F7FAFC",
-    900: "#171923",
+    50: '#F7FAFC',
+    900: '#171923',
   },
   semanticTokens: {
     colors: {
       text: {
-        default: "gray.900",
-        _dark: "gray.50",
+        default: 'gray.900',
+        _dark: 'gray.50',
       },
     },
   },
@@ -1261,7 +1259,7 @@ const customTheme = extendTheme({
 
 const App = () => (
   <ChakraProvider theme={customTheme}>
-    <Text color="text">
+    <Text color='text'>
       will be gray.900 in light mode and gray.50 in dark mode
     </Text>
   </ChakraProvider>
@@ -1269,31 +1267,31 @@ const App = () => (
 ```
 
 ```tsx live=false
-import { extendTheme } from "@chakra-ui/react"
+import { extendTheme } from '@chakra-ui/react'
 
 const theme = extendTheme({
   colors: {
     red: {
-      100: "#ff0010",
-      400: "#ff0040",
-      500: "#ff0050",
-      700: "#ff0070",
-      800: "#ff0080",
+      100: '#ff0010',
+      400: '#ff0040',
+      500: '#ff0050',
+      700: '#ff0070',
+      800: '#ff0080',
     },
   },
   semanticTokens: {
     colors: {
-      error: "red.500", // create a token alias
-      success: "red.100",
+      error: 'red.500', // create a token alias
+      success: 'red.100',
       primary: {
         // set variable conditionally with pseudo selectors like `_dark` and `_light`
         // use `default` to define fallback value
-        default: "red.500",
-        _dark: "red.400",
+        default: 'red.500',
+        _dark: 'red.400',
       },
       secondary: {
-        default: "red.800",
-        _dark: "red.700",
+        default: 'red.800',
+        _dark: 'red.700',
       },
     },
   },
@@ -1347,7 +1345,7 @@ const theme = extendTheme({
 - Add helper function `flatten`
 
 ```ts
-import { flatten } from "@chakra-ui/utils"
+import { flatten } from '@chakra-ui/utils'
 
 flatten({ space: [0, 1, 2, 4, 8, 16, 32] })
 /** =>
@@ -1426,8 +1424,8 @@ with `.peer` or `data-peer`) attribute.
 
 ```jsx live=false
 <>
-  <input type="checkbox" data-peer />
-  <Box bg="white" _peerFocus={{ bg: "green.400" }} />
+  <input type='checkbox' data-peer />
+  <Box bg='white' _peerFocus={{ bg: 'green.400' }} />
 </>
 ```
 
@@ -1529,7 +1527,7 @@ Add the addon to your configuration in `.storybook/main.js`:
 
 ```js live=false
 module.exports = {
-  addons: ["@chakra-ui/storybook-addon"],
+  addons: ['@chakra-ui/storybook-addon'],
 }
 ```
 
@@ -1628,7 +1626,7 @@ module.exports = {
   </PopoverTrigger>
   {/* popover will be positioned relative to this */}
   <PopoverAnchor>
-    <Box width="40px" height="40px" />
+    <Box width='40px' height='40px' />
   </PopoverAnchor>
   <PopoverContent>Hello World</PopoverContent>
 </Popover>
@@ -1657,10 +1655,10 @@ module.exports = {
 function Example() {
   // Via instantiation
   const toast = useToast({
-    position: "top",
-    title: "Container style is customizable",
+    position: 'top',
+    title: 'Container style is customizable',
     containerStyle: {
-      maxWidth: "100%",
+      maxWidth: '100%',
     },
   })
 
@@ -1670,7 +1668,7 @@ function Example() {
       onClick={() => {
         toast({
           containerStyle: {
-            maxWidth: "100%",
+            maxWidth: '100%',
           },
         })
       }}
@@ -1701,8 +1699,8 @@ function Example() {
 
 ```jsx live=false
 const HeartIcon = createIcon({
-  displayName: "HeartIcon",
-  path: [<path stroke="none" d="..." fill="none" />, <path d="..." />],
+  displayName: 'HeartIcon',
+  path: [<path stroke='none' d='...' fill='none' />, <path d='...' />],
 })
 ```
 
@@ -1768,10 +1766,10 @@ Here's how to resolve it:
 
 ```jsx live=false
 // Won't work 🎇
-import { useOutsideClick } from "@chakra-ui/hooks/dist/use-outside-click"
+import { useOutsideClick } from '@chakra-ui/hooks/dist/use-outside-click'
 
 // Works ✅
-import { useOutsideClick } from "@chakra-ui/hooks"
+import { useOutsideClick } from '@chakra-ui/hooks'
 ```
 
 If this affected your project, we recommend that you import hooks, functions or
@@ -2181,10 +2179,10 @@ theme but we promise to revisit the typings and API very soon.
 Creating a CSS variable in the theme
 
 ```jsx live=false
-import { cssVar, calc } from "@chakra-ui/theme-tools"
+import { cssVar, calc } from '@chakra-ui/theme-tools'
 
-const $width = cssVar("slider-width")
-const $height = cssVar("slider-height")
+const $width = cssVar('slider-width')
+const $height = cssVar('slider-height')
 
 const $diff = calc($width).subtract($height).toString()
 
@@ -2254,7 +2252,7 @@ type-safe, multipart component styles.
   root FormControl element to be themed.
 
 ```jsx live=false
-import { extendTheme } from "@chakra-ui/react"
+import { extendTheme } from '@chakra-ui/react'
 
 export const theme = extendTheme({
   components: {
@@ -2264,8 +2262,8 @@ export const theme = extendTheme({
         custom: {
           // style the root `FormControl` element
           container: {
-            color: "white",
-            bg: "blue.900",
+            color: 'white',
+            bg: 'blue.900',
           },
         },
       },
@@ -2447,7 +2445,7 @@ export or an export named `theme`.
 
 ```jsx live=false
 // chakra-theme-package/src/index.js
-import { extendTheme } from "@chakra-ui/react"
+import { extendTheme } from '@chakra-ui/react'
 
 const theme = extendTheme({})
 
@@ -2579,7 +2577,7 @@ To use this API, you'll need to set `transform` to `auto` or `auto-gpu` (for the
 GPU accelerated version).
 
 ```jsx live=false
-<Circle transform="auto" translateX="4" _hover={{ translateX: "8" }}>
+<Circle transform='auto' translateX='4' _hover={{ translateX: '8' }}>
   <CheckIcon />
 </Circle>
 ```
@@ -2791,35 +2789,35 @@ import {
   withDefaultSize,
   withDefaultVariant,
   withDefaultProps,
-} from "@chakra-ui/react"
+} from '@chakra-ui/react'
 
 const customTheme = extendTheme(
   {
     colors: {
       brand: {
         // ...
-        500: "#b4d455",
+        500: '#b4d455',
         // ...
       },
     },
   },
-  withDefaultColorScheme({ colorScheme: "brand" }),
+  withDefaultColorScheme({ colorScheme: 'brand' }),
   withDefaultSize({
-    size: "lg",
-    components: ["Input", "NumberInput", "PinInput"],
+    size: 'lg',
+    components: ['Input', 'NumberInput', 'PinInput'],
   }),
   withDefaultVariant({
-    variant: "outline",
-    components: ["Input", "NumberInput", "PinInput"],
+    variant: 'outline',
+    components: ['Input', 'NumberInput', 'PinInput'],
   }),
   // or all in one:
   withDefaultProps({
     defaultProps: {
-      colorScheme: "brand",
-      variant: "outline",
-      size: "lg",
+      colorScheme: 'brand',
+      variant: 'outline',
+      size: 'lg',
     },
-    components: ["Input", "NumberInput", "PinInput"],
+    components: ['Input', 'NumberInput', 'PinInput'],
   }),
   // optional:
   yourCustomBaseTheme, // defaults to our chakra default theme
@@ -2866,7 +2864,7 @@ const customTheme = extendTheme(
   `end`.
 
 ```jsx live=false
-<Button isLoading spinnerPlacement="end">
+<Button isLoading spinnerPlacement='end'>
   Click me
 </Button>
 ```
@@ -3126,7 +3124,7 @@ Popover
 - Use `--popover-bg` css property to control popover and arrow background.
 
 ```jsx live=false
-<PopoverContent style={{ "--popover-bg": "purple" }}>
+<PopoverContent style={{ '--popover-bg': 'purple' }}>
   <PopoverArrow />
 </PopoverContent>
 ```
@@ -3245,9 +3243,9 @@ Update text align attribute to use end instead of right for RTL.
 ```jsx live=false
 <Box
   sx={{
-    "--banner-color": "colors.red.200",
-    "& .banner": {
-      bg: "var(--banner-color)",
+    '--banner-color': 'colors.red.200',
+    '& .banner': {
+      bg: 'var(--banner-color)',
     },
   }}
 />
@@ -3464,7 +3462,7 @@ Update text align attribute to use end instead of right for RTL.
   `extendTheme` function even further.
 
 ```jsx live=false
-import { extendTheme } from "@chakra-ui/react"
+import { extendTheme } from '@chakra-ui/react'
 
 export const customTheme = extendTheme({
   // here you get autocomplete for
@@ -3506,13 +3504,13 @@ You can get typesafe access to your custom theme like this:
 const theme = {
   textStyles: {
     caps: {
-      fontWeight: "bold",
-      fontSize: "24px",
+      fontWeight: 'bold',
+      fontSize: '24px',
     },
   },
 }
 
-const styles = css({ textStyle: "caps" })(theme)
+const styles = css({ textStyle: 'caps' })(theme)
 ```
 
 This also works for the component theme as well.


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

JSX examples from the most recent changelogs in the [Changelog](https://chakra-ui.com/changelog) doc page are attempting to render preview, and end up breaking with visible error messages on the page.

Added `live=false` to these examples in the `changelog/index.mdx` file.
