### PR TITLE
docs: extend doc for size prop of heading

### DIFF
--- a/pages/docs/components/form/checkbox.mdx
+++ b/pages/docs/components/form/checkbox.mdx
@@ -188,7 +188,7 @@ shared styling props.
   <Stack spacing={[1, 5]} direction={['column', 'row']}>
     <Checkbox value='naruto'>Naruto</Checkbox>
     <Checkbox value='sasuke'>Sasuke</Checkbox>
-    <Checkbox value='kakashi'>kakashi</Checkbox>
+    <Checkbox value='kakashi'>Kakashi</Checkbox>
   </Stack>
 </CheckboxGroup>
 ```

--- a/pages/docs/components/typography/heading.mdx
+++ b/pages/docs/components/typography/heading.mdx
@@ -33,7 +33,8 @@ import { Heading } from '@chakra-ui/react'
 
 To increase the size of the heading, you can use the `fontSize` or `size` props.
 If you use the `size` prop, the font size of the heading will automatically
-decrease in size for smaller screens.
+decrease in size for smaller screens, but only by using size `lg` or above with
+the default theme. This can be seen in the theme source for the component.
 
 ```jsx
 <Stack spacing={6}>


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #667 and #669

## 📝 Description

Extension of documentation for breakpoints on the fontSize of `Heading` by using the `size` prop.

## 💣 Is this a breaking change (Yes/No):

No