### PR TITLE
Set `live=false` to final `useBreakpointValue` code example

### DIFF
--- a/content/docs/hooks/use-breakpoint-value.mdx
+++ b/content/docs/hooks/use-breakpoint-value.mdx
@@ -27,18 +27,22 @@ The `useBreakpointValue` hook returns the value for the current breakpoint.
 
 ## Usage
 
-> Make sure to provide a base value when using `useBreakpointValue` so it doesn't return `undefined` in the first render.
+> Make sure to provide a base value when using `useBreakpointValue` so it
+> doesn't return `undefined` in the first render.
 
 ```jsx
 function Example() {
-  const variant = useBreakpointValue({ 
-    base: 'outline', 
-    md: 'solid' 
-  }, {
-    // Breakpoint to use when mediaqueries cannot be used, such as in server-side rendering
-    // (Defaults to 'base')
-    fallback: 'md'
-  })
+  const variant = useBreakpointValue(
+    {
+      base: 'outline',
+      md: 'solid',
+    },
+    {
+      // Breakpoint to use when mediaqueries cannot be used, such as in server-side rendering
+      // (Defaults to 'base')
+      fallback: 'md',
+    },
+  )
 
   return (
     <VStack align='flex-start'>
@@ -51,15 +55,15 @@ function Example() {
 }
 ```
 
-This hook is built to work in server-side rendering (SSR) applications by default. You might notice a quick flash of incorrect media query values when you use them.
+This hook is built to work in server-side rendering (SSR) applications by
+default. You might notice a quick flash of incorrect media query values when you
+use them.
 
-If you're creating a client-side rendered app, you can leverage the ssr argument to get the correct value on the first render.
+If you're creating a client-side rendered app, you can leverage the ssr argument
+to get the correct value on the first render.
 
-```jsx
-const buttonSize = useBreakpointValue(
-  { base: "sm", lg: "md" },
-  { ssr: false },
-)
+```jsx live=false
+const buttonSize = useBreakpointValue({ base: 'sm', lg: 'md' }, { ssr: false })
 
 const breakpoint = useBreakpoint({ ssr: false })
 ```


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description
Add the `live=false` flag to the code block for the last example in the [useBreakpointValue](https://chakra-ui.com/docs/hooks/use-breakpoint-value) doc page

## ⛳️ Current behavior (updates)

With no `live=false` this example attempts to open a preview, but throws an error because of improper syntax. 

## 🚀 New behavior
This example did not intend to have a preview and `live=false` removes the rendered preview window

## 💣 Is this a breaking change (Yes/No):
Nope

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information
