### PR TITLE
bugfix: Table of Contents didn't update when you switched tabs

### DIFF
--- a/src/components/page-container.tsx
+++ b/src/components/page-container.tsx
@@ -59,17 +59,7 @@ function PageContainer(props: PageContainerProps) {
 
   if (!frontmatter) return <></>
 
-   const {
-    slug,
-    title,
-    description,
-    editUrl,
-    version,
-    headings = [],
-  } = frontmatter
-  const isNotUsageTab = /(props|theming)$/.test(slug)
-
-  console.log(headings)
+  const { title, description, editUrl, version, headings = [] } = frontmatter
 
   return (
     <>

--- a/src/components/page-container.tsx
+++ b/src/components/page-container.tsx
@@ -59,7 +59,17 @@ function PageContainer(props: PageContainerProps) {
 
   if (!frontmatter) return <></>
 
-  const { title, description, editUrl, version, headings = [] } = frontmatter
+   const {
+    slug,
+    title,
+    description,
+    editUrl,
+    version,
+    headings = [],
+  } = frontmatter
+  const isNotUsageTab = /(props|theming)$/.test(slug)
+
+  console.log(headings)
 
   return (
     <>

--- a/src/utils/contentlayer-utils.ts
+++ b/src/utils/contentlayer-utils.ts
@@ -36,7 +36,7 @@ export const getDocDoc = (slug: MixedArray): Doc | undefined => {
   const params = toArray(slug)
   const _slug = params.join('/')
   const doc = allDocs.find(
-    (doc) => doc.slug.endsWith(_slug) || doc.slug.endsWith(`${_slug}/theming`),
+    (doc) => doc.slug.endsWith(_slug) || doc.slug.endsWith(`${_slug}/usage`),
   ) as Doc | undefined
 
   if (!doc) return
@@ -49,7 +49,6 @@ export const getDocDoc = (slug: MixedArray): Doc | undefined => {
       ...doc.frontMatter,
       ...(getUsageDoc(doc.id)?.frontMatter ?? {}),
       ...(getThemingDoc(doc.id)?.frontMatter ?? {}),
-      slug: doc.frontMatter.slug.replace('/theming', ''),
     }
   }
 
@@ -58,7 +57,6 @@ export const getDocDoc = (slug: MixedArray): Doc | undefined => {
       ...doc.frontMatter,
       ...(getUsageDoc(doc.id)?.frontMatter ?? {}),
       ...(getPropsDoc(doc.id)?.frontMatter ?? {}),
-      slug: doc.frontMatter.slug.replace('/theming', ''),
     }
   }
 

--- a/src/utils/contentlayer-utils.ts
+++ b/src/utils/contentlayer-utils.ts
@@ -24,20 +24,41 @@ const getUsageDoc = (id: string) => {
   return allDocs.find((_doc) => _doc.id === id && _doc.scope === 'usage')
 }
 
+const getThemingDoc = (id: string) => {
+  return allDocs.find((_doc) => _doc.id === id && _doc.scope === 'theming')
+}
+
+const getPropsDoc = (id: string) => {
+  return allDocs.find((_doc) => _doc.id === id && _doc.scope === 'props')
+}
+
 export const getDocDoc = (slug: MixedArray): Doc | undefined => {
   const params = toArray(slug)
   const _slug = params.join('/')
   const doc = allDocs.find(
-    (doc) => doc.slug.endsWith(_slug) || doc.slug.endsWith(`${_slug}/usage`),
+    (doc) => doc.slug.endsWith(_slug) || doc.slug.endsWith(`${_slug}/theming`),
   ) as Doc | undefined
 
   if (!doc) return
 
-  // the presence of scope, means its a component documentation
-  if (doc.scope && doc.scope !== 'usage') {
+  const isThemingTab = doc.scope === 'theming'
+  const isPropsTab = doc.scope === 'props'
+
+  if (isThemingTab) {
     doc.frontMatter = {
       ...doc.frontMatter,
       ...(getUsageDoc(doc.id)?.frontMatter ?? {}),
+      ...(getThemingDoc(doc.id)?.frontMatter ?? {}),
+      slug: doc.frontMatter.slug.replace('/theming', ''),
+    }
+  }
+
+  if(isPropsTab) {
+    doc.frontMatter = {
+      ...doc.frontMatter,
+      ...(getUsageDoc(doc.id)?.frontMatter ?? {}),
+      ...(getPropsDoc(doc.id)?.frontMatter ?? {}),
+      slug: doc.frontMatter.slug.replace('/theming', ''),
     }
   }
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #817

## 📝 Description

> Add a brief description

The table of contents didn't update when we switched tabs, I have updated the `contentlayer-utils` to make that possible.

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying
Currently, when switching from the `Usage` to the `Theming` tab, the table of contents doesn't update.

## 🚀 New behavior

> Please describe the behavior or changes this PR adds
Now it will update as it gets the proper headings on the site.

## 💣 Is this a breaking change (Yes/No):
No.

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information
