### PR TITLE
fix(use-checkbox): fixed text color in dark mode

### DIFF
--- a/content/docs/hooks/use-checkbox-group.mdx
+++ b/content/docs/hooks/use-checkbox-group.mdx
@@ -61,7 +61,7 @@ function Example() {
         >
           {state.isChecked && <Box w={2} h={2} bg='green.500' />}
         </Flex>
-        <Text {...getLabelProps()}>Click me for {props.value}</Text>
+        <Text color="gray.700" {...getLabelProps()}>Click me for {props.value}</Text>
       </chakra.label>
     )
   }

--- a/content/docs/hooks/use-checkbox.mdx
+++ b/content/docs/hooks/use-checkbox.mdx
@@ -61,7 +61,7 @@ function Example() {
         >
           {state.isChecked && <Box w={2} h={2} bg='green.500' />}
         </Flex>
-        <Text {...getLabelProps()}>Click me</Text>
+        <Text color="gray.700" {...getLabelProps()}>Click me</Text>
       </chakra.label>
     )
   }


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

Fixed a problem in the `useCheckBox` demo where text was difficult to see in dark mode.

## ⛳️ Current behavior (updates)

<img width="200" alt="image" src="https://user-images.githubusercontent.com/20895397/185912834-f1433672-cec0-4c5c-ad95-8b9755f0c66d.png">

## 🚀 New behavior

Added `color="gray.700"` to Text.

<img width="200" alt="image" src="https://user-images.githubusercontent.com/20895397/185913008-6826bc11-1d18-49f6-a750-d6a25f70e49a.png">

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

- Also modified `useCheckboxGroup`.
- Operation in Light mode has not changed.
    - <img width="146" alt="image" src="https://user-images.githubusercontent.com/20895397/185913419-1eb2560b-93c4-41da-a764-25134dc90b4f.png">

