### PR TITLE
Added Em to Px conversion comments, for better understanding.

### DIFF
--- a/content/docs/styled-system/responsive-styles.mdx
+++ b/content/docs/styled-system/responsive-styles.mdx
@@ -16,11 +16,11 @@ UI provides default breakpoints, here's what it looks like:
 
 ```js
 const breakpoints = {
-  sm: '30em',
-  md: '48em',
-  lg: '62em',
-  xl: '80em',
-  '2xl': '96em',
+  sm: '30em', // 480px
+  md: '48em', // 768px
+  lg: '62em', // 992px
+  xl: '80em', // 1280px
+  '2xl': '96em', // 1536px
 }
 ```
 
@@ -55,11 +55,11 @@ values defined in the array to the breakpoints
 ```js
 // These are the default breakpoints
 const breakpoints = {
-  sm: '30em',
-  md: '48em',
-  lg: '62em',
-  xl: '80em',
-  '2xl': '96em',
+  sm: '30em', // 480px
+  md: '48em', // 768px
+  lg: '62em', // 992px
+  xl: '80em', // 1280px
+  '2xl': '96em', // 1536px
 }
 
 // Internally, we transform to this


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

> Added Em to PX conversion comments, so that it will be easier to understand in pixels

## ⛳️ Current behavior (updates)

> Current presentation has no em to px conversion comments. So I added it
 ```js

const breakpoints = {
  sm: '30em',
  md: '48em',
  lg: '62em',
  xl: '80em',
  '2xl': '96em',
}
 ```

## 🚀 New behavior

 ```js

const breakpoints = {
  sm: '30em', // 480px
  md: '48em', // 768px
  lg: '62em', // 992px
  xl: '80em', // 1280px
  '2xl': '96em', // 1536px
}
 ```

## 💣 Is this a breaking change (Yes/No):

NO

