### PR TITLE
Fix `<PopoverArrow/>` color on Popover example

### DIFF
--- a/content/docs/components/popover/usage.mdx
+++ b/content/docs/components/popover/usage.mdx
@@ -110,7 +110,7 @@ function WalkthroughPopover() {
         <PopoverHeader pt={4} fontWeight='bold' border='0'>
           Manage Your Channels
         </PopoverHeader>
-        <PopoverArrow />
+        <PopoverArrow bg='blue.800' />
         <PopoverCloseButton />
         <PopoverBody>
           Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

<!-- > Add a brief description -->

Color of the `<PopoverArrow/>` does not match the color of the `<PopoverContent/>`

<img width="703" alt="image" src="https://github.com/chakra-ui/chakra-ui-docs/assets/13529535/2be66f85-9b0f-4def-9289-851b1ac78c17">

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

Arrow color does not match the popover background color

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

Arrow color does match the popover background color

## 💣 Is this a breaking change (Yes/No):

No

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information
