### PR TITLE
docs(RadioButton docs): fixes to custom Radio Button ReadMe example code

### DIFF
--- a/content/docs/components/radio/usage.mdx
+++ b/content/docs/components/radio/usage.mdx
@@ -122,10 +122,10 @@ hooks to see more detail about their uses.
 ```jsx manual=true
 // 1. Create a component that consumes the `useRadio` hook
 function RadioCard(props) {
-  const { getInputProps, getRadioProps } = useRadio(props)
+  const { getInputProps, getCheckboxProps } = useRadio(props)
 
   const input = getInputProps()
-  const checkbox = getRadioProps()
+  const checkbox = getCheckboxProps()
 
   return (
     <Box as='label'>
@@ -170,9 +170,7 @@ function Example() {
       {options.map((value) => {
         const radio = getRadioProps({ value })
         return (
-          <RadioCard key={value} {...radio}>
-            {value}
-          </RadioCard>
+          <RadioCard key={value} {...radio} />
         )
       })}
     </HStack>


### PR DESCRIPTION
## 📝 Description

Documentation for Radio Button had example code that was throwing error for wrong variables

Property `getRadioProps` does not exist in `UseRadioProps`, fixed with getCheckboxProps since variable being assigned is `const checkbox`

Likewise, property `children` does not exist in `UseRadioProps`, fixed with `value` to show the value of each option

Self-close RadioCard element since RadioCard doesn't have a children prop

## ⛳️ Current behavior (updates)

Documentation

## 🚀 New behavior

Nothing, just documentation fix (example code will now stop displaying error)

## 💣 Is this a breaking change (Yes/No): No

## 📝 Additional Information