### PR TITLE
Fix typos in "Guide to creating Components" page

### DIFF
--- a/pages/guides/advanced/component-guide.mdx
+++ b/pages/guides/advanced/component-guide.mdx
@@ -113,7 +113,7 @@ Ensure you run these commands before creating a PR.
 
 ## Resources
 
-- Aria Practices: https://www.w3.org/TR/wai-aria-practices/
+- Aria Practices: https://www.w3.org/WAI/ARIA/apg/
 - Lightning Design System: https://www.lightningdesignsystem.com/
 
 ### TypeScript
@@ -121,7 +121,7 @@ Ensure you run these commands before creating a PR.
 - Clean Code Guide: https://github.com/labs42io/clean-code-typescript
 
 - Best TypeScript
-  Practices:https://github.com/typescript-cheatsheets/react-typescript-cheatsheet
+  Practices: https://github.com/typescript-cheatsheets/react-typescript-cheatsheet
 
 ### Testing
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #741

## 📝 Description

There's a missing leading space before the "Best TypeScript Practices" link, and the "Aria Practices" link is no longer an active document on w3.org.

To fix, add the leading space and change the "Aria Practices" link to https://www.w3.org/TR/wai-aria-practices/.

## ⛳️ Current behavior (updates)

- Typos described in issue #741

## 🚀 New behavior

- Changes "Aria Practices" link to `https://www.w3.org/WAI/ARIA/apg/`
- Adds missing leading space before link for "Best TypeScript Practices"

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Love Chakra 💚
