### PR TITLE
docs: update sandpack examples

### DIFF
--- a/configs/sandpack-contents/advanced-formik-integration/image-radio-buttons.js
+++ b/configs/sandpack-contents/advanced-formik-integration/image-radio-buttons.js
@@ -100,7 +100,7 @@ const Input = ({ name, ...props }: Props) => {
 
 export default Input;`,
 
-  App: `import { Box, ChakraProvider, Button } from "@chakra-ui/react";
+  App: `import { Box, Button } from "@chakra-ui/react";
 import { Formik, FormikProps } from "formik";
 
 import Input from "./input";
@@ -116,7 +116,7 @@ const AVATARS = [
 
 type Values = {
   email: string;
-  avatar: number;
+  avatar: string;
 };
 
 export default function App() {
@@ -130,9 +130,11 @@ export default function App() {
           <form onSubmit={props.handleSubmit}>
             <Input name="email" />
             <RadioGroup name="avatar" py={2} display="flex" gridColumnGap={2}>
-              {AVATARS.map(({ name, image }) => (
+              {AVATARS.map(({ name, image }) => {
+                console.log("App line 32 ~ name: ", name)
+                return (
                 <ImageRadio key={image} image={image} value={name} />
-              ))}
+              )})}
             </RadioGroup>
             <Button type="submit">Submit</Button>
           </form>
@@ -140,19 +142,18 @@ export default function App() {
       </Formik>
     </Box>
   );
-}
-`,
+}`,
   Index: `import * as React from "react";
-import { render } from "react-dom";
+import { createRoot } from "react-dom/client";
 import { ChakraProvider } from "@chakra-ui/react";
 
 import App from "./App";
 
-const rootElement = document.getElementById("root");
-render(
+const container = document.getElementById("root");
+const root = createRoot(container!);
+root.render(
   <ChakraProvider>
     <App />
-  </ChakraProvider>,
-  rootElement
+  </ChakraProvider>
 );`,
 }

--- a/configs/sandpack-contents/floating-labels/floating-labels.js
+++ b/configs/sandpack-contents/floating-labels/floating-labels.js
@@ -1,0 +1,78 @@
+module.exports = {
+  App: `import {
+  ChakraProvider,
+  FormControl,
+  FormErrorMessage,
+  FormHelperText,
+  FormLabel,
+  Input,
+  extendTheme,
+  Box
+} from "@chakra-ui/react";
+const activeLabelStyles = {
+  transform: "scale(0.85) translateY(-24px)"
+};
+export const theme = extendTheme({
+  components: {
+    Form: {
+      variants: {
+        floating: {
+          container: {
+            _focusWithin: {
+              label: {
+                ...activeLabelStyles
+              }
+            },
+            "input:not(:placeholder-shown) + label, .chakra-select__wrapper + label": {
+              ...activeLabelStyles
+            },
+            label: {
+              top: 0,
+              left: 0,
+              zIndex: 2,
+              position: "absolute",
+              backgroundColor: "white",
+              pointerEvents: "none",
+              mx: 3,
+              px: 1,
+              my: 2,
+              transformOrigin: "left top"
+            }
+          }
+        }
+      }
+    }
+  }
+});
+
+export default function App() {
+  return (
+    <ChakraProvider theme={theme}>
+      <Box p={8}>
+        <FormControl variant="floating" id="first-name" isRequired isInvalid>
+          <Input placeholder=" " />
+          {/* It is important that the Label comes after the Control due to css selectors */}
+          <FormLabel>First name</FormLabel>
+          <FormHelperText>Keep it very short and sweet!</FormHelperText>
+          <FormErrorMessage>Your First name is invalid</FormErrorMessage>
+        </FormControl>
+      </Box>
+    </ChakraProvider>
+  );
+}
+`,
+  Index: `import * as React from "react";
+import { createRoot } from "react-dom/client";
+import { ChakraProvider } from "@chakra-ui/react";
+
+import App from "./App";
+
+const container = document.getElementById("root");
+const root = createRoot(container!);
+root.render(
+  <ChakraProvider>
+    <App />
+  </ChakraProvider>
+);
+`,
+}

--- a/configs/sandpack-contents/formik-examples/login-form.js
+++ b/configs/sandpack-contents/formik-examples/login-form.js
@@ -68,16 +68,16 @@ export default function App() {
   );
 }`,
   Index: `import * as React from "react";
-import { render } from "react-dom";
+import { createRoot } from "react-dom/client";
 import { ChakraProvider } from "@chakra-ui/react";
 
 import App from "./App";
 
-const rootElement = document.getElementById("root");
-render(
+const container = document.getElementById("root");
+const root = createRoot(container!);
+root.render(
   <ChakraProvider>
     <App />
-  </ChakraProvider>,
-  rootElement
+  </ChakraProvider>
 );`,
 }

