### PR TITLE
chore: aligning variable names for consistency

### DIFF
--- a/content/docs/components/badge/theming.mdx
+++ b/content/docs/components/badge/theming.mdx
@@ -33,13 +33,13 @@ import { defineStyle, defineStyleConfig } from '@chakra-ui/react'
 ```jsx live=false
 import { defineStyle, defineStyleConfig } from '@chakra-ui/react'
 
-const outline = defineStyle({
+const boxy = defineStyle({
   border: '1px solid', // change the appearance of the border
   borderRadius: 0, // remove the border radius
 })
 
 export const badgeTheme = defineStyleConfig({
-  variants: { outline },
+  variants: { boxy },
 })
 ```
 

--- a/content/docs/components/badge/theming.mdx
+++ b/content/docs/components/badge/theming.mdx
@@ -33,7 +33,7 @@ import { defineStyle, defineStyleConfig } from '@chakra-ui/react'
 ```jsx live=false
 import { defineStyle, defineStyleConfig } from '@chakra-ui/react'
 
-const boxy = defineStyle({
+const outline = defineStyle({
   border: '1px solid', // change the appearance of the border
   borderRadius: 0, // remove the border radius
 })


### PR DESCRIPTION
Active implementation defines style as "boxy" but references "outline" variable in a code block. This PR aligns the variable names within that code block.

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

> Add a brief description

Active implementation defines style as "boxy" but references "outline" variable in a code block. This PR aligns the variable names within that code block.

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

Variable "boxy" is defined as a style, but variable "outline" is referenced within styleConfig.

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

Variable "outline" is changed to "boxy."

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

No.

## 📝 Additional Information
