### PR TITLE
docs(use-disclosure): add parameters table

### DIFF
--- a/content/docs/hooks/use-disclosure.mdx
+++ b/content/docs/hooks/use-disclosure.mdx
@@ -109,4 +109,10 @@ function Basic() {
 The `useDisclosure` hook accepts an optional object with the following
 properties:
 
-<PropsTable of='useDisclosure' />
+| Parameter                 | Type       | Description                                                                                                        |
+| ------------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------ |
+| `isOpen (Optional)`       | `boolean`  | If `true`, the controlled component is responsible for changing the visible state via `onClose` and `onOpen` props.|
+| `defaultIsOpen (Optional)`| `boolean`  | If `true`, it initially sets the controlled component to its visible state.                                        |
+| `onClose (Optional)`      | `function` | Function to set a falsy value for the `isOpen` parameter.                                                          |
+| `onOpen (Optional)`       | `function` | Function to set a truthy value for the `isOpen` parameter.                                                         |
+| `id (Optional)`           | `string`   | String that allows you to associate the disclosure state with a specific component or element on your page.        |


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #1540 

## 📝 Description

> When I am looking into the [parameter](https://chakra-ui.com/docs/hooks/use-disclosure#parameters) section of useDisclosure hook, I am not able to see any table for the parameters. This PR is about adding the parameters table.

## ⛳️ Current behavior (updates)

> When I am looking into the [parameter](https://chakra-ui.com/docs/hooks/use-disclosure#parameters) section of useDisclosure hook, I am not able to see any table for the parameters.

## 🚀 New behavior

>  The parameters table is added with `name`, `type` and their `description` 

## 💣 Is this a breaking change (Yes/No):

> No

## 📝 Additional Information
> N/A
