### PR TITLE
docs(theming): added tag theming docs

### DIFF
--- a/configs/sandpack-contents/component-theming/tag.js
+++ b/configs/sandpack-contents/component-theming/tag.js
@@ -1,0 +1,76 @@
+module.exports = {
+    App: `import { Box, IconButton, Center, Tag, useColorMode } from "@chakra-ui/react";
+import { FaMoon, FaSun } from "react-icons/fa";
+
+export default function App() {
+    const { toggleColorMode, colorMode } = useColorMode();
+    return (
+    <Box position="relative">
+        <Center h="100vh">
+            <Tag>Default</Tag>
+            &nbsp;&nbsp;&nbsp;&nbsp;
+            <Tag variant="brand">Branded</Tag>
+            &nbsp;&nbsp;&nbsp;&nbsp;
+            <Tag variant="thick">Thick</Tag>
+            &nbsp;&nbsp;&nbsp;&nbsp;
+            <Tag size="ml">XL Tag</Tag>
+        </Center>
+        <IconButton
+        aria-label="toggle theme"
+        rounded="full"
+        size="xs"
+        position="absolute"
+        bottom={4}
+        left={4}
+        onClick={toggleColorMode}
+        icon={colorMode === "dark" ? <FaSun /> : <FaMoon />}
+        />
+    </Box>
+    );
+}`,
+    Index: `import * as React from "react";
+import { createRoot } from "react-dom/client";
+import { ChakraProvider, extendTheme } from "@chakra-ui/react";
+import App from "./App";
+import { tagTheme } from "./theme/components/Tag";
+const theme = extendTheme({
+    components: {
+        Tag: tagTheme,
+    }
+});
+const container = document.getElementById("root");
+const root = createRoot(container!);
+root.render(
+    <ChakraProvider theme={theme}>
+        <App />
+    </ChakraProvider>
+);`,
+    TagTheme: `import { defineStyle, defineStyleConfig } from "@chakra-ui/styled-system";
+
+const brandPrimary = defineStyle({
+    bg: "orange.400",
+    color: "blackAlpha.700"
+});
+
+const ml = defineStyle({
+    px: "3",
+    py: "2",
+    fontSize: "25"
+});
+
+const thick = defineStyle({
+    px: "4",
+    py: "2",
+    bg: "blue.400"
+});
+
+export const tagTheme = defineStyleConfig({
+    sizes: {
+        ml: ml
+    },
+    variants: {
+        brand: brandPrimary,
+        thick: thick
+    }
+});`,
+}

--- a/content/docs/components/tag/theming.mdx
+++ b/content/docs/components/tag/theming.mdx
@@ -3,4 +3,145 @@ id: tag
 scope: theming
 ---
 
-TODO
+## Overview
+
+The `Tag` component is a single part component. All of the styling is
+applied directly to the `button` element.
+
+> To learn more about styling single part components, visit the
+> [Component Style](/docs/styled-system/component-style#styling-single-part-components)
+> page
+
+## Theming properties
+
+The properties that affect the theming of the `Tag` component are:
+
+- `variant`: The visual variant of the tag. Defaults to `subtle`.
+- `colorScheme`: The color scheme of the tag. Defaults to `gray`.
+- `size`: The size of the tag. Defaults to `md`.
+
+## Theming utilities
+
+- `defineStyle`: a function used to create style objects.
+- `defineStyleConfig`: a function used to define the style configuration for a
+  single part component.
+
+```js
+import { defineStyle, defineStyleConfig } from '@chakra-ui/react'
+```
+
+## Customizing the default theme
+
+```js
+import { defineStyle, defineStyleConfig } from '@chakra-ui/react'
+
+const thick = defineStyle({
+    px: "4",
+    py: "2",
+    bg: "blue.400"
+});
+
+export const tagTheme = defineStyleConfig({
+    variants: { thick },
+})
+```
+
+After customizing the tag theme, we can import it in our theme file and add
+it in the components property:
+
+```js
+import { extendTheme } from '@chakra-ui/react'
+import { tagTheme } from './components/tag'
+
+export const theme = extendTheme({
+  components: { Tag: tagTheme },
+})
+```
+
+> This is a crucial step to make sure that any changes that we make to the
+> tag theme are applied.
+
+## Adding a custom size
+
+Let's assume we want to include an extra large tag size. Here's how we can
+do that:
+
+```js
+import { defineStyle, defineStyleConfig } from '@chakra-ui/react'
+
+const ml = defineStyle({
+    px: "3",
+    py: "2",
+    fontSize: "25"
+});
+
+export const tagTheme = defineStyleConfig({
+    sizes: { ml },
+})
+
+// Now we can use the new `xl` size
+<Tag size="ml" />
+```
+
+Every time you're adding anything new to the theme, you'd need to run the cli
+command to get proper autocomplete in your IDE. You can learn more about the CLI
+tool [here](/docs/styled-system/cli).
+
+## Adding a custom variant
+
+Let's assume we want to include a custom branded variant. Here's how we can do
+that:
+
+```js
+import { defineStyle, defineStyleConfig } from '@chakra-ui/react'
+
+const brandPrimary = defineStyle({
+    bg: "orange.400",
+    color: "blackAlpha.700"
+});
+
+export const tagTheme = defineStyleConfig({
+    variants: { brandPrimary },
+})
+
+// Now we can use the new `brandPrimary` variant
+<Tag variant="brandPrimary" />
+```
+
+## Changing the default properties
+
+```js
+import { defineStyleConfig } from '@chakra-ui/react'
+export const tagTheme = defineStyleConfig({
+    defaultProps: {
+        size: 'ml',
+        variant: 'thick',
+        colorScheme: 'brand',
+    },
+})
+// This saves you time, instead of manually setting the size,
+// variant and color scheme every time you use a tag:
+<Tag size="xl" variant="thick" colorScheme="brand" />
+```
+
+## Showcase
+
+import {
+  App,
+  Index,
+  TagTheme,
+} from 'configs/sandpack-contents/component-theming/tag'
+
+<SandpackEmbed
+  files={{
+    '/theme/components/Tag.ts': TagTheme,
+    '/App.tsx': App,
+    '/index.tsx': {
+      code: Index,
+      hidden: true,
+    },
+  }}
+  dependencies={{
+    'react-icons': '^4.4.0',
+  }}
+/>


### PR DESCRIPTION
Closes #1093 

## 📝 Description

> Added docs for theming tags with examples.

## ⛳️ Current behavior (updates)

> No docs present

## 🚀 New behavior

> Adds docs for theming tags

## 💣 Is this a breaking change (Yes/No): No 

## 📝 Additional Information
