### PR TITLE
Update color-mode.mdx

### DIFF
--- a/content/docs/styled-system/color-mode.mdx
+++ b/content/docs/styled-system/color-mode.mdx
@@ -140,7 +140,7 @@ export default class Document extends NextDocument {
         <Head />
         <body>
           {/* 👇 Here's the script */}
-          <ColorModeScript initialColorMode={theme.config.initialColorMode} />
+          <ColorModeScript initialColorMode={theme.initialColorMode} />
           <Main />
           <NextScript />
         </body>


### PR DESCRIPTION

Closes: N/A

## 📝 Description

Updates documentation to use the proper path to `initialColorMode`. The theme object doesn't have a `config` key, it just contains all the keys.

Perhaps this is left over from a previous version/refactoring.

## ⛳️ Current behavior (updates)

Using example will return `undefined` and fallback to using a `light` color mode.

## 🚀 New behavior

Create the intended behavior of using the system color scheme and allowing the user to override it with a button.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