--- a/configs/sandpack-contents/formik-examples/plain-formik.js
+++ b/configs/sandpack-contents/formik-examples/plain-formik.js
@@ -28,14 +28,11 @@ export default function App() {
   )
 }`,
   Index: `import * as React from "react";
-import { render } from "react-dom";
-import { ChakraProvider } from "@chakra-ui/react";
+import { createRoot } from "react-dom/client";
 
 import App from "./App";
 
-const rootElement = document.getElementById("root");
-render(
-  <App />,
-  rootElement
-);`,
+const container = document.getElementById("root");
+const root = createRoot(container!);
+root.render(<App />);`,
 }

--- a/configs/sandpack-contents/formik-examples/simple.js
+++ b/configs/sandpack-contents/formik-examples/simple.js
@@ -27,16 +27,16 @@ export default function App() {
   )
 }`,
   Index: `import * as React from "react";
-import { render } from "react-dom";
+import { createRoot } from "react-dom/client";
 import { ChakraProvider } from "@chakra-ui/react";
 
 import App from "./App";
 
-const rootElement = document.getElementById("root");
-render(
+const container = document.getElementById("root");
+const root = createRoot(container!);
+root.render(
   <ChakraProvider>
     <App />
-  </ChakraProvider>,
-  rootElement
+  </ChakraProvider>
 );`,
 }

--- a/configs/sandpack-contents/formik-examples/validation.js
+++ b/configs/sandpack-contents/formik-examples/validation.js
@@ -79,16 +79,16 @@ export default function App() {
   );
 }`,
   Index: `import * as React from "react";
-import { render } from "react-dom";
+import { createRoot } from "react-dom/client";
 import { ChakraProvider } from "@chakra-ui/react";
 
 import App from "./App";
 
-const rootElement = document.getElementById("root");
-render(
+const container = document.getElementById("root");
+const root = createRoot(container!);
+root.render(
   <ChakraProvider>
     <App />
-  </ChakraProvider>,
-  rootElement
+  </ChakraProvider>
 );`,
 }

--- a/configs/sandpack-contents/framer-motion-examples/as-props.js
+++ b/configs/sandpack-contents/framer-motion-examples/as-props.js
@@ -14,12 +14,13 @@ const animation = \`${'${animationKeyframes}'} 2s ease-in-out infinite\`;
   
 export default function App() {
   return (
-    <Container h="100vh" d="flex" alignItems="center" justifyContent="center">
+    <Container h="100vh" display="flex" alignItems="center" justifyContent="center">
       <Box
         as={motion.div}
         animation={animation}
         // not work: transition={{ ... }}
         padding="2"
+        // @ts-ignore - "Does not exist" Type Error against Motion
         bgGradient="linear(to-l, #7928CA, #FF0080)"
         width="12"
         height="12"
@@ -29,16 +30,16 @@ export default function App() {
   )
 };`,
   Index: `import * as React from "react";
-import { render } from "react-dom";
+import { createRoot } from "react-dom/client";
 import { ChakraProvider } from "@chakra-ui/react";
-  
+
 import App from "./App";
-  
-const rootElement = document.getElementById("root");
-render(
+
+const container = document.getElementById("root");
+const root = createRoot(container!);
+root.render(
   <ChakraProvider>
     <App />
-  </ChakraProvider>,
-  rootElement
+  </ChakraProvider>
 );`,
 }

