### PR TITLE
chore: update deprecated api in framer-motion

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -12,7 +12,7 @@ import {
   useDisclosure,
   useUpdateEffect,
 } from '@chakra-ui/react'
-import { useViewportScroll } from 'framer-motion'
+import { useScroll } from 'framer-motion'
 import NextLink from 'next/link'
 import { useEffect, useRef, useState } from 'react'
 import { FaMoon, FaSun, FaYoutube } from 'react-icons/fa'
@@ -135,7 +135,7 @@ function Header(props: HTMLChakraProps<'header'>) {
   const [y, setY] = useState(0)
   const { height = 0 } = ref.current?.getBoundingClientRect() ?? {}
 
-  const { scrollY } = useViewportScroll()
+  const { scrollY } = useScroll()
   useEffect(() => {
     return scrollY.onChange(() => setY(scrollY.get()))
   }, [scrollY])


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->


## 📝 Description

> Add a brief description

use `useScroll` instead of `useViewportScroll`, because `useViewportScroll` have been deprecated 

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying
 There is an error in the devtools.
```js
react_devtools_backend.js:4026 useViewportScroll is deprecated. Convert to useScroll().
```

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

clearn warn in the devtools

## 💣 Is this a breaking change (Yes/No):

NO

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information
