### PR TITLE
Adding isExternal on discord server link to better user experience

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -79,7 +79,11 @@ function HeaderContent() {
                 _hover={{ color: 'gray.600' }}
               />
             </Link>
-            <Link aria-label='Go to Chakra UI Discord page' href='/discord'>
+            <Link
+              isExternal
+              aria-label='Go to Chakra UI Discord page'
+              href='/discord'
+            >
               <Icon
                 as={DiscordIcon}
                 display='block'


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

> The implementation is super simple, I just added the `isExternal` property to the Link component, which is the link wrapper for the discord server. This keeps the default of having external links open in a new tab.

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Chakra users. --> No breaking changes.
