### PR TITLE
bugfix: Use background repeat space on talk invite graphic

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -650,7 +650,7 @@ const HomePage = ({
           bgImage='url(/audio-bar.svg)'
           bgPos='bottom center'
           bgSize='120px'
-          bgRepeat='repeat no-repeat'
+          bgRepeat='space no-repeat'
         >
           <Container
             pt='7.5rem'


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

No issue opened

## 📝 Description

This fixes an inconsistency the repeating audio bar graphic on the talk invite section on the homepage.

## ⛳️ Current behavior (updates)

![Current behavior](https://user-images.githubusercontent.com/29145479/171695739-55ff7abd-e417-4030-a260-c7bc46050501.png)

## 🚀 New behavior

![New behavior](https://user-images.githubusercontent.com/29145479/171695797-52cd02b6-2fdd-4b28-aa65-38ea12187bb9.png)

## 💣 Is this a breaking change (Yes/No):
No
<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information
- https://caniuse.com/background-repeat-round-space
