### PR TITLE
docs: fix import statement to reflect where defineStyleConfig is

### DIFF
--- a/content/docs/styled-system/component-style.mdx
+++ b/content/docs/styled-system/component-style.mdx
@@ -90,7 +90,7 @@ below.
 Here's a contrived implementation of the design:
 
 ```tsx live=false
-import { defineStyleConfig } from '@chakra-ui/theme'
+import { defineStyleConfig } from '@chakra-ui/react'
 
 const Button = defineStyleConfig({
   // The styles all button have in common


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

the `defineStyleConfig` was being imported from the wrong place. I have made the change to the docs to import from `'@chakra-ui/react'` instead of `/theme`

## 💣 Is this a breaking change (Yes/No):
No

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->
