### PR TITLE
docs(popover): mention `forwardRef` with custom components

### DIFF
--- a/pages/docs/components/overlay/popover.mdx
+++ b/pages/docs/components/overlay/popover.mdx
@@ -51,7 +51,7 @@ When using this component, ensure the children passed to `PopoverTrigger` is
 focusable and has a forwarded ref. Users can tab to it using their keyboard and
 is critical for accessibility. If you are using a custom component inside
 `PopoverTrigger` (or [PopoverAnchor](#popover-anchor)) it needs Chakra's
-[forwardRef](https://chakra-ui.com/docs/components/recipes/as-prop#option-1-using-forwardref-from-chakra-uireact).
+[forwardRef](../recipes/as-prop#option-1-using-forwardref-from-chakra-uireact).
 
 > **A11y:** When Popover opens, focus is sent to `PopoverContent`. When it
 > closes, focus is returned to the trigger.
@@ -290,7 +290,7 @@ action about popover.
 
 > 🚨 Note: As with [PopoverTrigger](#basic-usage), if you use a custom component
 > inside `PopoverAnchor` ensure that it uses Chakra's
-> [forwardRef](https://chakra-ui.com/docs/components/recipes/as-prop#option-1-using-forwardref-from-chakra-uireact)
+> [forwardRef](../recipes/as-prop#option-1-using-forwardref-from-chakra-uireact)
 > so the popover is triggered successfully.
 
 ```jsx

--- a/pages/docs/components/overlay/popover.mdx
+++ b/pages/docs/components/overlay/popover.mdx
@@ -48,8 +48,10 @@ import {
 ## Basic Usage
 
 When using this component, ensure the children passed to `PopoverTrigger` is
-focusable. Users can tab to it using their keyboard, and it can take a `ref`. It
-is critical for accessiblity.
+focusable and has a forwarded ref. Users can tab to it using their keyboard and
+is critical for accessibility. If you are using a custom component inside
+`PopoverTrigger` (or [PopoverAnchor](#popover-anchor)) it needs Chakra's
+[forwardRef](https://chakra-ui.com/docs/components/recipes/as-prop#option-1-using-forwardref-from-chakra-uireact).
 
 > **A11y:** When Popover opens, focus is sent to `PopoverContent`. When it
 > closes, focus is returned to the trigger.
@@ -285,6 +287,11 @@ triggerred by components inside `PopoverTrigger`.
 In this case, you can only open and close the popover with `Button`. If you
 click on `Input`, it acts same as the original input and doesn't trigger any
 action about popover.
+
+> 🚨 Note: As with [PopoverTrigger](#basic-usage), if you use a custom component
+> inside `PopoverAnchor` ensure that it uses Chakra's
+> [forwardRef](https://chakra-ui.com/docs/components/recipes/as-prop#option-1-using-forwardref-from-chakra-uireact)
+> so the popover is triggered successfully.
 
 ```jsx
 function WithPopoverAnchor() {

--- a/pages/docs/components/overlay/popover.mdx
+++ b/pages/docs/components/overlay/popover.mdx
@@ -236,7 +236,7 @@ You can control the opening and closing of the popover by passing the `isOpen`,
 and `onClose` props.
 
 Sometimes you might need to set the `returnFocusOnClose` prop to `false` to
-prevent popver from returning focus to `PopoverTrigger`'s children.
+prevent popover from returning focus to `PopoverTrigger`'s children.
 
 ```jsx
 function ControlledUsage() {
@@ -282,7 +282,7 @@ function ControlledUsage() {
 
 You can wrap your component with `PopoverAnchor` to prevent trigger any action.
 The wrapped component will become a position reference. Actions will only be
-triggerred by components inside `PopoverTrigger`.
+triggered by components inside `PopoverTrigger`.
 
 In this case, you can only open and close the popover with `Button`. If you
 click on `Input`, it acts same as the original input and doesn't trigger any
@@ -467,7 +467,7 @@ happen when the component is displayed.
 </Popover>
 ```
 
-## Accessiblity
+## Accessibility
 
 > When you see the word _"trigger"_, it is referring to the `children` of
 > `PopoverTrigger`


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #513 

## 📝 Description

Add details in the [Basic Usage](https://chakra-ui.com/docs/components/overlay/popover#basic-usage) and [Popover Anchor](https://chakra-ui.com/docs/components/overlay/popover#popover-anchor) sections about using Chakra's `forwardRef` in custom components that are used as children in `PopoverAnchor` and `PopoverTrigger`.
