### PR TITLE
Update usage.mdx

### DIFF
--- a/content/docs/components/input/usage.mdx
+++ b/content/docs/components/input/usage.mdx
@@ -97,10 +97,9 @@ focused the input.
 ```jsx
 <Stack spacing={4}>
   <InputGroup>
-    <InputLeftElement
-      pointerEvents='none'
-      children={<PhoneIcon color='gray.300' />}
-    />
+    <InputLeftElement pointerEvents='none'>
+      <PhoneIcon color='gray.300' />
+    <InputLeftElement/>
     <Input type='tel' placeholder='Phone number' />
   </InputGroup>
 
@@ -112,7 +111,9 @@ focused the input.
       children='$'
     />
     <Input placeholder='Enter amount' />
-    <InputRightElement children={<CheckIcon color='green.500' />} />
+    <InputRightElement>
+      <CheckIcon color='green.500' />
+    </InputRightElement>
   </InputGroup>
 </Stack>
 ```


### PR DESCRIPTION
In react, you cannot pass a child as a prop, it needs to be contained within the element. This documentation is misleading and leads to errors, and thus should display code that is valid.

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

> In react, you cannot pass a child as a prop, it needs to be contained within the element. This documentation is misleading and leads to errors, and thus should display code that is valid.

## ⛳️ Current behavior (updates)

> Stop React from throwing an error when using code from documentation

## 🚀 New behavior

> Correct documentation with code that does not throw errors

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
