### PR TITLE
docs: correct font theme examples

### DIFF
--- a/pages/docs/styled-system/recipes/using-fonts.mdx
+++ b/pages/docs/styled-system/recipes/using-fonts.mdx
@@ -43,8 +43,8 @@ import { extendTheme } from '@chakra-ui/react'
 
 const theme = extendTheme({
   fonts: {
-    heading: 'Open Sans, sans-serif',
-    body: 'Raleway, sans-serif',
+    heading: `'Open Sans', sans-serif`,
+    body: `'Raleway', sans-serif`,
   },
 })
 
@@ -148,8 +148,8 @@ import { extendTheme } from '@chakra-ui/react'
 
 const theme = extendTheme({
   fonts: {
-    heading: 'Heading Font Name, sans-serif',
-    body: 'Body Font Name, sans-serif',
+    heading: `'Heading Font Name', sans-serif`,
+    body: `'Body Font Name', sans-serif`,
   },
 })
 


### PR DESCRIPTION
## 📝 Description

The existing examples for the [Using Fonts](https://chakra-ui.com/docs/styled-system/recipes/using-fonts) recipe incorrectly reference font families for the theme. If you don't wrap the font family with quotation marks, it will fail to load if the font name has any whitespace between it, which is the case for the Open Sans example.

While it's okay to not wrap quotation marks around font names like Inter, for the sake of reducing future confusion on why some fonts work and others may not due to this niche CSS rule, I think it's best to wrap every example with quotation markers.

This PR updates the examples with valid examples. Using backticks, escape backslashes or double quotes is purely preferential. I personally chose backticks because I think it looks the cleanest.

## 📝 References

[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/CSS/font-family#valid_family_names)
fontsource/fontsource#495
