### PR TITLE
Fix typo: color more -> color mode

### DIFF
--- a/content/getting-started/migration.mdx
+++ b/content/getting-started/migration.mdx
@@ -87,7 +87,7 @@ toast({ title: 'Chakra UI' })
 
 ### 3. Color mode update
 
-#### Color more transition
+#### Color mode transition
 
 Ensure the transition between light/dark modes happens instantly without
 transition. This helps to avoid a weird UX when switch modes for elements with
@@ -129,7 +129,7 @@ you can set `type` prop to `cookie`.
 <ColorModeScript type='cookie' />
 ```
 
-#### Color more precedence
+#### Color mode precedence
 
 Refactored color mode to behave consistently between provider and script. The
 new precedence is as follows:


### PR DESCRIPTION
This change just fixes a typo found on the docs seen here: https://chakra-ui.com/getting-started/migration#color-more-transition

`color more` -> `color mode`