### PR TITLE
docs:updated useRadio snippets

### DIFF
--- a/configs/sandpack-contents/advanced-formik-integration/image-radio-buttons.js
+++ b/configs/sandpack-contents/advanced-formik-integration/image-radio-buttons.js
@@ -29,7 +29,7 @@ const ImageRadio = React.forwardRef((props: Props, ref) => {
     checked: isChecked,
   });
 
-  const { state, getInputProps, getCheckboxProps, htmlProps, getLabelProps } =
+  const { state, getInputProps, getRadioProps, htmlProps, getLabelProps } =
     useRadio({
       isChecked: isChecked,
       ...field,
@@ -39,7 +39,7 @@ const ImageRadio = React.forwardRef((props: Props, ref) => {
     <chakra.label {...htmlProps} cursor="pointer">
       <input {...getInputProps({}, ref)} hidden />
       <Box
-        {...getCheckboxProps()}
+        {...getRadioProps()}
         bg={state.isChecked ? "green.200" : "transparent"}
         w={12}
         p={1}

--- a/content/docs/components/radio/usage.mdx
+++ b/content/docs/components/radio/usage.mdx
@@ -122,10 +122,10 @@ hooks to see more detail about their uses.
 ```jsx manual=true
 // 1. Create a component that consumes the `useRadio` hook
 function RadioCard(props) {
-  const { getInputProps, getCheckboxProps } = useRadio(props)
+  const { getInputProps, getRadioProps } = useRadio(props)
 
   const input = getInputProps()
-  const checkbox = getCheckboxProps()
+  const checkbox = getRadioProps()
 
   return (
     <Box as='label'>

--- a/content/docs/hooks/use-radio-group.mdx
+++ b/content/docs/hooks/use-radio-group.mdx
@@ -37,14 +37,14 @@ The `useRadioGroup` hook returns following props
 function Example() {
   function CustomRadio(props) {
     const { image, ...radioProps } = props
-    const { state, getInputProps, getCheckboxProps, htmlProps, getLabelProps } =
+    const { state, getInputProps, getRadioProps, htmlProps, getLabelProps } =
       useRadio(radioProps)
 
     return (
       <chakra.label {...htmlProps} cursor='pointer'>
         <input {...getInputProps({})} hidden />
         <Box
-          {...getCheckboxProps()}
+          {...getRadioProps()}
           bg={state.isChecked ? 'green.200' : 'transparent'}
           w={12}
           p={1}

--- a/content/docs/hooks/use-radio.mdx
+++ b/content/docs/hooks/use-radio.mdx
@@ -20,15 +20,11 @@ The `useRadio` hook returns following props
 | Name               | Type         | Description                                                              |
 | ------------------ | ------------ | ------------------------------------------------------------------------ |
 | `state`            | `RadioState` | An object that contains all props defining the current state of a radio. |
-| `getCheckboxProps` | `PropGetter` | A function to get the props of the radio.                                |
+| `getRadioProps`    | `PropGetter` | A function to get the props of the radio.                                |
 | `getInputProps`    | `PropGetter` | A function to get the props of the input field.                          |
 | `getLabelProps`    | `PropGetter` | A function to get the props of the radio label.                          |
 | `getRootProps`     | `PropGetter` | A function to get the props of the radio root.                           |
 | `htmlProps`        | `{}`         | An object with all htmlProps.                                            |
-
-> The `getCheckboxProps` function does return the props of the radio. The naming
-> error is known. Changing it would mean a breaking change to a lot of users,
-> which is why it will stay like this until the next major release.
 
 ## Usage
 
@@ -36,14 +32,14 @@ The `useRadio` hook returns following props
 function Example() {
   const CustomRadio = (props) => {
     const { image, ...radioProps } = props
-    const { state, getInputProps, getCheckboxProps, htmlProps, getLabelProps } =
+    const { state, getInputProps, getRadioProps, htmlProps, getLabelProps } =
       useRadio(radioProps)
 
     return (
       <chakra.label {...htmlProps} cursor='pointer'>
         <input {...getInputProps({})} hidden />
         <Box
-          {...getCheckboxProps()}
+          {...getRadioProps()}
           bg={state.isChecked ? 'green.200' : 'transparent'}
           w={12}
           p={1}


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #1515 

## 📝 Description

 Updated custom radio docs [#Custom-radio-buttons](https://chakra-ui.com/docs/components/radio/usage#custom-radio-buttons) from  #1515  

## ⛳️ Current behavior (updates)
The useRadio hook states that getCheckboxProps is deprecated.
In the [example](https://chakra-ui.com/docs/components/radio#custom-radio-buttons), the following code snippet:
```
function RadioCard(props) {
  const { getInputProps, getCheckboxProps } = useRadio(props)

  const input = getInputProps()
  const checkbox = getCheckboxProps()
```
should be 

```
function RadioCard(props) {
  const { getInputProps, getRadioProps } = useRadio(props)

  const input = getInputProps()
  const checkbox = getRadioProps()
```


## 🚀 New behavior

```
function RadioCard(props) {
  const { getInputProps, getRadioProps } = useRadio(props)

  const input = getInputProps()
  const checkbox = getRadioProps()
```

## 💣 Is this a breaking change (No):

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information
