### PR TITLE
fix(get-showcase-data): add missing new data pushes

### DIFF
--- a/scripts/get-showcase-data.ts
+++ b/scripts/get-showcase-data.ts
@@ -84,6 +84,7 @@ async function main() {
       // If it's youtube's url, use a thumbnail instead of a screenshot
       if (isYoutubeVideoUrl(url) || isYoutubeShortUrl(url)) {
         target.image = getYouTubeThumbnail(url)
+        currentDataTarget.push(target)
         continue
       }
 
@@ -94,6 +95,7 @@ async function main() {
           localDirToPreviewImageDir,
           key,
         )
+        currentDataTarget.push(target)
         continue
       }
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #763 

## 📝 Description

Add missing pushes to the `showcase.json` of target items from `awesome-chakra-ui` repo that are from Github or Youtube.

There is a nested for loop in the `main()` function that loops through each item from `awesome-chakra-ui` to obtain an image path to be pushed to `showcase.json`. However, with the checks for Github and Youtube URLs that are true, image paths are retrieved but the entire item never gets pushed and the check gets hit with the `continue` keyword to immediately terminate and move to the next iteration of the loop. 

This PR simply adds the array push for any item that has a Youtube or Github URL.

_P.S. This will currently retrieve 10 items that were getting ignored in the script._