### PR TITLE
fix: fix active condition in sidebar link

### DIFF
--- a/src/components/sidebar/sidebar-link.tsx
+++ b/src/components/sidebar/sidebar-link.tsx
@@ -40,7 +40,7 @@ type SidebarLinkProps = PropsOf<typeof chakra.div> & {
 const SidebarLink = ({ href, children, ...rest }: SidebarLinkProps) => {
   const { asPath, query } = useRouter()
 
-  const isActive = asPath.split('?')[0] === href
+  const isActive = asPath.split('?')[0].split('#')[0] === href
 
   const link = useRef<HTMLAnchorElement>()
 


### PR DESCRIPTION
## 📝 Description

When you open a hashed URL and navigate through the pages, the URL you opened remains active. I modified the conditions the link is active in sidebar.

## ⛳️ Current behavior (updates)

1. Open URL with hash https://chakra-ui.com/guides/first-steps#framework-guide
2. Click other link in page
3. You can see 'First Step' is still active

<img width="751" alt="CleanShot 2022-06-03 at 16 44 21@2x" src="https://user-images.githubusercontent.com/7007253/171810942-d1c66ac6-5821-44ed-8aac-3eff2fb71428.png">

## 🚀 New behavior
1. Open URL with hash https://chakra-ui.com/guides/first-steps#framework-guide
2. Click other link in page
3. You can see 'First Step' is not active.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
