### PR TITLE
feature(docs): link component theming docs

### DIFF
--- a/configs/sandpack-contents/component-theming/link.js
+++ b/configs/sandpack-contents/component-theming/link.js
@@ -7,23 +7,30 @@ export default function App() {
   const { toggleColorMode, colorMode } = useColorMode();
   return (
     <Box position="relative" h="100vh">
-      <SimpleGrid gap={12} p={12}>
+      <SimpleGrid gap={12} p={12} columns={2}>
         <Link textDecoration={"underline"} href="https://chakra-ui.com">
-          Themed Underline Link
+          themed underline link
         </Link>
         <Link href="https://chakra-ui.com" isExternal>
-          Themed External Link <ExternalLinkIcon mx="2px" />
+          themed external link <ExternalLinkIcon mx="2px" />
         </Link>
         <Text>
           Themed Link{" "}
           <Link href="https://chakra-ui.com">
-            With Inline Text
+            with inline text
           </Link>
         </Text>
+        <Link href="https://chakra-ui.com" variant="custom">
+          themed link with custom variant
+        </Link>
+        <Link href="https://chakra-ui.com" size="xl">
+          link size xl
+        </Link>
       </SimpleGrid>
 
       <IconButton
         rounded="full"
+        aria-label="change theme"
         size="xs"
         position="absolute"
         bottom={4}
@@ -58,47 +65,37 @@ root.render(
 const baseStyle = defineStyle({
   fontWeight: "normal", // change the font weight to normal
   fontFamily: "mono", // change the font family to monospaced
-  textColor:  "purple.500" // change the text color to purple
+  textColor:  "purple.500", // change the text color to purple
+  textTransform:'capitalize'
 })
 
 const sizes = {
-  md: defineStyle({
-    fontSize: "sm", // Change font size to sm (14px)
+  xl: defineStyle({
+    fontSize: "xl", // Change font size to sm (20px),
   }),
 }
+
 
 // Defining a custom variant
 const customVariant = defineStyle((props) => {
   const { colorScheme: c } = props
   return {
     fontFamily: "sans-serif",
-    bg: \`\${c}.500\`,
-    fontWeight: "semibold",
     color: 'white',
-    borderRadius: '3xl',
-    transition: 'transform 0.15s ease-out, background 0.15s ease-out',
+    transition: 'transform 0.15s ease-out, fontWeight 0.15s ease-out',
     _dark: {
-      bg: \`\${c}.200\`,
-      color: 'gray.800',
+      color: \`\${c}.500\`,
     },
-
+    
     _hover: {
       transform: "scale(1.05, 1.05)",
-      bg: \`\${c}.600\`,
-
+      fontWeight: "semibold",
+      textDecorationStyle: "wavy",
       _dark: {
-        bg: \`\${c}.300\`,
+        color: \`\${c}.500\`,
       },
     },
 
-    _active: {
-      bg: \`\${c}.700\`,
-      transform: "scale(1, 1)",
-
-      _dark: {
-        bg: \`\${c}.400\`,
-      }
-    },
   }
 })
 

--- a/configs/sandpack-contents/component-theming/link.js
+++ b/configs/sandpack-contents/component-theming/link.js
@@ -1,0 +1,112 @@
+module.exports = {
+  App: `import { Box, SimpleGrid, IconButton, Link, Text, useColorMode } from "@chakra-ui/react";
+import { FaMoon, FaSun } from "react-icons/fa";
+import { ExternalLinkIcon } from "@chakra-ui/icons";
+
+export default function App() {
+  const { toggleColorMode, colorMode } = useColorMode();
+  return (
+    <Box position="relative" h="100vh">
+      <SimpleGrid gap={12} p={12}>
+        <Link textDecoration={"underline"} href="https://chakra-ui.com">
+          Themed Underline Link
+        </Link>
+        <Link href="https://chakra-ui.com" isExternal>
+          Themed External Link <ExternalLinkIcon mx="2px" />
+        </Link>
+        <Text>
+          Themed Link{" "}
+          <Link href="https://chakra-ui.com">
+            With Inline Text
+          </Link>
+        </Text>
+      </SimpleGrid>
+
+      <IconButton
+        rounded="full"
+        size="xs"
+        position="absolute"
+        bottom={4}
+        left={4}
+        onClick={toggleColorMode} icon={colorMode === "dark" ? <FaSun /> : <FaMoon />}
+      />
+    </Box>
+  );
+}`,
+  Index: `import * as React from "react";
+import { createRoot } from "react-dom/client";
+import { ChakraProvider, extendTheme } from "@chakra-ui/react";
+
+import App from "./App";
+import { linkTheme } from "./theme/components/Link.ts";
+
+const theme = extendTheme({
+  components: {
+    Link: linkTheme,
+  }
+});
+
+const container = document.getElementById("root");
+const root = createRoot(container!);
+root.render(
+  <ChakraProvider theme={theme}>
+    <App />
+  </ChakraProvider>
+);`,
+  LinkTheme: `import { defineStyle, defineStyleConfig } from "@chakra-ui/styled-system"
+
+const baseStyle = defineStyle({
+  fontWeight: "normal", // change the font weight to normal
+  fontFamily: "mono", // change the font family to monospaced
+  textColor:  "purple.500" // change the text color to purple
+})
+
+const sizes = {
+  md: defineStyle({
+    fontSize: "sm", // Change font size to sm (14px)
+  }),
+}
+
+// Defining a custom variant
+const customVariant = defineStyle((props) => {
+  const { colorScheme: c } = props
+  return {
+    fontFamily: "sans-serif",
+    bg: \`\${c}.500\`,
+    fontWeight: "semibold",
+    color: 'white',
+    borderRadius: '3xl',
+    transition: 'transform 0.15s ease-out, background 0.15s ease-out',
+    _dark: {
+      bg: \`\${c}.200\`,
+      color: 'gray.800',
+    },
+
+    _hover: {
+      transform: "scale(1.05, 1.05)",
+      bg: \`\${c}.600\`,
+
+      _dark: {
+        bg: \`\${c}.300\`,
+      },
+    },
+
+    _active: {
+      bg: \`\${c}.700\`,
+      transform: "scale(1, 1)",
+
+      _dark: {
+        bg: \`\${c}.400\`,
+      }
+    },
+  }
+})
+
+export const linkTheme = defineStyleConfig({
+  baseStyle,
+  sizes,
+  variants: {
+    custom: customVariant,
+  }
+})`,
+}

--- a/content/docs/components/link/theming.mdx
+++ b/content/docs/components/link/theming.mdx
@@ -43,7 +43,6 @@ import { defineStyle, defineStyleConfig } from '@chakra-ui/react'
 
 const xl = defineStyle({
   fontSize: 'xl',
-  px: '6',
 })
 
 export const linkTheme = defineStyleConfig({
@@ -54,16 +53,9 @@ export const linkTheme = defineStyleConfig({
 <Link size="xl">...</Link>
 ```
 
-Every time you're adding anything new to the theme, you'd need to run the cli
-command to get proper autocomplete in your IDE. Here's how you can do that:
-
-```bash
-# run it once:
-npx chakra-cli tokens path/to/theme.ts
-
-# or run it in watch mode:
-npx chakra-cli tokens path/to/theme.ts --watch
-```
+Every time you're adding anything new to the theme, you'd need to run the CLI
+command to get proper autocomplete in your IDE. You can learn more about the CLI
+tool [here](/docs/styled-system/cli).
 
 ## Adding a custom variant
 

--- a/content/docs/components/link/theming.mdx
+++ b/content/docs/components/link/theming.mdx
@@ -2,3 +2,164 @@
 id: link
 scope: theming
 ---
+
+The `Link` component is a single part component. All of the styling is applied
+directly to the `anchor` element.
+
+> To learn more about styling single part components, visit the
+> [Component Style](/docs/styled-system/component-style#styling-single-part-components)
+> page.
+
+## Theming properties
+
+The properties that affect the theming of the `Link` component are:
+
+- `variant`: The visual variant of the Link component.
+- `colorScheme`: The color scheme of the Link component.
+- `size`: The size of the Link component.
+
+> Note: Theming properties for Link component are not implemented in the default
+> theme. You can
+> [extend the theme](/docs/styled-system/customize-theme#customizing-component-styles)
+> to implement them.
+
+## Theming utilities
+
+- `defineStyle`: a function used to create style objects.
+- `defineStyleConfig`: a function used to define the style configuration for a
+  single part component.
+
+```jsx live=false
+import { defineStyle, defineStyleConfig } from '@chakra-ui/react'
+```
+
+## Adding a custom size
+
+Let's assume we want to include an extra large link size. Here's how we can do
+that:
+
+```jsx live=false
+import { defineStyle, defineStyleConfig } from '@chakra-ui/react'
+
+const xl = defineStyle({
+  fontSize: 'xl',
+  px: '6',
+})
+
+export const linkTheme = defineStyleConfig({
+  sizes: { xl },
+})
+
+// Now we can use the new `xl` size
+<Link size="xl">...</Link>
+```
+
+Every time you're adding anything new to the theme, you'd need to run the cli
+command to get proper autocomplete in your IDE. Here's how you can do that:
+
+```bash
+# run it once:
+npx chakra-cli tokens path/to/theme.ts
+
+# or run it in watch mode:
+npx chakra-cli tokens path/to/theme.ts --watch
+```
+
+## Adding a custom variant
+
+Let's assume we want to include a custom branded variant. Here's how we can do
+that:
+
+```jsx live=false
+import { defineStyle, defineStyleConfig } from '@chakra-ui/react'
+
+const brandPrimary = defineStyle({
+  textDecoration: 'underline',
+  color: 'white',
+  fontFamily: 'serif',
+  fontWeight: 'normal',
+
+  // let's also provide dark mode alternatives
+  _dark: {
+    color: 'orange.800',
+  }
+})
+
+export const linkTheme = defineStyleConfig({
+  variants: { brandPrimary },
+})
+
+// Now we can use the new `brandPrimary` variant
+<Link variant="brandPrimary">...</Link>
+```
+
+## Using a custom color scheme
+
+Let's assume we want to use our own custom color scale based on our brand. We'd
+need to define the color scale first in the main theme file:
+
+```jsx live=false
+import { extendTheme } from '@chakra-ui/react'
+
+export const theme = extendTheme({
+  colors: {
+    brand: {
+      50: '#f7fafc',
+      ...
+      500: '#718096',
+      ...
+      900: '#171923',
+    }
+  }
+})
+```
+
+Then, we can use the custom color scale as the color scheme for the Link
+component:
+
+```jsx live=false
+<Link colorScheme='brand'>...</Link>
+```
+
+## Setting default properties
+
+Let's assume that we want to set the default size, variant or color scheme of
+every link in our app. Here's how we can do that:
+
+```jsx live=false
+import { defineStyleConfig } from '@chakra-ui/react'
+
+export const linkTheme = defineStyleConfig({
+  defaultProps: {
+    size: 'xl',
+    variant: 'brandPrimary',
+    colorScheme: 'brand',
+  },
+})
+
+// This saves you time, instead of manually setting the size,
+// variant and color scheme every time you use a Link component:
+<Link size="xl" variant="brandPrimary" colorScheme="brand">...</Link>
+```
+
+## Showcase
+
+import {
+  App,
+  Index,
+  LinkTheme,
+} from 'configs/sandpack-contents/component-theming/link'
+
+<SandpackEmbed
+  files={{
+    '/theme/components/Link.ts': LinkTheme,
+    '/App.tsx': App,
+    '/index.tsx': {
+      code: Index,
+      hidden: true,
+    },
+  }}
+  dependencies={{
+    'react-icons': '^4.4.0',
+  }}
+/>


### PR DESCRIPTION
Closes #1076 

## 📝 Description

Adds theming documentation for the `Link` component.


## 💣 Is this a breaking change (Yes/No):

No

