### PR TITLE
docs(Card): Updated import path in docs.

### DIFF
--- a/content/docs/components/card/usage.mdx
+++ b/content/docs/components/card/usage.mdx
@@ -14,7 +14,7 @@ description:
 Chakra UI exports 4 components to help you create a Card.
 
 ```js
-import { Card, CardHeader, CardBody, CardFooter } from '@chakra-ui/react'
+import { Card, CardHeader, CardBody, CardFooter } from '@chakra-ui/card'
 ```
 
 - **Card:** The parent wrapper that provides context for its children.


### PR DESCRIPTION
**Updated import path.** 

Earlier import path wasn't working. Found this out when I tried to import using `'@chakra-ui/react'`and got: `Module '"@chakra-ui/react"' has no exported member 'Card'.`