### PR TITLE
fix: chakra ui version in sandboxes on v1 docs

### DIFF
--- a/src/components/sandpack-embed/index.tsx
+++ b/src/components/sandpack-embed/index.tsx
@@ -20,8 +20,8 @@ const SandpackEmbed = ({ dependencies, ...props }: Props) => (
     customSetup={{
       dependencies: {
         'react-icons': '3.11.0',
-        '@chakra-ui/react': 'latest',
-        '@chakra-ui/icons': 'latest',
+        '@chakra-ui/react': '1.8.8',
+        '@chakra-ui/icons': '1.1.7',
         '@emotion/react': '^11.7.0',
         '@emotion/styled': '^11.6.0',
         'framer-motion': '^4.1.17',


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #767 

## 📝 Description

All sandboxes have `latest` as version for the packages `@chakra-ui/react` and `@chakra-ui/icons` which caused problems on the **v1 docs**.

## ⛳️ Current behavior (updates)

Most of the sandboxes in the **v1 docs** shows errors, see e.g. the example on the [startpage](https://v1.chakra-ui.com) or [Chakra UI + Formik](https://v1.chakra-ui.com/guides/integrations/with-formik).

## 🚀 New behavior

This PR sets `@chakra-ui/react` and `@chakra-ui/icons` to the latest v1 version on the v1 branch.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
