### PR TITLE
feat: add 'Edit this page on GitHub' link

### DIFF
--- a/configs/site-config.ts
+++ b/configs/site-config.ts
@@ -1,4 +1,5 @@
 const baseUrl = 'https://github.com/chakra-ui/chakra-ui'
+const docBaseUrl = 'https://github.com/chakra-ui/chakra-ui-docs'
 
 const siteConfig = {
   copyright: `Copyright © ${new Date().getFullYear()} Segun Adebayo. All Rights Reserved.`,
@@ -16,7 +17,7 @@ const siteConfig = {
   },
   repo: {
     url: baseUrl,
-    editUrl: `${baseUrl}/edit/main/website/pages`,
+    editUrl: `${docBaseUrl}/edit/main/pages`,
     blobUrl: `${baseUrl}/blob/main`,
   },
   openCollective: {

--- a/configs/site-config.ts
+++ b/configs/site-config.ts
@@ -17,7 +17,7 @@ const siteConfig = {
   },
   repo: {
     url: baseUrl,
-    editUrl: `${docBaseUrl}/edit/main/pages`,
+    editUrl: `${docBaseUrl}/tree/main/pages`,
     blobUrl: `${baseUrl}/blob/main`,
   },
   openCollective: {

--- a/contentlayer.config.ts
+++ b/contentlayer.config.ts
@@ -15,10 +15,6 @@ const computedFields: ComputedFields = {
     type: 'string',
     resolve: (doc) => `/${doc._raw.flattenedPath}`,
   },
-  editUrl: {
-    type: 'string',
-    resolve: (doc) => `${siteConfig.repo.editUrl}/${doc._id}`,
-  },
 }
 
 const Guides = defineDocumentType(() => ({
@@ -41,6 +37,7 @@ const Guides = defineDocumentType(() => ({
         tags: doc.tags,
         author: doc.author,
         slug: `/${doc._raw.flattenedPath}`,
+        editUrl: `${siteConfig.repo.editUrl}/${doc._id}`,
         headings: getTableOfContents(doc.body.raw),
       }),
     },
@@ -71,6 +68,7 @@ const Blogs = defineDocumentType(() => ({
         title: doc.title,
         description: doc.description,
         slug: `/${doc._raw.flattenedPath}`,
+        editUrl: `${siteConfig.repo.editUrl}/${doc._id}`,
       }),
     },
   },
@@ -99,6 +97,7 @@ const Doc = defineDocumentType(() => ({
         image: doc.image,
         version: doc.version,
         slug: `/${doc._raw.flattenedPath}`,
+        editUrl: `${siteConfig.repo.editUrl}/${doc._id}`,
         headings: getTableOfContents(doc.body.raw),
       }),
     },
@@ -121,6 +120,7 @@ const Tutorial = defineDocumentType(() => ({
         title: doc.title,
         description: doc.description,
         slug: `/${doc._raw.flattenedPath}`,
+        editUrl: `${siteConfig.repo.editUrl}/${doc._id}`,
         headings: getTableOfContents(doc.body.raw),
       }),
     },
@@ -143,6 +143,7 @@ const FAQ = defineDocumentType(() => ({
         title: doc.title,
         description: doc.description,
         slug: `/${doc._raw.flattenedPath}`,
+        editUrl: `${siteConfig.repo.editUrl}/${doc._id}`,
         headings: getTableOfContents(doc.body.raw),
       }),
     },

--- a/i18n/ui.json
+++ b/i18n/ui.json
@@ -180,7 +180,7 @@
       "join-the-chakra-discord": "Join the #Chakra Discord!"
     },
     "edit-page-button": {
-      "edit-this-page": "Edit this page"
+      "edit-this-page": "Edit this page on GitHub"
     },
     "footer": {
       "title": "Nigeria",

--- a/src/components/edit-page-button.tsx
+++ b/src/components/edit-page-button.tsx
@@ -1,4 +1,4 @@
-import { Icon, Link, Stack, chakra } from '@chakra-ui/react'
+import { Box, Icon, Link, Stack, chakra } from '@chakra-ui/react'
 import * as React from 'react'
 import { MdEdit } from 'react-icons/md'
 import { t } from 'utils/i18n'
@@ -6,18 +6,20 @@ import { t } from 'utils/i18n'
 const EditPageLink = ({ href }: { href?: string }) => {
   return (
     <Link href={href} isExternal>
-      <Stack
-        display='inline-flex'
-        direction='row'
-        spacing={1}
-        align='center'
-        opacity={0.7}
-      >
-        <Icon as={MdEdit} mr='1' />
-        <chakra.span>
-          {t('component.edit-page-button.edit-this-page')}
-        </chakra.span>
-      </Stack>
+      <Box fontSize='sm' textAlign='right'>
+        <Stack
+          display='inline-flex'
+          direction='row'
+          spacing={1}
+          align='center'
+          opacity={0.7}
+        >
+          <Icon as={MdEdit} mr='1' />
+          <chakra.span>
+            {t('component.edit-page-button.edit-this-page')}
+          </chakra.span>
+        </Stack>
+      </Box>
     </Link>
   )
 }


### PR DESCRIPTION
## 📝 Description

Add a link to the end of each page (except changelog) to edit the page on GitHub.
<img src="https://user-images.githubusercontent.com/14218719/172788734-27d21dbe-81a1-41ca-9f7f-720c317856b3.png" width="75%" height="75%">

## ⛳️ Current behavior (updates)

No link from document page to directly edit it

## 🚀 New behavior

Link added to the end of each page to provide easy way to access and edit the documentation

## 💣 Is this a breaking change (Yes/No):

No

