### PR TITLE
Docs: Fix typo "vertical" -> "horizontal"

### DIFF
--- a/content/docs/components/stack/usage.mdx
+++ b/content/docs/components/stack/usage.mdx
@@ -16,7 +16,7 @@ import { Stack, HStack, VStack } from '@chakra-ui/react'
 ```
 
 - VStack: used to stack elements in the vertical direction
-- HStack: used to stack elements in the vertical direction
+- HStack: used to stack elements in the horizontal direction
 - Stack: used to stack elements in the vertical or horizontal direction
 
 ## Usage


### PR DESCRIPTION
## 📝 Description

> Fixed Typo

## ⛳️ Current behavior (updates)

> Docs state that HStack stacks elements in vertical direction.

## 🚀 New behavior

> Changed it to state that HStack stacks elements in the horizontal direction.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
