### PR TITLE
feat: added `pnpm` installation

### DIFF
--- a/content/getting-started/index.mdx
+++ b/content/getting-started/index.mdx
@@ -18,6 +18,10 @@ npm i @chakra-ui/react @emotion/react @emotion/styled framer-motion
 yarn add @chakra-ui/react @emotion/react @emotion/styled framer-motion
 ```
 
+```bash
+pnpm add @chakra-ui/react @emotion/react @emotion/styled framer-motion
+```
+
 After installing Chakra UI, you need to set up the `ChakraProvider` at the root
 of your application. This can be either in your `index.jsx`, `index.tsx` or
 `App.jsx` depending on the framework you use.


### PR DESCRIPTION
## 📝 Description

> Add `pnpm` installation in Installation page

## 💣 Is this a breaking change (Yes/No):
No

## 📝 Additional Information
These days a lot people are using `pnpm` as their package manager instead of `npm` or `yarn`.  This PR adds an instruction in Installation page. Basically the `pnpm` command have same command with `yarn`, but it will helps people that never using `yarn` / `npm` or new `pnpm` user easier to find the instruction directly.
