### PR TITLE
fix(docs): fix the small english mistake on the global-styles doc

### DIFF
--- a/content/docs/styled-system/global-styles.mdx
+++ b/content/docs/styled-system/global-styles.mdx
@@ -7,7 +7,7 @@ category: 'features'
 `GlobalStyle` is a new component in v1 that injects styles defined in
 `theme.styles.global` into the global styles of your app or website.
 
-This allows you define theme-aware styles for any elements.
+This allows you to define theme-aware styles for any elements.
 
 ## How it works
 


### PR DESCRIPTION
## 📝 Description

There was a small English error on the chakra-ui global styles doc (it is missing the word "to")

## ⛳️ Current behavior (updates)

It was missing the word "to" on the global styles doc.

## 🚀 New behavior

Added the word "to" on the global styles doc.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Please let me know if I did anything wrong, I'm a first-time contributor to this repo. Thanks!
