### PR TITLE
fix(componenet-sidebar): change the order of items as it appears

### DIFF
--- a/configs/components-sidebar.ts
+++ b/configs/components-sidebar.ts
@@ -314,8 +314,8 @@ const sidebar: Routes = {
           summarize: true,
           routes: [
             {
-              title: 'Transitions',
-              path: '/docs/components/other/transitions',
+              title: 'Close Button',
+              path: '/docs/components/other/close-button',
             },
             {
               title: 'Portal',
@@ -326,8 +326,8 @@ const sidebar: Routes = {
               path: '/docs/components/other/show-hide',
             },
             {
-              title: 'Close Button',
-              path: '/docs/components/other/close-button',
+              title: 'Transitions',
+              path: '/docs/components/other/transitions',
             },
           ],
         },


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes nothing

## 📝 Description

This fix reorders the links of the components as presented in the docs.

## ⛳️ Current behavior (updates)

When navigating from MEDIA AND ICONS section, from the Image component to the next component, you get to Transition, which isn't the first component in the OTHER section.

![image](https://user-images.githubusercontent.com/13337543/174097205-1920ad29-bfd5-4330-b96a-2310d3f54222.png)


so the current NEXT order is:
Image-> Transitions -> Portal -> Show/Hide -> Close Button

## 🚀 New behavior

Fix the order to be sequential.
new NEXT order is:
Image -> Close Button -> Portal -> Show/Hide -> Transitions
Just like in the visual presented order
![image](https://user-images.githubusercontent.com/13337543/174097027-4c4132ae-9fb7-4fc8-b7d7-13b70333b24e.png)

## 💣 Is this a breaking change (Yes/No):

NO

## 📝 Additional Information

NO
