### PR TITLE
docs: Fix broken link in advanced theming (for distributing theme packages)

### DIFF
--- a/content/docs/styled-system/advanced-theming.mdx
+++ b/content/docs/styled-system/advanced-theming.mdx
@@ -152,7 +152,7 @@ chakra-cli tokens <path/to/your/theme.(js|ts)>
 ```
 
 or, for a
-[theme package](/docs/styled-system/advanced#distributing-a-theme-package):
+[theme package](/docs/styled-system/advanced-theming#distributing-a-theme-package):
 
 ```bash
 chakra-cli tokens <@your-org/chakra-theme-package>


### PR DESCRIPTION
	
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->


## 📝 Description

Fixed a broken link in the [advanced theming page](https://chakra-ui.com/docs/styled-system/advanced-theming)

## ⛳️ Current behavior (updates)

Currently the link 404s

## 🚀 New behavior

The link goes to the respective page, and to the respective section

## 💣 Is this a breaking change (Yes/No):
No
<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information
None