### PR TITLE
docs(icons): Update examples to use the suggested prop (boxSize)

### DIFF
--- a/content/docs/components/icon/usage.mdx
+++ b/content/docs/components/icon/usage.mdx
@@ -40,7 +40,7 @@ import { PhoneIcon, AddIcon, WarningIcon } from '@chakra-ui/icons'
 <PhoneIcon />
 
 // Use the `boxSize` prop to change the icon size
-<AddIcon w={6} h={6} />
+<AddIcon boxSize={6} />
 
 // Use the `color` prop to change the icon color
 <WarningIcon w={8} h={8} color="red.500" />
@@ -82,7 +82,7 @@ function Example() {
   <Icon as={MdSettings} />
 
   {/* Use the `boxSize` prop to change the icon size */}
-  <Icon as={MdReceipt} w={6} h={6} />
+  <Icon as={MdReceipt} boxSize={6} />
 
   {/* Use the `color` prop to change the icon color */}
   <Icon as={MdGroupWork} w={8} h={8} color='red.500' />


### PR DESCRIPTION
The examples for the icon component in 2 places said `use the 'boxSize' prop to change the icon size` but the example given had `w` & `h` passed instead.

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

> Add a brief description

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information
