### PR TITLE
docs(icon): clarify icon / icons package usage

### DIFF
--- a/pages/docs/components/media-and-icons/icon.mdx
+++ b/pages/docs/components/media-and-icons/icon.mdx
@@ -25,9 +25,10 @@ Chakra provides multiple ways to use icons in your project:
 
 ## Using Chakra UI icons
 
-Chakra provides a set of commonly used interface icons you can use in your
-project. To use these icons, install `@chakra-ui/icons`, import the icons you
-need and style them.
+Chakra provides a set of commonly used interface icons you can use them in your
+project. These icons are published into a separate package that&apos;s not part
+of `@chakra-ui/react` by default. To use these icons, install the
+`@chakra-ui/icons` package, import the icons you need and style them.
 
 ### Installation
 


### PR DESCRIPTION
Closes #683 

## 📝 Description

The `@chakra-ui/icon` and `@chakra-ui/icons` package description could be a bit confusing. I've explicitly specified that the `@chakra-ui/icons` package is a standalone package that's not included in `@chakra-ui/react` and that it has to be installed individually in order to use the Chakra UI icons.