### PR TITLE
docs: add initialValue to fix a type error of ref

### DIFF
--- a/pages/docs/components/overlay/modal.mdx
+++ b/pages/docs/components/overlay/modal.mdx
@@ -89,7 +89,7 @@ closes.
 ```jsx
 function ReturnFocus() {
   const { isOpen, onOpen, onClose } = useDisclosure()
-  const finalRef = React.useRef()
+  const finalRef = React.useRef(null)
 
   return (
     <>
@@ -181,8 +181,8 @@ Chakra provides 2 props for this use case:
 function InitialFocus() {
   const { isOpen, onOpen, onClose } = useDisclosure()
 
-  const initialRef = React.useRef()
-  const finalRef = React.useRef()
+  const initialRef = React.useRef(null)
+  const finalRef = React.useRef(null)
 
   return (
     <>
@@ -348,7 +348,7 @@ function ScrollingExample() {
   const { isOpen, onOpen, onClose } = useDisclosure()
   const [scrollBehavior, setScrollBehavior] = React.useState('inside')
 
-  const btnRef = React.useRef()
+  const btnRef = React.useRef(null)
   return (
     <>
       <RadioGroup value={scrollBehavior} onChange={setScrollBehavior}>


### PR DESCRIPTION
## 📝 Description

When i use modal examples(like InitialFocus), i get this type error.
`Type 'MutableRefObject<undefined>' is not assignable to type 'LegacyRef<HTMLButtonElement> | undefined'.
  Type 'MutableRefObject<undefined>' is not assignable to type 'RefObject<HTMLButtonElement>'.
    Types of property 'current' are incompatible.
      Type 'undefined' is not assignable to type 'HTMLButtonElement | null'.ts(2322)
index.d.ts(137, 9): The expected type comes from property 'ref' which is declared here on type 'IntrinsicAttributes & OmitCommonProps<DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement>, keyof ButtonProps> & ButtonProps & { ...; }'
`
To fix this error, i add null for initialValue

## ⛳️ Current behavior (updates)

Type incompatible error occurs

## 🚀 New behavior

The error disappear

## 💣 Is this a breaking change (Yes/No): No

