### PR TITLE
docs(theming): Fix extendTheme of space

### DIFF
--- a/pages/docs/styled-system/theming/theme.mdx
+++ b/pages/docs/styled-system/theming/theme.mdx
@@ -267,7 +267,7 @@ const spacing = {
   },
 }
 
-const theme = extendTheme({ spacing, ... })
+const theme = extendTheme({ space: spacing.space, ... })
 ```
 
 By default, Chakra includes a comprehensive numeric spacing scale inspired by


### PR DESCRIPTION
Closes # <!-- Github issue # here -->

## 📝 Description

I think docs is wrong. 

## ⛳️ Current behavior (updates)

This code does not affect spacing.
```
import { extendTheme } from '@chakra-ui/react'

const spacing = {
  space: {
    // ...
  },
}

const theme = extendTheme({ spacing })
```

## 🚀 New behavior

But It affects.
```
import { extendTheme } from '@chakra-ui/react'

const spacing = {
  space: {
    // ...
  },
}

const theme = extendTheme({ space: spacing.space })
```

## 💣 Is this a breaking change (Yes/No):

No 

## 📝 Additional Information
