### PR TITLE
docs: Include shouldWrapChildren in Atlaskit editable example

### DIFF
--- a/content/community/recipes/atlaskit-editable.mdx
+++ b/content/community/recipes/atlaskit-editable.mdx
@@ -43,7 +43,7 @@ function App() {
         isPreviewFocusable={true}
         selectAllOnFocus={false}
       >
-        <Tooltip label="Click to edit">
+        <Tooltip label="Click to edit" shouldWrapChildren={true}>
           <EditablePreview
             py={2}
             px={4}


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #NO-ISSUE <!-- Github issue # here -->

## 📝 Description

In the example, the edit tooltip jumps to the top left of the screen when you click the editable input. This prop ensures this doesn't happen, and is useful for readers to see used here.

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

The tooltip jumps to the top left of the screen in the example

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

The tooltip no longer jumps

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information
