### PR TITLE
docs: Fixed error in Input-component

### DIFF
--- a/content/docs/components/input/usage.mdx
+++ b/content/docs/components/input/usage.mdx
@@ -99,7 +99,7 @@ focused the input.
   <InputGroup>
     <InputLeftElement pointerEvents='none'>
       <PhoneIcon color='gray.300' />
-    <InputLeftElement/>
+    </InputLeftElement>
     <Input type='tel' placeholder='Phone number' />
   </InputGroup>
 


### PR DESCRIPTION
## 📝 Description

Syntax error in the Input-component - section: [Add elements inside Input](https://chakra-ui.com/docs/components/input#add-elements-inside-input)

## ⛳️ Current behavior (updates)

Can't render the component due to self-closing tag.

## 🚀 New behavior

Renders the component correctly

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