--- a/configs/sandpack-contents/framer-motion-examples/chakra-factory.js
+++ b/configs/sandpack-contents/framer-motion-examples/chakra-factory.js
@@ -1,55 +1,55 @@
 module.exports = {
   App: `import { Container, chakra } from '@chakra-ui/react';
-  import { motion, isValidMotionProp } from 'framer-motion';
-    
-  const ChakraBox = chakra(motion.div, {
-    /**
-     * Allow motion props and the children prop to be forwarded.
-     * All other chakra props not matching the motion props will still be forwarded.
-     */
-    shouldForwardProp: (prop) => isValidMotionProp(prop) || prop === 'children',
-  });
-    
-  export default function App() {
-    return (
-      <Container h="100vh" d="flex" alignItems="center" justifyContent="center">
-        <ChakraBox
-          animate={{
-            scale: [1, 2, 2, 1, 1],
-            rotate: [0, 0, 270, 270, 0],
-            borderRadius: ["20%", "20%", "50%", "50%", "20%"],
-          }}
-          // @ts-ignore no problem in operation, although type error appears.
-          transition={{
-            duration: 3,
-            ease: "easeInOut",
-            repeat: Infinity,
-            repeatType: "loop",
-          }}
-          padding="2"
-          bgGradient="linear(to-l, #7928CA, #FF0080)"
-          display="flex"
-          justifyContent="center"
-          alignItems="center"
-          width="100px"
-          height="100px"
-        >
-          I'm Dizzy!
-        </ChakraBox>
-      </Container>
-    )
-  }`,
+import { motion, isValidMotionProp } from 'framer-motion';
+  
+const ChakraBox = chakra(motion.div, {
+  /**
+   * Allow motion props and the children prop to be forwarded.
+   * All other chakra props not matching the motion props will still be forwarded.
+   */
+  shouldForwardProp: (prop) => isValidMotionProp(prop) || prop === 'children',
+});
+  
+export default function App() {
+  return (
+    <Container h="100vh" display="flex" alignItems="center" justifyContent="center">
+      <ChakraBox
+        animate={{
+          scale: [1, 2, 2, 1, 1],
+          rotate: [0, 0, 270, 270, 0],
+          borderRadius: ["20%", "20%", "50%", "50%", "20%"],
+        }}
+        // @ts-ignore no problem in operation, although type error appears.
+        transition={{
+          duration: 3,
+          ease: "easeInOut",
+          repeat: Infinity,
+          repeatType: "loop",
+        }}
+        padding="2"
+        bgGradient="linear(to-l, #7928CA, #FF0080)"
+        display="flex"
+        justifyContent="center"
+        alignItems="center"
+        width="100px"
+        height="100px"
+      >
+        I'm Dizzy!
+      </ChakraBox>
+    </Container>
+  )
+}`,
   Index: `import * as React from "react";
-  import { render } from "react-dom";
-  import { ChakraProvider } from "@chakra-ui/react";
-    
-  import App from "./App";
-    
-  const rootElement = document.getElementById("root");
-  render(
-    <ChakraProvider>
-      <App />
-    </ChakraProvider>,
-    rootElement
-  );`,
+import { createRoot } from "react-dom/client";
+import { ChakraProvider } from "@chakra-ui/react";
+
+import App from "./App";
+
+const container = document.getElementById("root");
+const root = createRoot(container!);
+root.render(
+  <ChakraProvider>
+    <App />
+  </ChakraProvider>
+);`,
 }

--- a/configs/sandpack-contents/homepage/files.ts
+++ b/configs/sandpack-contents/homepage/files.ts
@@ -41,9 +41,8 @@ import { ChakraProvider } from "@chakra-ui/react";
 import App from "./App";
 
 const rootElement = document.getElementById("root");
-ReactDOM.createRoot(rootElement).render(
+ReactDOM.createRoot(rootElement!).render(
   <ChakraProvider>
     <App />
-  </ChakraProvider>,
-  rootElement
+  </ChakraProvider>
 );`

--- a/configs/sandpack-contents/prose/prose.js
+++ b/configs/sandpack-contents/prose/prose.js
@@ -149,7 +149,7 @@ export default function App() {
   );
 }`,
   Index: `import * as React from "react";
-import { render } from "react-dom";
+import { createRoot } from "react-dom/client";
 import { ChakraProvider, extendTheme } from "@chakra-ui/react";
 import { withProse } from "@nikolovlazar/chakra-ui-prose";
 
@@ -166,11 +166,11 @@ const theme = extendTheme(
   })
 );
 
-const rootElement = document.getElementById("root");
-render(
+const container = document.getElementById("root");
+const root = createRoot(container!);
+root.render(
   <ChakraProvider theme={theme}>
     <App />
-  </ChakraProvider>,
-  rootElement
+  </ChakraProvider>
 );`,
 }

