### PR TITLE
Updated package version to v1 in NextJS getting started docs

### DIFF
--- a/pages/guides/getting-started/nextjs-guide.mdx
+++ b/pages/guides/getting-started/nextjs-guide.mdx
@@ -27,11 +27,11 @@ author: estheragbaje
 In your Next.js project, install Chakra UI by running either of the following:
 
 ```bash
-npm i @chakra-ui/react @emotion/react@^11 @emotion/styled@^11 framer-motion@^6
+npm i @chakra-ui/react@^1 @emotion/react@^11 @emotion/styled@^11 framer-motion@^6
 ```
 
 ```bash
-yarn add @chakra-ui/react @emotion/react@^11 @emotion/styled@^11 framer-motion@^6
+yarn add @chakra-ui/react@^1 @emotion/react@^11 @emotion/styled@^11 framer-motion@^6
 ```
 
 ### Provider Setup


### PR DESCRIPTION
Closes #1402

## 📝 Description

Both npm and yarn commands install the v1 version of chakra-ui in the NextJS docs

## ⛳️ Current behavior (updates)

Only changes to v1 docs

## 🚀 New behavior

Now the package installed for ```@chakra-ui/react``` is up to the version the docs are written for (v1) for users that are getting started with the v1 version

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
