### PR TITLE
Add space between pin inputs OTP example

### DIFF
--- a/content/docs/components/pin-input/usage.mdx
+++ b/content/docs/components/pin-input/usage.mdx
@@ -59,12 +59,14 @@ Use the `otp` prop on `PinInput` to set `autocomplete="one-time-code"` for all
 children `PinInputField` components.
 
 ```jsx
-<PinInput otp>
-  <PinInputField />
-  <PinInputField />
-  <PinInputField />
-  <PinInputField />
-</PinInput>
+<HStack>
+  <PinInput otp>
+    <PinInputField />
+    <PinInputField />
+    <PinInputField />
+    <PinInputField />
+  </PinInput>
+</HStack>
 ```
 
 ### Masking the pin input's value


### PR DESCRIPTION
## 📝 Description
Add space between pin inputs OTP example

## ⛳️ Current behavior (updates)

![Screenshot 2023-03-28 at 20 42 07](https://user-images.githubusercontent.com/38554977/228284205-d39bcb50-ef19-4b0b-826c-619a0e0008f2.jpg)


## 🚀 New behavior

![Screenshot 2023-03-28 at 20 42 52](https://user-images.githubusercontent.com/38554977/228284377-9e7192bb-9e16-4084-a4c7-4811757da5db.jpg)


## 💣 Is this a breaking change (Yes/No): No