--- a/pages/docs/components/recipes/floating-labels.mdx
+++ b/pages/docs/components/recipes/floating-labels.mdx
@@ -13,6 +13,11 @@ this is the only way to achieve this.
 
 Below is the gist to achieve floating labels.
 
+import {
+  App as AppFloatingLabel,
+  Index as IndexFloatingLabel,
+} from 'configs/sandpack-contents/floating-labels/floating-labels.js'
+
 <SandpackEmbed
   options={{
     editorHeight: 600,
@@ -21,80 +26,7 @@ Below is the gist to achieve floating labels.
   zIndex={0}
   tabIndex={-1}
   files={{
-    '/App.tsx': `import {
-  Container,
-  ChakraProvider,
-  FormControl,
-  FormErrorMessage,
-  FormHelperText,
-  FormLabel,
-  Input,
-  extendTheme,
-  Box,
-} from '@chakra-ui/react'
-const activeLabelStyles = {
-  transform: 'scale(0.85) translateY(-24px)',
-}
-export const theme = extendTheme({
-  components: {
-    Form: {
-      variants: {
-        floating: {
-          container: {
-            _focusWithin: {
-              label: {
-                ...activeLabelStyles,
-              },
-            },
-            'input:not(:placeholder-shown) + label, .chakra-select__wrapper + label':
-              {
-                ...activeLabelStyles,
-              },
-            label: {
-              top: 0,
-              left: 0,
-              zIndex: 2,
-              position: 'absolute',
-              backgroundColor: 'white',
-              pointerEvents: 'none',
-              mx: 3,
-              px: 1,
-              my: 2,
-              transformOrigin: 'left top'
-            },
-          },
-        },
-      },
-    },
-  },
-})
-export default function App() {
-  return (
-    <ChakraProvider theme={theme}>
-      <Box p={8}>
-        <FormControl variant='floating' id='first-name' isRequired isInvalid>
-          <Input placeholder=' ' />
-          {/* It is important that the Label comes after the Control due to css selectors */}
-          <FormLabel>First name</FormLabel>
-          <FormHelperText>Keep it very short and sweet!</FormHelperText>
-          <FormErrorMessage>Your First name is invalid</FormErrorMessage>
-        </FormControl>
-      </Box>
-    </ChakraProvider>
-  )
-}
-`,
-    '/index.tsx': `import * as React from "react";
-import { render } from "react-dom";
-import { ChakraProvider } from "@chakra-ui/react";
-
-import App from './App'
-
-const rootElement = document.getElementById("root");
-
-render(
-
-<ChakraProvider>
-  <App />
-</ChakraProvider>
-, rootElement, );`, }} />
+    '/App.tsx': AppFloatingLabel,
+    '/index.tsx': IndexFloatingLabel,
+  }}
+/>


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Update all Sandpack code examples in the docsite with the following changes:

- Convert code to React 18 API
- At least one example has its code inline in the `files` prop of the `SandPackEmbed` component. Move this code to the `sandpack-content` directory to de-clutter the doc file and provide consistency with other sandpack content.

### Examples to Update
- [x] [Floating Labels Recipe](https://chakra-ui.com/docs/components/recipes/floating-labels)
- [x] "Less code. More speed." section of the [Homepage](https://chakra-ui.com)
- [x] All examples, [ChakraUI + Formik](https://chakra-ui.com/guides/integrations/with-formik)
- [x] All examples, [ChakraUI + Framer Motion](https://chakra-ui.com/guides/integrations/with-framer)
- [x] [Advanced Formik Integration](https://chakra-ui.com/guides/recipes/advanced-formik-integration) 
   - Only addresses typing error related to ChakraUI Issue [#6023](https://github.com/chakra-ui/chakra-ui/issues/6023) as it is a quick fix. Other typing errors in the example should be addressed in a separate PR, if need be. (Example may need a revamp, typescript-wise?)
- [x] [ChakraUI Prose](https://chakra-ui.com/guides/recipes/prose)

## 📝 Additional Information
(VERY MINOR) Per the React 18 Concurrent Renderer, because the generated files in the `SandPackEmbed`s are `.tsx`, the container passed to `createRoot` needs a postfix to prevent an "is null" type error when a user views the example in CSB. (No problem removing this small change if requested! 😄)
