### PR TITLE
chore(.vscode): replace deprecated mdx extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -6,6 +6,6 @@
     "eamodio.gitlens",
     "pflannery.vscode-versionlens",
     "esbenp.prettier-vscode",
-    "silvenon.mdx"
+    "unifiedjs.vscode-mdx"
   ]
 }


### PR DESCRIPTION
In the `.vscode/extension.json` the recommended MDX extension listed is now deprecated. This PR replaces it with the current extension
.