### PR TITLE
Small typescript error in card theming docs

### DIFF
--- a/content/docs/components/card/theming.mdx
+++ b/content/docs/components/card/theming.mdx
@@ -162,13 +162,13 @@ const baseStyle = definePartsStyle({
   },
 })
 
-const sizes = definePartsStyle({
-  md: {
+const sizes = {
+  md: definePartsStyle({
     container: {
       borderRadius: '0px',
     },
-  },
-})
+  }),
+}
 
 export const cardTheme = defineMultiStyleConfig({ baseStyle, sizes })
 ```


### PR DESCRIPTION
## 📝 Description

Just a little error in the card theming doc page. It actually worked, but typescript complained a lot. `definePartsStyle()` was just in the wrong place in the object. The "custom size" section below it has the correct setup.
