### PR TITLE
feature: Adding theming documentation for Number Input

### DIFF
--- a/configs/sandpack-contents/component-theming/number-input.js
+++ b/configs/sandpack-contents/component-theming/number-input.js
@@ -1,0 +1,166 @@
+module.exports = {
+  App: `import {
+    Box,
+    IconButton,
+    NumberDecrementStepper,
+    NumberIncrementStepper,
+    NumberInput,
+    NumberInputField,
+    NumberInputStepper,
+    SimpleGrid,
+    useColorMode,
+    Text
+  } from "@chakra-ui/react";
+  import { FaMoon, FaSun } from "react-icons/fa";
+  
+  export default function App() {
+    const { toggleColorMode, colorMode } = useColorMode();
+    
+    return (
+      <Box position="relative" h="100vh">
+        <SimpleGrid gap={12} p={12} columns={2}>
+          <Box>
+            <Text fontSize="sm">Themed filled number input:</Text>
+            <NumberInput variant="filled">
+              <NumberInputField />
+              <NumberInputStepper>
+                <NumberIncrementStepper />
+                <NumberDecrementStepper />
+              </NumberInputStepper>
+            </NumberInput>
+          </Box>
+          <Box>
+            <Text fontSize="sm">Themed outline number input:</Text>
+            <NumberInput variant="outline">
+              <NumberInputField />
+              <NumberInputStepper>
+                <NumberIncrementStepper />
+                <NumberDecrementStepper />
+              </NumberInputStepper>
+            </NumberInput>
+          </Box>
+          <Box>
+            <Text fontSize="sm">Themed flushed number input:</Text>
+            <NumberInput variant="flushed">
+              <NumberInputField />
+              <NumberInputStepper>
+                <NumberIncrementStepper />
+                <NumberDecrementStepper />
+              </NumberInputStepper>
+            </NumberInput>
+          </Box>
+          <Box>
+            <Text fontSize="sm">Custom variant number input:</Text>
+            <NumberInput variant="primary">
+              <NumberInputField />
+              <NumberInputStepper>
+                <NumberIncrementStepper />
+                <NumberDecrementStepper />
+              </NumberInputStepper>
+            </NumberInput>
+          </Box>
+        </SimpleGrid>
+        <IconButton
+          aria-label="toggle theme"
+          rounded="full"
+          size="xs"
+          position="absolute"
+          bottom={4}
+          left={4}
+          onClick={toggleColorMode}
+          icon={colorMode === "dark" ? <FaSun /> : <FaMoon />}
+        />
+      </Box>
+    );
+  }`,
+  Index: `import * as React from "react";
+  import { createRoot } from "react-dom/client";
+  import { ChakraProvider, extendTheme } from "@chakra-ui/react";
+  import App from "./App";
+  import { numberInputTheme } from "./theme/components/NumberInput";
+  const theme = extendTheme({
+    components: {
+      NumberInput: numberInputTheme,
+    }
+  });
+  const container = document.getElementById("root");
+  const root = createRoot(container!);
+  root.render(
+    <ChakraProvider theme={theme}>
+      <App />
+    </ChakraProvider>
+  );`,
+  NumberInputTheme: `import { numberInputAnatomy } from "@chakra-ui/anatomy";
+  import { createMultiStyleConfigHelpers } from "@chakra-ui/react";
+
+  const {
+    definePartsStyle,
+    defineMultiStyleConfig
+  } = createMultiStyleConfigHelpers(numberInputAnatomy.keys);
+
+  const filled = definePartsStyle({
+    field: {
+      borderRadius: 0,
+      borderColor: "purple.200"
+    },
+    stepper: {
+      color: "purple.500",
+      borderColor: "purple.200",
+
+      // Let's also provide dark mode alternatives
+      _dark: {
+        color: "purple.400"
+      }
+    }
+  });
+
+  const outline = definePartsStyle({
+    field: {
+      border: 0,
+      _focus: {
+        ring: "1px",
+        ringColor: "purple.300",
+        ringOffset: "2px",
+        ringOffsetColor: "purple.200"
+      }
+    }
+  });
+
+  const flushed = definePartsStyle({
+    stepper: {
+      _active: {
+        color: "green.300"
+      },
+      _odd: {
+        background: "green.200"
+      },
+      _even: {
+        background: "red.200"
+      }
+    }
+  });
+
+  const primary = definePartsStyle({
+    field: {
+      border: "1px solid",
+      borderColor: "gray.200",
+      background: "gray.50",
+      fontWeight: "bold",
+
+      // Let's also provide dark mode alternatives
+      _dark: {
+        borderColor: "gray.600",
+        background: "gray.800"
+      }
+    },
+    stepper: {
+      color: "purple.500",
+      background: "gray.200"
+    }
+  });
+
+  export const numberInputTheme = defineMultiStyleConfig({
+    variants: { primary, filled, outline, flushed }
+  });
+  `,
+}

--- a/content/docs/components/number-input/theming.mdx
+++ b/content/docs/components/number-input/theming.mdx
@@ -2,3 +2,194 @@
 id: number-input
 scope: theming
 ---
