### PR TITLE
docs: fix refs type error in Basic Drawer component usage

### DIFF
--- a/content/docs/components/drawer/usage.mdx
+++ b/content/docs/components/drawer/usage.mdx
@@ -34,14 +34,14 @@ function DrawerExample() {
 
   return (
     <>
-      <Button ref={btnRef} colorScheme='teal' onClick={onOpen}>
+      <Button ref={btnRef.current} colorScheme='teal' onClick={onOpen}>
         Open
       </Button>
       <Drawer
         isOpen={isOpen}
         placement='right'
         onClose={onClose}
-        finalFocusRef={btnRef}
+        finalFocusRef={btnRef.current}
       >
         <DrawerOverlay />
         <DrawerContent>


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

This PR prevents type definition errors when using the Basic Drawer Example.

## ⛳️ Current behavior (updates)

A TypeScript type definition error is detected when using the existing Basic Drawer Example Code.
This is not a problem in working, but if you have set restrictions at build time, such as with ESLint, you will need to use `@ts-ignore` or other means to deal with the problem.

Here is the error when opened in VSCode.

<img width="1004" alt="スクリーンショット 2022-12-07 22 32 48" src="https://user-images.githubusercontent.com/39184410/206192694-5920ae4b-a904-4ac1-9972-ccc0a04697ba.png">

```
(property) ref?: React.LegacyRef<HTMLButtonElement> | undefined
Type 'MutableRefObject<undefined>' is not assignable to type 'LegacyRef<HTMLButtonElement> | undefined'.
  Type 'MutableRefObject<undefined>' is not assignable to type 'RefObject<HTMLButtonElement>'.
    Types of property 'current' are incompatible.
      Type 'undefined' is not assignable to type 'HTMLButtonElement | null'.ts(2322)
index.d.ts(138, 9): The expected type comes from property 'ref' which is declared here on type 'IntrinsicAttributes & OmitCommonProps<DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement>, keyof ButtonProps> & ButtonProps & { ...; }'
```
<img width="960" alt="スクリーンショット 2022-12-07 22 33 03" src="https://user-images.githubusercontent.com/39184410/206192702-dda36cc6-8483-4fd1-af49-21d17e98e457.png">

```
(property) finalFocusRef?: React.RefObject<FocusableElement> | undefined
The ref of element to receive focus when the modal closes.

Type 'MutableRefObject<undefined>' is not assignable to type 'RefObject<FocusableElement>'.
  Types of property 'current' are incompatible.
    Type 'undefined' is not assignable to type 'FocusableElement | null'.ts(2322)
index.d.ts(115, 5): The expected type comes from property 'finalFocusRef' which is declared here on type 'IntrinsicAttributes & DrawerProps'
```


## 🚀 New behavior

By specifying  `current`, the corresponding type definition error was suppressed.

## 💣 Is this a breaking change (Yes/No):

No

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information
This may be a temporary fix, but we would like to modify it so that it is not boring for beginning students who use Example.

Best regards,