### PR TITLE
chore(FormControl): remove unnecessary htmlFor and id

### DIFF
--- a/content/docs/components/form-control/usage.mdx
+++ b/content/docs/components/form-control/usage.mdx
@@ -121,9 +121,9 @@ indicate that a field is optional you can add `optionalIndicator` to the
 
 ```jsx
 <FormControl>
-  <FormLabel htmlFor='amount'>Amount</FormLabel>
+  <FormLabel>Amount</FormLabel>
   <NumberInput max={50} min={10}>
-    <NumberInputField id='amount' />
+    <NumberInputField />
     <NumberInputStepper>
       <NumberIncrementStepper />
       <NumberDecrementStepper />

--- a/content/docs/components/form-control/usage.mdx
+++ b/content/docs/components/form-control/usage.mdx
@@ -16,6 +16,7 @@ Chakra UI exports 4 components for Form Control:
   children.
 - **`FormLabel`**: The label of a form section. The usage is similar to
   [html label](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label).
+  `htmlFor` is set by default for children input.
 - **`FormHelperText`**: The message that tells users more details about the form
   section.
 - **`FormErrorMessage`**: The message that shows up when an error occurs.
@@ -33,8 +34,8 @@ import {
 
 ```jsx
 <FormControl>
-  <FormLabel htmlFor='email'>Email address</FormLabel>
-  <Input id='email' type='email' />
+  <FormLabel>Email address</FormLabel>
+  <Input type='email' />
   <FormHelperText>We'll never share your email.</FormHelperText>
 </FormControl>
 ```
@@ -71,9 +72,8 @@ function errorMessageExample() {
 
   return (
     <FormControl isInvalid={isError}>
-      <FormLabel htmlFor='email'>Email</FormLabel>
+      <FormLabel>Email</FormLabel>
       <Input
-        id='email'
         type='email'
         value={input}
         onChange={handleInputChange}
@@ -100,8 +100,8 @@ indicate that a field is optional you can add `optionalIndicator` to the
 
 ```jsx
 <FormControl isRequired>
-  <FormLabel htmlFor='first-name'>First name</FormLabel>
-  <Input id='first-name' placeholder='First name' />
+  <FormLabel>First name</FormLabel>
+  <Input placeholder='First name' />
 </FormControl>
 ```
 
@@ -109,8 +109,8 @@ indicate that a field is optional you can add `optionalIndicator` to the
 
 ```jsx
 <FormControl>
-  <FormLabel htmlFor='country'>Country</FormLabel>
-  <Select id='country' placeholder='Select country'>
+  <FormLabel>Country</FormLabel>
+  <Select placeholder='Select country'>
     <option>United Arab Emirates</option>
     <option>Nigeria</option>
   </Select>
@@ -164,8 +164,8 @@ function FormikExample() {
           <Field name='name' validate={validateName}>
             {({ field, form }) => (
               <FormControl isInvalid={form.errors.name && form.touched.name}>
-                <FormLabel htmlFor='name'>First name</FormLabel>
-                <Input {...field} id='name' placeholder='name' />
+                <FormLabel>First name</FormLabel>
+                <Input {...field} placeholder='name' />
                 <FormErrorMessage>{form.errors.name}</FormErrorMessage>
               </FormControl>
             )}

--- a/content/docs/components/form-control/usage.mdx
+++ b/content/docs/components/form-control/usage.mdx
@@ -205,3 +205,7 @@ function FormikExample() {
 - If you render `FormErrorMessage` and `isInvalid` is `false` or `undefined`,
   `FormErrorMessage` won't be visible. The only way to make it visible is by
   passing `isInvalid` and setting it to `true`.
+  
+- You can still supply an `id` prop to `FormControl` that will override the randomly generated `id` and attach to the `for` attribute of the label and the `id` of the form element. (It also affects the `id` attribute of the label)
+
+- The combination of `htmlFor` and `id` are optional in which adding both will also override the generated `id` sent to the provider.


### PR DESCRIPTION
## 📝 Description

- Little changes on some examples, removing unnecessary `htmlFor` and `id`;
- And improvements about usage of this properties at `Improvements from v1` section.

## ⛳️ Current behavior (updates)

Today, the [documentation](https://chakra-ui.com/docs/components/form-control/usage) of `FormControl` shows `htmlFor` and `id` as necessary props (it doesn't say that, but it does imply)

## 🚀 New behavior

Most samples will not show these props. However, their use is described for situations of greater need for control.

## 💣 Is this a breaking change (Yes/No):

No
