### PR TITLE
fix version-switcher in dark mode

### DIFF
--- a/src/components/version-switcher.tsx
+++ b/src/components/version-switcher.tsx
@@ -25,6 +25,8 @@ function VersionSwitcher(props: SelectProps) {
       fontWeight='semibold'
       color='gray.600'
       _dark={{ color: 'whiteAlpha.600' }}
+      background="chakra-body-bg"
+      sx={{ "--select-bg": "colors.chakra-body-bg" }}
       value={currentVersionUrl}
       aria-label={`Select the Chakra UI Docs version. You're currently viewing the version ${currentVerion} docs`}
       onChange={(e) => {


### PR DESCRIPTION
Workaround for white version switcher. We should probably make a proper fix for Select's unstyled-variant overriding [`Select.baseStyle.field._dark`](https://github.com/chakra-ui/chakra-ui/blob/cbd09c3/packages/components/theme/src/components/select.ts#L22)

Closes https://discord.com/channels/660863154703695893/660863154703695896/1045820502586962030

## 📝 Description

> make version switcher apply the page background color to it's menu.

## ⛳️ Current behavior (updates)

> In darkmode, the select menu and it's `<option>` items use white text on white background (in both Firefox and Chrome)

## 🚀 New behavior

> In darkmode, it now shows white text on **dark background**

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Screenshot of the old behavior (from the original bug report on Discord)
![grafik](https://user-images.githubusercontent.com/1379744/204093051-4eaabc35-aa00-4be8-b1a3-f75de6ff8965.png)

