### PR TITLE
fix(docs): fixed broken link in customize page

### DIFF
--- a/content/docs/styled-system/customize-theme.mdx
+++ b/content/docs/styled-system/customize-theme.mdx
@@ -57,7 +57,7 @@ You can also use the color for the `colorScheme` prop like this:
 
 > If you're curious as to what theme styles you can override, please reference
 > the
-> [default theme foundation style files](https://github.com/chakra-ui/chakra-ui/tree/main/packages/theme/src/foundations).
+> [default theme foundation style files](https://github.com/chakra-ui/chakra-ui/tree/main/packages/components/theme/src/foundations).
 
 ## Customizing component styles
 


### PR DESCRIPTION
Closes #945 

## 📝 Description

Customize Theme page contains a link that points to the old Foundations theme path.

## ⛳️ Current behavior (updates)

Dead link.

## 🚀 New behavior

No more dead link!

## 💣 Is this a breaking change (Yes/No):

Nope

## 📝 Additional Information
