### PR TITLE
docs: added collapse info in transitions page

### DIFF
--- a/content/docs/components/transitions/usage.mdx
+++ b/content/docs/components/transitions/usage.mdx
@@ -4,8 +4,8 @@ category: other
 title: Transitions
 package: '@chakra-ui/transition'
 description:
-  Chakra exports four components `Fade`, `ScaleFade`, `Slide`, and `SlideFade`
-  to provide simple transitions.
+  Chakra exports five components `Fade`, `ScaleFade`, `Slide`,
+  `SlideFade` and `Collapse` to provide simple transitions.
 ---
 
 ## Import
@@ -18,12 +18,12 @@ following props:
 - `unmountOnExit` prop used to unmount the component when it is not visible.
 
 ```js
-import { Fade, ScaleFade, Slide, SlideFade } from '@chakra-ui/react'
+import { Fade, ScaleFade, Slide, SlideFade, Collapse } from '@chakra-ui/react'
 ```
 
 ## Usage
 
-Chakra exports four components `Fade`, `ScaleFade`, `Slide`, and `SlideFade` to
+Chakra exports five components `Fade`, `ScaleFade`, `Slide`, `SlideFade` and `Collapse` to
 provide simple transitions.
 
 ### Fade transition
@@ -182,4 +182,3 @@ function Example() {
   )
 }
 ```
-


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #1307 <!-- Github issue # here -->

## 📝 Description

The **Collapse** component is missing some information on the **Transitions** page. It is not listed in the imports example and it is also not included in the description of Transitions.

## ⛳️ Current behavior (updates)

Missing **Collapse** information in **Transitions** page.

## 🚀 New behavior

List the **Collapse** component in imports example and in **Transitions** description.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information
### Old doc
![image](https://user-images.githubusercontent.com/53843982/229935382-3c986e67-d71c-4282-b671-70ac23ba475c.png)
![image](https://user-images.githubusercontent.com/53843982/229935546-7b83d29f-68ab-4e33-8233-0506853e1d54.png)
![image](https://user-images.githubusercontent.com/53843982/229935568-2d5446ba-7ae2-4fb2-b0ac-092cc41c511a.png)

### Modified doc
![image](https://user-images.githubusercontent.com/53843982/229935660-620b4b45-9a31-4965-a689-583f2fb1bdb3.png)
![image](https://user-images.githubusercontent.com/53843982/229935683-42b9283b-647f-442a-bf80-68edf5a2e8df.png)
![image](https://user-images.githubusercontent.com/53843982/229935713-72cc599c-7dc3-4f87-acae-4a28189e1fb7.png)

