### PR TITLE
fix :search  results for changelog pages are not working, 

### DIFF
--- a/layouts/changelog.tsx
+++ b/layouts/changelog.tsx
@@ -47,7 +47,7 @@ export function getVersions(): RouteItem[] {
       .map(({ version }) => version),
   ).map((version) => ({
     title: `v${version}`,
-    path: `/changelog/${version}`,
+    path: `/changelog/v${version}`,
   }))
 }
 
@@ -63,7 +63,6 @@ export default function MDXLayout(props: MDXLayoutProps) {
 
   const routes = getRoutes(frontmatter.slug)
   const versions = getVersions()
-
   return (
     <PageContainer
       hideToc={true}

--- a/pages/changelog/[version].tsx
+++ b/pages/changelog/[version].tsx
@@ -19,7 +19,7 @@ export default function Page({
 
   useEffect(() => {
     if (router.query.version === 'latest') {
-      router.replace(`/changelog/${doc.version}`)
+      router.replace(`/changelog/v${doc.version}`)
     }
   }, [router, doc])
 

--- a/pages/changelog/[version].tsx
+++ b/pages/changelog/[version].tsx
@@ -31,15 +31,16 @@ export default function Page({
 }
 
 export const getStaticPaths: GetStaticPaths = () => {
+  const paths = [
+    ...allChangelogs.map((doc) => ({
+      params: { version: `v${doc.version}` },
+    })),
+    {
+      params: { version: 'latest' },
+    },
+  ]
   return {
-    paths: [
-      ...allChangelogs.map((doc) => ({
-        params: { version: doc.version },
-      })),
-      {
-        params: { version: 'latest' },
-      },
-    ],
+    paths,
     fallback: false,
   }
 }
@@ -48,14 +49,14 @@ export const getStaticProps: GetStaticProps = async (ctx) => {
   let versionParam = ctx.params.version
 
   if (versionParam === 'latest') {
-    versionParam = semverMaxSatisfying(
+    versionParam = `v${semverMaxSatisfying(
       allChangelogs.map(({ version }) => version),
       '*',
-    )
+    )}`
   }
-
-  const doc = allChangelogs.find(({ version }) => version === versionParam)
-
+  const doc = allChangelogs.find(
+    ({ version }) => `v${version}` === versionParam,
+  )
   return {
     props: { doc },
   }


### PR DESCRIPTION


<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #1430  <!-- Github issue # here -->

## 📝 Description

>  Fix on changelog documentions not showing in algolia search

## ⛳️ Current behavior (updates)

Currently search: results for changelog pages are not working, due to  to the path of the page being `/changelog/2.0.1 ` but the link in the search result is sending me to `/changelog/v2.0.1`. 

## 🚀 New behavior
What I did is by prefixing the content path generated from content layer in getStaticPaths and updating the related anchor tags with prefix `v`

## 💣 Is this a breaking change (Yes/No):

No


## 📝 Additional Information
I am not very sure about the approach but please let me know if there any better way  I can improve on this

