### PR TITLE
docs: add hint for default min and max prop of NumberInput

### DIFF
--- a/content/docs/components/number-input/usage.mdx
+++ b/content/docs/components/number-input/usage.mdx
@@ -51,6 +51,13 @@ Pass the `min` prop or `max` prop to set an upper and lower limit for the input.
 By default, the input will restrict the value to stay within the specified
 range.
 
+> These props defaults to
+> [Number.MIN_SAFE_INTEGER](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MIN_SAFE_INTEGER)
+> and
+> [Number.MAX_SAFE_INTEGER](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER)
+> . If they do not match your requirements you can use other `Number` properties
+> as `min` or `max`.
+
 ```jsx
 <NumberInput defaultValue={15} min={10} max={20}>
   <NumberInputField />


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #914

## 📝 Description

Adds a hint for the default `min` and `max` values.

## ⛳️ Current behavior (updates)

No hints, information only on props tab (there it is currently wrong, PR is open, see below)

## 🚀 New behavior
Adds a short hint for the default values of the `min` and `max` prop.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
Fix for default values in docs: https://github.com/chakra-ui/chakra-ui/pull/6485