### PR TITLE
docs: change "prebuild" to "prebuilt" for components page description

### DIFF
--- a/pages/docs/components/index.tsx
+++ b/pages/docs/components/index.tsx
@@ -46,7 +46,7 @@ export const ComponentsOverview = ({ categories, headings }: Props) => {
     >
       <VStack w='full' mt={5} alignItems='stretch' spacing={12}>
         <Text lineHeight='tall'>
-          Chakra UI provides prebuild components to help you build your projects
+          Chakra UI provides prebuilt components to help you build your projects
           faster. Here is an overview of the component categories:
         </Text>
         <Input


### PR DESCRIPTION
## 📝 Description

Changes the word `prebuild` to `prebuilt` on the [components page](https://chakra-ui.com/docs/components).

## 💣 Is this a breaking change (Yes/No): No

## 📝 Additional Information
I'm assuming this was a typo, but my apologies if I'm wrong 😄 
