### PR TITLE
fix: Adjust length of password input validation

### DIFF
--- a/configs/sandpack-contents/formik-examples/validation.js
+++ b/configs/sandpack-contents/formik-examples/validation.js
@@ -50,7 +50,7 @@ export default function App() {
                     validate={(value) => {
                       let error;
 
-                      if (value.length < 5) {
+                      if (value.length < 6) {
                         error = "Password must contain at least 6 characters";
                       }
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

> Length adjusted from password input validation

## ⛳️ Current behavior (updates)

> The validation checks if password is less than five 

## 🚀 New behavior

> The validation checks if password is less than six

## 💣 Is this a breaking change (Yes/No):

> No

## 📝 Additional Information

### Current behavior 
![current-behavior-01](https://user-images.githubusercontent.com/72468926/213298105-70044c77-3858-4c95-9d6a-bfd514aaca64.png)
![current-behavior-02](https://user-images.githubusercontent.com/72468926/213298117-d6f85c4c-9fbd-43ef-a34d-123408601b02.png)

### New behavior
![new-behavior](https://user-images.githubusercontent.com/72468926/213298164-a97cbd3e-ada4-4ad6-8e5b-8e93b0720d21.png)
