### PR TITLE
docs(tooltip): remove "Tooltip around disabled Button" section

### DIFF
--- a/content/docs/components/tooltip/usage.mdx
+++ b/content/docs/components/tooltip/usage.mdx
@@ -92,52 +92,6 @@ component.
 </Tooltip>
 ```
 
-### Tooltip around disabled Button
-
-By default the `Tooltip` is not shown when it is around a disabled `Button`.
-
-```jsx
-<Tooltip hasArrow label='You can not see me'>
-  <Button isDisabled>Button</Button>
-</Tooltip>
-```
-
-To show the `Tooltip` on a disabled `Button` you need to provide the
-`shouldWrapChildren` prop. This means that the `Button` is surrounded by a span
-on which the `Tooltip` is pinned. You could simply add a margin to the `Tooltip`
-to have it more or less 'pinned' on the `Button` again.
-
-```jsx
-<Tooltip hasArrow label='You can see me' shouldWrapChildren mt='3'>
-  <Button isDisabled>Button</Button>
-</Tooltip>
-```
-
-> There's a case where the `borderRadius` of a button breaks when the button is
-> in a `ButtonGroup` that has the `isAttached` prop set, and the tooltip has the
-> `shouldWrapChildren` prop set. A workaround could be to pass the specific
-> `borderRadius` depending on the `isDisabled` prop of the `Button`.
-
-```jsx
-<ButtonGroup colorScheme='teal' isAttached>
-  <Tooltip label='works'>
-    <Button>1</Button>
-  </Tooltip>
-
-  <Tooltip label='messes up border radius' shouldWrapChildren>
-    <Button isDisabled>2</Button>
-  </Tooltip>
-
-  <Tooltip label='this could be a workaround' shouldWrapChildren>
-    <Button isDisabled borderRadius='0'>
-      3
-    </Button>
-  </Tooltip>
-
-  <Button>4</Button>
-</ButtonGroup>
-```
-
 ## Placement
 
 Using the `placement` prop you can adjust where your tooltip will be displayed.


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #1023 

## 📝 Description

After chakra-ui/chakra-ui#6653, the workaround is no longer necessary.
It's basically just a revert of https://github.com/chakra-ui/chakra-ui-docs/commit/2551661a1c820fdd8c40bfb128834283bd151883

## ⛳️ Current behavior (updates)

This section is outdated.

## 🚀 New behavior

This section is removed.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
