### PR TITLE
fix(form-control): remove the htmlFor attribute

### DIFF
--- a/content/docs/components/form-control/usage.mdx
+++ b/content/docs/components/form-control/usage.mdx
@@ -44,7 +44,7 @@ import {
 
 ```jsx
 <FormControl as='fieldset'>
-  <FormLabel as='legend' htmlFor={null}>
+  <FormLabel as='legend'>
     Favorite Naruto Character
   </FormLabel>
   <RadioGroup defaultValue='Itachi'>


### PR DESCRIPTION
## 📝 Description

I fixed the issue where a compile error was occurring because null was being specified for `htmlFor`.
The type of `htmlFor` is `﻿string | undefined`. Please refer to [@types/react](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L2317-L2320) for more information.

## ⛳️ Current behavior (updates)

<img width="742" alt="image" src="https://user-images.githubusercontent.com/20895397/236469225-c9f1e39f-f2bf-4e81-934b-bf01874e2126.png">

## 🚀 New behavior

I removed htmlFor to prevent the compile error from occurring.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

If it is preferred to explicitly specify `undefined`, please let me know.
