### PR TITLE
docs(popover): use `useDisclosure` in controlled state example

### DIFF
--- a/pages/docs/components/overlay/popover.mdx
+++ b/pages/docs/components/overlay/popover.mdx
@@ -240,11 +240,11 @@ prevent popover from returning focus to `PopoverTrigger`'s children.
 
 ```jsx
 function ControlledUsage() {
-  const { isOpen, onOpen, onClose } = useDisclosure()
+  const { isOpen, onToggle, onClose } = useDisclosure()
 
   return (
     <>
-      <Button mr={5} onClick={onOpen}>
+      <Button mr={5} onClick={onToggle}>
         Trigger
       </Button>
       <Popover

--- a/pages/docs/components/overlay/popover.mdx
+++ b/pages/docs/components/overlay/popover.mdx
@@ -240,18 +240,17 @@ prevent popover from returning focus to `PopoverTrigger`'s children.
 
 ```jsx
 function ControlledUsage() {
-  const [isOpen, setIsOpen] = React.useState(false)
-  const open = () => setIsOpen(!isOpen)
-  const close = () => setIsOpen(false)
+  const { isOpen, onOpen, onClose } = useDisclosure()
+
   return (
     <>
-      <Button mr={5} onClick={open}>
+      <Button mr={5} onClick={onOpen}>
         Trigger
       </Button>
       <Popover
         returnFocusOnClose={false}
         isOpen={isOpen}
-        onClose={close}
+        onClose={onClose}
         placement='right'
         closeOnBlur={false}
       >


### PR DESCRIPTION
## 📝 Description

In the `Popover` component docs, in the "Controlled State" example, replace `useState` with `useDisclosure`.

## ⛳️ Current behavior (updates)

Used the `useState` hook.

## 🚀 New behavior

Uses the `useDisclosure` hook.

## 💣 Is this a breaking change (Yes/No):

 No

