### PR TITLE
style(props-table): add spacing between prop descriptions

### DIFF
--- a/src/components/props-table.tsx
+++ b/src/components/props-table.tsx
@@ -35,13 +35,7 @@ export type PropsTableProps = {
 
 const PropsTable = ({
   of,
-  omit = [
-    'layerStyle',
-    'noOfLines',
-    'textStyle',
-    'orientation',
-    'styleConfig',
-  ],
+  omit = ['layerStyle', 'noOfLines', 'textStyle', 'orientation', 'styleConfig'],
   only,
 }: PropsTableProps) => {
   const propList = React.useMemo(
@@ -58,7 +52,7 @@ Remove the use of <PropsTable of="${of}" /> for this component in the docs.`,
   }
 
   return (
-    <Stack overflowX='auto' spacing='10' my='10'>
+    <Stack overflowX='auto' spacing='16' my='10'>
       {propList.map((prop) => (
         <chakra.div
           key={prop.name}
@@ -86,7 +80,7 @@ Remove the use of <PropsTable of="${of}" /> for this component in the docs.`,
             <chakra.h3
               css={{
                 fontSize: '0.8em',
-                paddingBottom: 16,
+                paddingBottom: 4,
                 marginBottom: 16,
                 borderBottomWidth: 1,
               }}


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #709 

## 📝 Description

Update spacing between props in the `PropsTable` so that the name of each prop did not appear as if it was a part of the previous prop description.

## ⛳️ Current behavior (updates)

Current table (light mode):
![image](https://user-images.githubusercontent.com/65234762/173388418-10769f8a-fb52-4755-bf4e-12fc5e3100e7.png)


## 🚀 New behavior

Updated table: (light mode):
![image](https://user-images.githubusercontent.com/65234762/173388603-97da9699-a603-4bf2-b378-622862d02ea0.png)
