### PR TITLE
fix(docs): update tailwind dark mode information

### DIFF
--- a/content/getting-started/comparison.mdx
+++ b/content/getting-started/comparison.mdx
@@ -75,8 +75,6 @@ box.
 ### Dark Mode 🌜
 
 **Tailwind CSS**: All components are dark mode compatible with `dark` variant.
-Due to file size considerations, the dark mode variant is not enabled in
-Tailwind by default.
 
 **Chakra UI**: All components are light and dark mode compatible. You can also
 author your own light and dark mode experience across your application.


### PR DESCRIPTION
## 📝 Description

Tailwind dark mode is [enabled by default](https://tailwindcss.com/docs/upgrade-guide#remove-dark-mode-configuration) from Tailwind v3 onwards. They use the new JIT compiler so file size is no longer a concern.

## ⛳️ Current behavior (updates)

Docs mention that tailwind dark mode needs to be explicitly enabled

## 🚀 New behavior

Removed the part where the docs mention that tailwind dark mode needs to be explicitly enabled as this is no longer the case

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

None