### PR TITLE
Fix a small grammar mistake in the Tabs docs

### DIFF
--- a/content/docs/components/tabs/usage.mdx
+++ b/content/docs/components/tabs/usage.mdx
@@ -165,7 +165,7 @@ Stretch the tab list to fit the container by passing `isFitted` prop.
 
 ### Styling the tab states via props
 
-In the event that you need to create custom styles for the tabs. Simply set the variant
+In the event that you need to create custom styles for the tabs, simply set the variant
 to `unstyled`, and use the `_selected`, `_hover`, `_active` style props.
 
 ```jsx

--- a/content/docs/components/tabs/usage.mdx
+++ b/content/docs/components/tabs/usage.mdx
@@ -165,7 +165,7 @@ Stretch the tab list to fit the container by passing `isFitted` prop.
 
 ### Styling the tab states via props
 
-In event you need to create custom styles for the tabs. Simply set the variant
+In the event that you need to create custom styles for the tabs. Simply set the variant
 to `unstyled`, and use the `_selected`, `_hover`, `_active` style props.
 
 ```jsx


### PR DESCRIPTION
## 📝 Description

Fixes a small English mistake in the [`Tabs` docs](https://chakra-ui.com/docs/components/tabs)

## 💣 Is this a breaking change (Yes/No):
No
