### PR TITLE
(docs) Next JS: Change custom document to use functional components.

### DIFF
--- a/content/getting-started/nextjs-guide.mdx
+++ b/content/getting-started/nextjs-guide.mdx
@@ -114,11 +114,10 @@ for local storage syncing to work correctly.
 // pages/_document.js
 
 import { ColorModeScript } from '@chakra-ui/react'
-import NextDocument, { Html, Head, Main, NextScript } from 'next/document'
+import { Html, Head, Main, NextScript } from 'next/document'
 import theme from './theme'
 
-export default class Document extends NextDocument {
-  render() {
+export default function Document() {
     return (
       <Html lang='en'>
         <Head />
@@ -130,7 +129,6 @@ export default class Document extends NextDocument {
         </body>
       </Html>
     )
-  }
 }
 ```
 


### PR DESCRIPTION
## 📝 Description

> Using a functional component over a class component is the recommended method to override the default document as per Next documentation: https://nextjs.org/docs/advanced-features/custom-document

## ⛳️ Current behavior (updates)

> Docs for NextJS Custom Document use class component

## 🚀 New behavior

> Docs for NextJS Custom Document use functional component

## 💣 Is this a breaking change (Yes/No):
No

