### PR TITLE
change React.useState(0) to useState(0)

### DIFF
--- a/content/docs/components/tabs/usage.mdx
+++ b/content/docs/components/tabs/usage.mdx
@@ -337,7 +337,7 @@ onChange as well, or else the tabs will not be interactive.
 
 ```jsx
 function ControlledExample() {
-  const [tabIndex, setTabIndex] = React.useState(0)
+  const [tabIndex, setTabIndex] = useState(0)
 
   const handleSliderChange = (event) => {
     setTabIndex(parseInt(event.target.value, 10))


### PR DESCRIPTION

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->
## 📝 Description

> wanted to use the tabs component and noticed `React.useState()` was used instead of `useState()` one of the examples.

## ⛳️ Current behavior (updates)

> syntax was `React.useState(0)`

## 🚀 New behavior

> syntax was changed to `useState(0)`

## 💣 Is this a breaking change (Yes/No):
NO
<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information
