### PR TITLE
Update usage.mdx

### DIFF
--- a/content/docs/components/radio/usage.mdx
+++ b/content/docs/components/radio/usage.mdx
@@ -122,10 +122,10 @@ hooks to see more detail about their uses.
 ```jsx manual=true
 // 1. Create a component that consumes the `useRadio` hook
 function RadioCard(props) {
-  const { getInputProps, getRadioProps } = useRadio(props)
+  const { getInputProps, getCheckboxProps } = useRadio(props)
 
   const input = getInputProps()
-  const checkbox = getRadioProps()
+  const checkbox = getCheckboxProps()
 
   return (
     <Box as='label'>


### PR DESCRIPTION
getRadioProps is not exists, I think need to change to getCheckboxProps.

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

> Fix "caught TypeError: getRadioProps is not a function" error

## ⛳️ Current behavior (updates)

> Change getRadioProps to getCheckboxProps

## 🚀 New behavior

> Change getRadioProps to getCheckboxProps in Custom Radio Buttons Section

## 💣 Is this a breaking change (Yes/No):

No