### PR TITLE
docs(props-table): fix boolean default value display in props table

### DIFF
--- a/src/components/props-table.tsx
+++ b/src/components/props-table.tsx
@@ -138,9 +138,14 @@ function makePropsTable({ of, omit, only }: MakePropsTableOptions) {
       name,
       ...value,
       type: cleanType(value.type),
+      defaultValue: cleanDefaultValue(value.defaultValue),
     }))
 }
 
 function cleanType(value: any) {
   return typeof value === 'string' ? value.replace(';', '') : value
+}
+
+function cleanDefaultValue(value: any) {
+  return typeof value === 'boolean' ? value.toString() : value;
 }


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Hello, first time contributor here 😄

## 📝 Description

Fixes boolean default value display in props table.

## ⛳️ Current behavior (updates)

`true` default value in props table show an empty string, `false` as a default value hide whole default value line, because of a falsy condition in `src/components/props-table.tsx` :
```typescript
{prop.defaultValue && (
  <Flex>
    <div className='row'>{t('component.props-table.default')}</div>
    <div className='cell'>
      <InlineCode whiteSpace='normal' fontSize='0.8em'>
        {prop.defaultValue}
      </InlineCode>
    </div>
  </Flex>
)}
```

Sometimes `false` is already in string in json docs files, in this case nothing changes because the type is a string not a boolean, for example :

```json
"allowPinchZoom": {
  "type": "boolean;",
  "defaultValue": "false.", // instead of literal value `false`
  "required": false,
  "description": "Handle zoom/pinch gestures on iOS devices when scroll locking is enabled."
},
```

## 🚀 New behavior

Boolean values are converted to a string, using `.toString()` to show a nice `true` (and `false`) string.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

It's not a big thing, but it was misleading when default value was blank instead of showing `true`, or not present at all when default value was `false`.