### PR TITLE
import Card from @chakra-ui/card instead of /react

### DIFF
--- a/content/docs/components/card/usage.mdx
+++ b/content/docs/components/card/usage.mdx
@@ -13,7 +13,7 @@ description:
 Chakra UI exports 4 components to help you create a Card.
 
 ```js
-import { Card, CardHeader, CardBody, CardFooter } from '@chakra-ui/react'
+import { Card, CardHeader, CardBody, CardFooter } from '@chakra-ui/card'
 ```
 
 - **Card:** The parent wrapper that provides context for its children.


### PR DESCRIPTION
Closes https://discord.com/channels/660863154703695893/1044908921560776744/1044908921560776744

## 📝 Description

The docs page says to import the Card components from `@chakra-ui/react`, however that doesn't seem to currently work, which causes confusion. This PR fixes the import.



## 💣 Is this a breaking change (Yes/No):

No