### PR TITLE
docs(with-capsize): add outdated notice

### DIFF
--- a/content/getting-started/with-capsize.mdx
+++ b/content/getting-started/with-capsize.mdx
@@ -6,6 +6,10 @@ author: nikolovlazar
 category: integrations
 ---
 
+> 🚨 `chakra-capsize` is currently NOT compatible with Chakra UI v2 and React
+> 18, and is not actively being updated. Revert to `@chakra-ui/react@1.8.8` if
+> you want to use this package.
+
 Integrating Chakra UI with Capsize is made super easy by using the
 [chakra-capsize](https://github.com/ceteio/chakra-capsize) community package by
 [ceteio](https://github.com/ceteio).


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #733 

Adds a notice to the [Chakra UI + Capsize](https://chakra-ui/getting-started/with-capsize) doc page stating that `@ceteio/chakra-capsize` is not up-to-date and not compatible with Chakra UI v2 and React 18.
