### PR TITLE
docs(card): add missing double quote and fix styling for prop name

### DIFF
--- a/content/docs/components/card/usage.mdx
+++ b/content/docs/components/card/usage.mdx
@@ -119,7 +119,7 @@ Place the content within the `CardBody` to get a nice padding around.
 ### Horizontal Card
 
 The card component has `display: flex` by default. This means you make the
-content in a horizontal direction by passing `direction="row`.
+content in a horizontal direction by passing `direction="row"`.
 
 ```jsx
 <Card
@@ -280,7 +280,7 @@ the Card.
 
 Chakra UI provides 4 card variants - `elevated`, `outline`, `filled`, and
 `unstyled`. Use the `variant` prop to change the style of your card. If the
-variant prop is not passed, the default variant, `elevated` is used.
+`variant` prop is not passed, the default variant, `elevated` is used.
 
 ```jsx
 <Stack spacing='4'>


### PR DESCRIPTION
## 📝 Description

Fix minor typo in the documentation of the card component

## ⛳️ Current behavior (updates)

n/a

## 🚀 New behavior

no new behavior

## 💣 Is this a breaking change (Yes/No): No