### PR TITLE
Docs: Remove Stary Instance of 'none' in Pseudo Docs

### DIFF
--- a/pages/docs/styled-system/features/style-props.mdx
+++ b/pages/docs/styled-system/features/style-props.mdx
@@ -648,7 +648,6 @@ import { Button } from "@chakra-ui/react"
 | `_mediaReduceMotion`    | `@media (prefers-reduced-motion: reduce)`                                                                                                                                                  | none        |
 | `_dark`                 | `.chakra-ui-dark &`<br />`[data-theme=dark] &`<br />`&[data-theme=dark]`                                                                                                                   | none        |
 | `_light`                | `.chakra-ui-light &`<br />`[data-theme=light] &`<br />`&[data-theme=light]`                                                                                                                | none        |
-| none                    |
 
 ### Other Props
 


### PR DESCRIPTION
## 📝 Description

In the Styled System docs, beneath the `pseudo` section, there was a stray table row with the word `none`. This PR removes that stray word and row.

## ⛳️ Current behavior (updates)

In the Styled System docs, beneath the `pseudo` section, an unnecessary row is shown with only the word `none`.

## 🚀 New behavior

This PR removes that unnecessary row and the word `none`.

## 💣 Is this a breaking change (Yes/No):

No.
