### PR TITLE
docs(omni-search): fix non-unique key in omni search results

### DIFF
--- a/src/components/omni-search.tsx
+++ b/src/components/omni-search.tsx
@@ -293,7 +293,7 @@ function OmniSearch() {
                     const isLvl1 = item.type === 'lvl1'
 
                     return (
-                      <Link key={item.id} href={item.url} passHref>
+                      <Link key={item.url} href={item.url} passHref>
                         <a>
                           <Box
                             id={`search-item-${index}`}
@@ -310,7 +310,7 @@ function OmniSearch() {
                             }}
                             ref={menuNodes.ref(index)}
                             role='option'
-                            key={item.id}
+                            key={item.url}
                             sx={{
                               display: 'flex',
                               alignItems: 'center',


### PR DESCRIPTION
## 📝 Description

Small fix to use a unique key in Omni Search results.

## ⛳️ Current behavior (updates)

Omni Search use `item.id` from `configs/search-meta.json` as a key for search results which is not unique. It results in outdated data (unordered search results, unhoverable... check video as an example) and poor performance because React can't optimize rendering correctly.

Example of non-unique id :
![CleanShot 2023-02-05 at 23 24 40](https://user-images.githubusercontent.com/56580353/216851731-c2de4a17-030b-435a-8200-bd917a331be2.png)

Video of outdated data :
https://user-images.githubusercontent.com/56580353/216851993-58a7fccb-c839-42bf-9551-67643757bc45.mp4

## 🚀 New behavior

Use `item.url` which is unique across all search data entries which results in correct search results 😄

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

Not needed.