### PR TITLE
docs(migration): update prop "wordBreak"

### DIFF
--- a/content/getting-started/migration.mdx
+++ b/content/getting-started/migration.mdx
@@ -196,7 +196,7 @@ We removed the `area` prop from the `Grid` component. You can pass it to the
 We removed the `d` style prop. Use written out `display` prop instead.
 
 We removed the `isTruncated` style prop. You can use `noOfLines={1}` instead and
-manually set the `wordWrap` to `break-all`.
+manually set the `wordBreak` to `break-all`.
 
 #### Theme
 


### PR DESCRIPTION
the correct standard prop should be "wordBreak" ("wordWrap" doesn't exist)

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description
when migrating chakra to v2, the "isTruncated" indicates to use "wordWrap" prop. 
This prop doesn't exist and leads to confusion.

> Add a brief description

## ⛳️ Current behavior (updates)
n/a
> Please describe the current behavior that you are modifying

## 🚀 New behavior
n/a
> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):
n/a
<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->
