### PR TITLE
fix(docs): replace "later" with "earlier"

### DIFF
--- a/content/getting-started/index.mdx
+++ b/content/getting-started/index.mdx
@@ -5,7 +5,7 @@ tags: ['principles']
 ---
 
 > Version 2 of Chakra UI is only compatible with React 18. If you are still
-> needing to use React 17 or later, please use
+> needing to use React 17 or earlier, please use
 > [version 1 of Chakra UI](https://v1.chakra-ui.com/guides/first-steps).
 
 To use Chakra UI in your project, run one of the following commands in your terminal:


### PR DESCRIPTION
## 📝 Description

Fixes a small typo since presumably v1 is for React 17 or earlier, not later.

## 💣 Is this a breaking change (Yes/No):

No
