### PR TITLE
Update redwoodjs-guide.mdx

### DIFF
--- a/content/getting-started/redwoodjs-guide.mdx
+++ b/content/getting-started/redwoodjs-guide.mdx
@@ -126,7 +126,7 @@ below.
 1. Install the official Storybook Addon for Chakra UI:
 
    ```bash
-   yarn add -D @chakra-ui/storybook-addon
+   yarn workspace web add -D @chakra-ui/storybook-addon
    ```
 
 2. Add the addon to your configuration in `web/config/storybook.config.js`:


### PR DESCRIPTION
## 📝 Description

> Install the storybook addon to web workspace instead of monorepo root

## ⛳️ Current behavior (updates)

> Redwood storybook integration provides command to install addon to the root of the project

## 🚀 New behavior

> Redwood storybook integration provides command to install addon to the web workspace of the project

## 💣 Is this a breaking change (Yes/No):

It is not a breaking change, it won't affect existing setups. 