### PR TITLE
fix(form-control): comment out import line in Formik example

### DIFF
--- a/content/docs/components/form-control/usage.mdx
+++ b/content/docs/components/form-control/usage.mdx
@@ -134,7 +134,8 @@ Form Libraries like [Formik](https://jaredpalmer.com/formik/) make it soooo easy
 to manage form state and validation. I 💖 Formik
 
 ```jsx
-// import { Field, Form, Formik } from '@formik';
+// The below import defines which components come from formik
+// import { Field, Form, Formik } from 'formik';
 
 function FormikExample() {
   function validateName(value) {

--- a/content/docs/components/form-control/usage.mdx
+++ b/content/docs/components/form-control/usage.mdx
@@ -73,11 +73,7 @@ function errorMessageExample() {
   return (
     <FormControl isInvalid={isError}>
       <FormLabel>Email</FormLabel>
-      <Input
-        type='email'
-        value={input}
-        onChange={handleInputChange}
-      />
+      <Input type='email' value={input} onChange={handleInputChange} />
       {!isError ? (
         <FormHelperText>
           Enter the email you'd like to receive the newsletter on.
@@ -138,7 +134,7 @@ Form Libraries like [Formik](https://jaredpalmer.com/formik/) make it soooo easy
 to manage form state and validation. I 💖 Formik
 
 ```jsx
-import { Field, Form, Formik } from '@formik';
+// import { Field, Form, Formik } from '@formik';
 
 function FormikExample() {
   function validateName(value) {
@@ -207,7 +203,9 @@ function FormikExample() {
 - If you render `FormErrorMessage` and `isInvalid` is `false` or `undefined`,
   `FormErrorMessage` won't be visible. The only way to make it visible is by
   passing `isInvalid` and setting it to `true`.
-  
-- You can still supply an `id` prop to `FormControl` that will override the randomly generated `id` and attach to the `for` attribute of the label and the `id` of the form element. (It also affects the `id` attribute of the label)
+- You can still supply an `id` prop to `FormControl` that will override the
+  randomly generated `id` and attach to the `for` attribute of the label and the
+  `id` of the form element. (It also affects the `id` attribute of the label)
 
-- The combination of `htmlFor` and `id` are optional in which adding both will also override the generated `id` sent to the provider.
+- The combination of `htmlFor` and `id` are optional in which adding both will
+  also override the generated `id` sent to the provider.


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #1066

## 📝 Description

PR #1030 introduced a change to the Formik code example in the [FormControl](https://chakra-ui.com/docs/components/form-control/usage#usage-with-form-libraries) component docs, where an import statement for `Formik` was added to define which components from that package are being used compared to components from Chakra.

However, based on how the React Preview is designed, import statements from packages do not need to be defined in the code block, and break in the compiler. Therefore, this import statement should've been added as a comment.

## ⛳️ Current behavior (updates)

Preview of the Formik example does not render, and a syntax error is thrown

## 🚀 New behavior

Import statement is commented out and the preview renders as expected

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
