### PR TITLE
fix(component-links): allow overflow of the container

### DIFF
--- a/src/components/mdx-components/component-links.tsx
+++ b/src/components/mdx-components/component-links.tsx
@@ -90,6 +90,7 @@ function ComponentLinks(props: ComponentLinksProps) {
     </ComponentLink>
   )
 
+  // Note: Currently an unused component
   const storybookLink = storybook?.url && (
     <ComponentLink
       url={storybook.url}
@@ -101,6 +102,7 @@ function ComponentLinks(props: ComponentLinksProps) {
     </ComponentLink>
   )
 
+  // Note: Currently an unused component
   const videoLink = video?.url && (
     <ComponentLink
       url={video.url}

--- a/src/components/mdx-components/component-links.tsx
+++ b/src/components/mdx-components/component-links.tsx
@@ -131,7 +131,13 @@ function ComponentLinks(props: ComponentLinksProps) {
   )
 
   return (
-    <Wrap className='component-links' mt='2rem' spacing='4' {...rest}>
+    <Wrap
+      className='component-links'
+      mt='2rem'
+      spacing='4'
+      overflow='unset'
+      {...rest}
+    >
       {githubLink}
       {themeComponentLink}
       {npmLink}

--- a/src/components/mdx-components/component-links.tsx
+++ b/src/components/mdx-components/component-links.tsx
@@ -21,7 +21,7 @@ type ComponentLinkProps = ButtonProps & {
 }
 
 function ComponentLink(props: ComponentLinkProps) {
-  const { icon, url, children, iconSize, iconColor, ...rest } = props
+  const { icon: BtnIcon, url, children, iconSize, iconColor, ...rest } = props
   return (
     <Button
       as={Link}
@@ -29,10 +29,12 @@ function ComponentLink(props: ComponentLinkProps) {
       isExternal
       px='12px'
       display='flex'
+      fontSize='sm'
       alignItems='center'
       minH='32px'
       borderWidth='1px'
       borderRadius='md'
+      marginInlineStart='0 !important'
       color={useColorModeValue('gray.600', 'whiteAlpha.700')}
       _hover={{
         color: useColorModeValue('gray.700', 'whiteAlpha.900'),
@@ -41,14 +43,20 @@ function ComponentLink(props: ComponentLinkProps) {
         transform: 'translateY(-1px)',
         textDecor: 'none',
       }}
+      leftIcon={<BtnIcon />}
+      sx={{
+        '& span': {
+          width: iconSize,
+        },
+        '& svg': {
+          color: iconColor,
+          width: 'full',
+          height: 'auto',
+        },
+      }}
       {...rest}
     >
-      <HStack>
-        <Icon fontSize={iconSize} as={icon} color={iconColor} />
-        <Text fontSize='sm' lineHeight='short'>
-          {children}
-        </Text>
-      </HStack>
+      {children}
     </Button>
   )
 }

--- a/src/components/mdx-components/component-links.tsx
+++ b/src/components/mdx-components/component-links.tsx
@@ -27,6 +27,7 @@ function ComponentLink(props: ComponentLinkProps) {
       as={Link}
       href={url}
       isExternal
+      bg='inherit'
       px='12px'
       display='flex'
       fontSize='sm'
@@ -38,9 +39,8 @@ function ComponentLink(props: ComponentLinkProps) {
       color={useColorModeValue('gray.600', 'whiteAlpha.700')}
       _hover={{
         color: useColorModeValue('gray.700', 'whiteAlpha.900'),
-        bg: useColorModeValue('gray.300', 'whiteAlpha.300'),
         boxShadow: 'sm',
-        transform: 'translateY(-1px)',
+        transform: 'translateY(-2px)',
         textDecor: 'none',
       }}
       leftIcon={<BtnIcon />}
@@ -137,7 +137,8 @@ function ComponentLinks(props: ComponentLinksProps) {
     <ButtonGroup
       className='component-links'
       mt='2rem'
-      spacing='4'
+      gap='4'
+      flexWrap='wrap'
       overflow='unset'
       {...rest}
     >

--- a/src/components/mdx-components/component-links.tsx
+++ b/src/components/mdx-components/component-links.tsx
@@ -2,18 +2,18 @@ import {
   HStack,
   Icon,
   Link,
-  LinkProps,
-  Text,
-  Wrap,
-  WrapItem,
   useColorModeValue,
+  ButtonGroup,
+  Button,
+  ButtonProps,
+  Text,
 } from '@chakra-ui/react'
 import React from 'react'
 import { FaGithub, FaNpm, FaYoutube } from 'react-icons/fa'
 import StorybookIcon from '../storybook-icon'
 import { t } from 'utils/i18n'
 
-type ComponentLinkProps = LinkProps & {
+type ComponentLinkProps = ButtonProps & {
   icon: React.ElementType
   url: string
   iconSize?: string
@@ -23,7 +23,8 @@ type ComponentLinkProps = LinkProps & {
 function ComponentLink(props: ComponentLinkProps) {
   const { icon, url, children, iconSize, iconColor, ...rest } = props
   return (
-    <Link
+    <Button
+      as={Link}
       href={url}
       isExternal
       px='12px'
@@ -35,8 +36,10 @@ function ComponentLink(props: ComponentLinkProps) {
       color={useColorModeValue('gray.600', 'whiteAlpha.700')}
       _hover={{
         color: useColorModeValue('gray.700', 'whiteAlpha.900'),
+        bg: useColorModeValue('gray.300', 'whiteAlpha.300'),
         boxShadow: 'sm',
         transform: 'translateY(-1px)',
+        textDecor: 'none',
       }}
       {...rest}
     >
@@ -46,7 +49,7 @@ function ComponentLink(props: ComponentLinkProps) {
           {children}
         </Text>
       </HStack>
-    </Link>
+    </Button>
   )
 }
 
@@ -64,74 +67,64 @@ function ComponentLinks(props: ComponentLinksProps) {
   const githubRepoUrl = 'https://github.com/chakra-ui/chakra-ui'
 
   const githubLink = (github?.url || github?.package) && (
-    <WrapItem>
-      <ComponentLink
-        url={
-          github.url || `${githubRepoUrl}/tree/main/packages/${github.package}`
-        }
-        icon={FaGithub}
-        iconColor={iconColor}
-        iconSize='1rem'
-      >
-        {t('component.mdx-components.component-links.view-source')}
-      </ComponentLink>
-    </WrapItem>
+    <ComponentLink
+      url={
+        github.url || `${githubRepoUrl}/tree/main/packages/${github.package}`
+      }
+      icon={FaGithub}
+      iconColor={iconColor}
+      iconSize='1rem'
+    >
+      {t('component.mdx-components.component-links.view-source')}
+    </ComponentLink>
   )
 
   const npmLink = npm?.package && (
-    <WrapItem>
-      <ComponentLink
-        url={`https://www.npmjs.com/package/${npm.package}`}
-        icon={FaNpm}
-        iconSize='2rem'
-        iconColor='red.500'
-      >
-        {npm.package}
-      </ComponentLink>
-    </WrapItem>
+    <ComponentLink
+      url={`https://www.npmjs.com/package/${npm.package}`}
+      icon={FaNpm}
+      iconSize='2rem'
+      iconColor='red.500'
+    >
+      {npm.package}
+    </ComponentLink>
   )
 
   const storybookLink = storybook?.url && (
-    <WrapItem>
-      <ComponentLink
-        url={storybook.url}
-        icon={StorybookIcon}
-        iconSize='1.25rem'
-        iconColor='pink.500'
-      >
-        {t('component.mdx-components.component-links.view-storybook')}
-      </ComponentLink>
-    </WrapItem>
+    <ComponentLink
+      url={storybook.url}
+      icon={StorybookIcon}
+      iconSize='1.25rem'
+      iconColor='pink.500'
+    >
+      {t('component.mdx-components.component-links.view-storybook')}
+    </ComponentLink>
   )
 
   const videoLink = video?.url && (
-    <WrapItem>
-      <ComponentLink
-        url={video.url}
-        icon={FaYoutube}
-        iconSize='1.2rem'
-        iconColor='red.500'
-      >
-        {t('component.mdx-components.component-links.view-video')}
-      </ComponentLink>
-    </WrapItem>
+    <ComponentLink
+      url={video.url}
+      icon={FaYoutube}
+      iconSize='1.2rem'
+      iconColor='red.500'
+    >
+      {t('component.mdx-components.component-links.view-video')}
+    </ComponentLink>
   )
 
   const themeComponentLink = theme && (
-    <WrapItem>
-      <ComponentLink
-        url={`${githubRepoUrl}/tree/main/packages/theme/src/components/${theme.componentName}.ts`}
-        icon={FaGithub}
-        iconColor={iconColor}
-        iconSize='1rem'
-      >
-        {t('component.mdx-components.component-links.view-theme-source')}
-      </ComponentLink>
-    </WrapItem>
+    <ComponentLink
+      url={`${githubRepoUrl}/tree/main/packages/theme/src/components/${theme.componentName}.ts`}
+      icon={FaGithub}
+      iconColor={iconColor}
+      iconSize='1rem'
+    >
+      {t('component.mdx-components.component-links.view-theme-source')}
+    </ComponentLink>
   )
 
   return (
-    <Wrap
+    <ButtonGroup
       className='component-links'
       mt='2rem'
       spacing='4'
@@ -143,7 +136,7 @@ function ComponentLinks(props: ComponentLinksProps) {
       {npmLink}
       {storybookLink}
       {videoLink}
-    </Wrap>
+    </ButtonGroup>
   )
 }
 

--- a/src/components/mdx-components/component-links.tsx
+++ b/src/components/mdx-components/component-links.tsx
@@ -1,12 +1,9 @@
 import {
-  HStack,
-  Icon,
   Link,
   useColorModeValue,
   ButtonGroup,
   Button,
   ButtonProps,
-  Text,
 } from '@chakra-ui/react'
 import React from 'react'
 import { FaGithub, FaNpm, FaYoutube } from 'react-icons/fa'


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #619

Revert the `overflow` prop originally set from the `Wrap` component that contains the component links (i.e. source code, theme, npm) to allow the boxShadow on focus and the transition on hover to not be clipped.

Clipping comes from the combination of `overflow: hidden` and negative margins, both set by the `Wrap` component.
