### PR TITLE
docs(style-props): remove invalid props from filter code examples

### DIFF
--- a/content/docs/styled-system/style-props.mdx
+++ b/content/docs/styled-system/style-props.mdx
@@ -450,12 +450,7 @@ function Filters() {
       'url(https://picsum.photos/id/1080/200/300) center/cover no-repeat',
   }
   return (
-    <Flex
-      flexWrap='wrap'
-      spacing='24px'
-      gap='16px'
-      justifyContent='space-evenly'
-    >
+    <Flex flexWrap='wrap' gap='24px' justifyContent='space-evenly'>
       {/* adding filter property to the element */}
       <Box sx={basicBoxStyles} filter='grayscale(80%)'>
         Box with Filter
@@ -497,12 +492,7 @@ function BackdropFilters() {
     fontSize: '20px',
   }
   return (
-    <Flex
-      flexWrap='wrap'
-      spacing='24px'
-      gap='16px'
-      justifyContent='space-evenly'
-    >
+    <Flex flexWrap='wrap' gap='24px' justifyContent='space-evenly'>
       {/* adding backdrop-filter property to the element */}
       <Box sx={outerBoxStyles}>
         <Box sx={innerBoxStyles} backdropFilter='invert(100%)'>


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #853 

## 📝 Description

Remove the invalid prop `spacing` from the `Flex` parent components in the `filter` and `backdropFilter` code examples.