### PR TITLE
Update vite-guide.mdx

### DIFF
--- a/content/getting-started/vite-guide.mdx
+++ b/content/getting-started/vite-guide.mdx
@@ -28,6 +28,7 @@ Go to the `src` directory and inside `main.jsx` or `main.tsx`, wrap
 `ChakraProvider` around `App`:
 
 ```jsx live=false
+import React from 'react'
 import { ChakraProvider } from '@chakra-ui/react'
 import * as ReactDOM from 'react-dom/client'
 


### PR DESCRIPTION
`import React from 'react'` is necessary for `<React.StrictMode>`

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

> `import React from 'react'` is necessary for: `<React.StrictMode>`

## ⛳️ Current behavior (updates)

> The absence of this line creates a ReferenceError, as well as IDE errors 

## 🚀 New behavior

> Fix ReferenceError

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
