### PR TITLE
docs(advanced-theming): update link for theme typings

### DIFF
--- a/content/docs/styled-system/advanced-theming.mdx
+++ b/content/docs/styled-system/advanced-theming.mdx
@@ -115,7 +115,7 @@ for more recommendations on how to structure your theme package.
 > Note ⚠️: If you're using TypeScript, you'll want to include some documentation
 > guiding consumers of your theme package to add a `postinstall` script to
 > generate typings for your theme. See the
-> [theme typings](/docs/styled-system/advanced#theme-typings) section
+> [theme typings](/docs/styled-system/advanced-theming#theme-typings) section
 > for details.
 
 ## Theme Typings


### PR DESCRIPTION

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

Fixed a broken link in the [advanced theming page](https://chakra-ui.com/docs/styled-system/advanced-theming)

## ⛳️ Current behavior (updates)

The link 404s

## 🚀 New behavior

The link goes to the respective page, and to the respective section

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

None