+
+The `NumberInput` component is a multipart component. The styling needs to be applied
+to each part specifically.
+
+> To learn more about styling multipart components, visit the
+> [Component Style](/docs/styled-system/component-style#styling-multipart-components)
+> page.
+
+## Anatomy 
+
+## Theming properties
+
+The properties that affect the theming of the `Input` component are:
+
+- `variant`: The visual variant of the button. Defaults to `outline`.
+- `size`: The size of the button. Defaults to `md`.
+
+## Theming utilities
+
+## Theming utilities
+
+- `createMultiStyleConfigHelpers`: a function that returns a set of utilities
+  for creating style configs for a multipart component (`definePartsStyle` and
+  `defineMultiStyleConfig`).
+- `definePartsStyle`: a function used to create multipart style objects.
+- `defineMultiStyleConfig`: a function used to define the style configuration
+  for a multipart component.
+
+
+```jsx live=false
+import { inputAnatomy } from '@chakra-ui/anatomy'
+import { createMultiStyleConfigHelpers } from '@chakra-ui/react'
+
+const { definePartsStyle, defineMultiStyleConfig } =
+  createMultiStyleConfigHelpers(inputAnatomy.keys)
+```
+
+## Customizing the default theme
+
+```jsx live=false
+import { numberInputAnatomy } from '@chakra-ui/anatomy'
+import { createMultiStyleConfigHelpers } from '@chakra-ui/react'
+
+const { definePartsStyle, defineMultiStyleConfig } =
+  createMultiStyleConfigHelpers(inputAnatomy.keys)
+
+const baseStyle = definePartsStyle({
+  // define the part you're going to style
+  field: {
+    fontWeight: "semibold",
+    color: "red.500"
+  },
+})
+
+export const numberInputTheme = defineMultiStyleConfig({ baseStyle })
+```
+
+After customizing the number input theme, we can import it in our theme file and add it
+in the `components` property:
+
+```jsx live=false
+import { extendTheme } from '@chakra-ui/react'
+import { numberInputTheme } from './components/number-input'
+
+export const theme = extendTheme({
+  components: { NumberInput: numberInputTheme },
+})
+```
+
+> This is a crucial step to make sure that any changes that we make to the input
+> theme are applied.
+
+## Adding a custom size
+
+Let's assume we want to include an extra large input size. Here's how we can do
+that:
+
+```jsx live=false
+import { numberInputAnatomy } from "@chakra-ui/anatomy";
+import { createMultiStyleConfigHelpers, defineStyle } from "@chakra-ui/react";
+
+const {
+  definePartsStyle,
+  defineMultiStyleConfig
+} = createMultiStyleConfigHelpers(numberInputAnatomy.keys);
+
+const xl = defineStyle({
+  fontSize: "lg",
+  h: "20",
+  px: "2"
+});
+
+const sizes = {
+  xl: definePartsStyle({ field: xl, stepper: xl, addon: xl })
+};
+
+export const numberInputTheme = defineMultiStyleConfig({ sizes });
+
+// Now we can use the new `xl` size
+<NumberInput size="xl" ... />
+```
+
+Every time you're adding anything new to the theme, you'd need to run the CLI
+command to get proper autocomplete in your IDE. You can learn more about the CLI
+tool [here](/docs/styled-system/cli).
+
+## Adding a custom variant
+
+Let's assume we want to include a custom primary variant. Here's how we can do that:
+
+```jsx live=false
+import { numberInputAnatomy } from "@chakra-ui/anatomy";
+import { createMultiStyleConfigHelpers } from "@chakra-ui/react";
+
+const {
+  definePartsStyle,
+  defineMultiStyleConfig
+} = createMultiStyleConfigHelpers(numberInputAnatomy.keys);
+
+const primary = definePartsStyle({
+  field: {
+    border: "1px solid",
+    borderColor: "gray.200",
+    background: "gray.50",
+    fontWeight: "bold",
+
+    // Let's also provide dark mode alternatives
+    _dark: {
+      borderColor: "gray.600",
+      background: "gray.800"
+    }
+  },
+  stepper: {
+    color: "purple.500",
+    background: "gray.200"
+  }
+});
+
+export const numberInputTheme = defineMultiStyleConfig({
+  variants: { primary }
+});
+
+// Now we can use the new `pill` variant
+<NumberInput variant="primary" ... />
+```
+
+## Changing the default properties
+
+Let's assume we want to change the default size and variant of every number input in
+our app. Here's how we can do that:
+
+```jsx live=false
+import { numberInputAnatomy } from '@chakra-ui/anatomy'
+import { createMultiStyleConfigHelpers, defineStyle } from '@chakra-ui/react'
+
+const { defineMultiStyleConfig } = createMultiStyleConfigHelpers(
+  numberInputAnatomy.keys,
+)
+
+export const numberInputTheme = defineMultiStyleConfig({
+  defaultProps: {
+    size: 'xl',
+    variant: 'primary',
+  },
+})
+
+// This saves you time, instead of manually setting the size and variant every time you use an input:
+<NumberInput size="xl" variant="primary" ... />
+```
+
+## Showcase
+
+import {
+  App,
+  Index,
+  NumberInputTheme,
+} from 'configs/sandpack-contents/component-theming/number-input'
+
+<SandpackEmbed
+  files={{
+    '/theme/components/NumberInput.ts': NumberInputTheme,
+    '/App.tsx': App,
+    '/index.tsx': {
+      code: Index,
+      hidden: true,
+    },
+  }}
+  dependencies={{
+    'react-icons': '^4.4.0',
+  }}
+/>


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #1078 

## 📝 Description

> The goal of this pull request is to add theming documentation for the Number Input component.

## ⛳️ Current behavior (updates)

> Currently, there is no documentation on how you can theme / customize the Number Input component.

## 🚀 New behavior

> Now, when the devs that use Chakra UI can find clear instructions on how to customize the Number Input.

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->
No.

## 📝 Additional Information
