### PR TITLE
bugfix: Preview going over header 

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -320,6 +320,9 @@ const HomePage = ({
                   '/App.tsx': App,
                   '/index.tsx': Index,
                 }}
+                previewOptions={{
+                  zIndex: 0,
+                }}
                 isHorizontal
               />
             </Box>

--- a/src/components/sandpack-embed/index.tsx
+++ b/src/components/sandpack-embed/index.tsx
@@ -15,7 +15,7 @@ type Props = BoxProps & {
   devDependencies?: Record<string, string>
   layoutOptions?: SandpackLayoutProps
   editorOptions?: CodeEditorProps
-  previewOptions?: PreviewProps
+  previewOptions?: PreviewProps & BoxProps
   files: {
     [x: string]: string
   }


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #1210 

## 📝 Description

The preview of the CodeSandbox on the landing page went over the header.

## ⛳️ Current behavior (updates)

As mentioned above, the preview went over the header, causing the header to look behind the preview.

## 🚀 New behavior

I've added a zIndex of 0 to the preview on the landing page and extended the previewOptions to accept `BoxProps`.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information
