### PR TITLE
docs: use correct google font preconnect link

### DIFF
--- a/pages/guides/getting-started/remix-guide.mdx
+++ b/pages/guides/getting-started/remix-guide.mdx
@@ -171,7 +171,7 @@ export const meta: MetaFunction = () => ({
 export let links: LinksFunction = () => {
   return [
     { rel: 'preconnect', href: 'https://fonts.googleapis.com' },
-    { rel: 'preconnect', href: 'https://fonts.gstaticom' },
+    { rel: 'preconnect', href: 'https://fonts.gstatic.com' },
     {
       rel: 'stylesheet',
       href: 'https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,300;0,400;0,500;0,600;0,700;0,800;1,300;1,400;1,500;1,600;1,700;1,800&display=swap'


### PR DESCRIPTION
The preconnect link for google fonts in the Remix guide has a typo. This change corrects the incorrect url