### PR TITLE
docs/next13-app-directory

### DIFF
--- a/content/getting-started/nextjs-guide.mdx
+++ b/content/getting-started/nextjs-guide.mdx
@@ -40,7 +40,7 @@ function MyApp({ Component, pageProps }) {
   )
 }
 
-export default MyApp
+export default MyApp;
 ```
 
 ### App Directory Setup
@@ -60,8 +60,7 @@ provider with the `useServerInsertedHTML` hook from next/navigation. This is
 necessary to ensure that computed styles are included in the initial server
 payload (during streaming).
 
-To use Chakra UI in app directory, you can wrap `ChakraProvider` and
-`CacheProvider` in your own client Component.
+To use Chakra UI in app directory, you can wrap `ChakraProvider` and `CacheProvider` in your own client Component.
 
 ```jsx live=false
 // app/providers.tsx
@@ -70,33 +69,39 @@ To use Chakra UI in app directory, you can wrap `ChakraProvider` and
 import { CacheProvider } from '@chakra-ui/next-js'
 import { ChakraProvider } from '@chakra-ui/react'
 
-export function Providers({ children }: { children: React.ReactNode }) {
+export function Providers({ 
+    children 
+  }: { 
+  children: React.ReactNode 
+  }) {
   return (
     <CacheProvider>
-      <ChakraProvider>{children}</ChakraProvider>
+      <ChakraProvider>
+        {children}
+      </ChakraProvider>
     </CacheProvider>
   )
 }
 ```
 
-Now, you can import and render `<Providers />` directly within your root. With
-the providers rendered at the root, all the components and hooks from Chakra UI
-will work as expected within your own Client Components.
+Now, you can import and render `<Providers />` directly within your root. With the providers rendered at the root, all the components and hooks from Chakra UI will work as expected within your own Client Components.
 
 ```jsx live=false
 // app/layout.tsx
-import { Providers } from './providers'
+import { Providers } from "./providers";
 
 export default function RootLayout({
   children,
 }: {
-  children: React.ReactNode,
+  children: React.ReactNode;
 }) {
   return (
-    <html lang='en'>
-      <Providers>{children}</Providers>
+    <html lang="en">
+        <Providers>
+          {children}
+        </Providers>
     </html>
-  )
+  );
 }
 ```
 
@@ -217,21 +222,20 @@ export default function Page() {
 }
 ```
 
-### Chakra UI with next/font
+### Chakra UI with next/font 
 
-With Next.js 13, you can optimize your fonts (including custom fonts) and remove
-external network requests for improved privacy and performance.
+With Next.js 13, you can optimize your fonts (including custom fonts) and remove external network requests for improved privacy and performance.
 
 To use the new `next/font` with Chakra UI globally;
 
 ```jsx live=false
 /* pages/_app.tsx */
-import { Rubik } from 'next/font/google'
+import { Rubik } from 'next/font/google';
 
-const rubik = Rubik({ subsets: ['latin'] })
+const rubik = Rubik({ subsets: ['latin'] });
 
 const App = ({ Component, pageProps }: AppProps) => {
-  ;<>
+  <>
     <style jsx global>
       {`
         :root {
@@ -243,9 +247,8 @@ const App = ({ Component, pageProps }: AppProps) => {
       <Component {...pageProps} />
     </ChakraProvider>
   </>
-}
+};
 ```
-
 Now you can use the optimized font with your custom theme file across the app.
 
 ```jsx live=false

--- a/content/getting-started/nextjs-guide.mdx
+++ b/content/getting-started/nextjs-guide.mdx
@@ -40,7 +40,7 @@ function MyApp({ Component, pageProps }) {
   )
 }
 
-export default MyApp;
+export default MyApp
 ```
 
 ### App Directory Setup
@@ -60,7 +60,8 @@ provider with the `useServerInsertedHTML` hook from next/navigation. This is
 necessary to ensure that computed styles are included in the initial server
 payload (during streaming).
 
-To use Chakra UI in app directory, you can wrap `ChakraProvider` and `CacheProvider` in your own client Component.
+To use Chakra UI in app directory, you can wrap `ChakraProvider` and
+`CacheProvider` in your own client Component.
 
 ```jsx live=false
 // app/providers.tsx
@@ -69,41 +70,33 @@ To use Chakra UI in app directory, you can wrap `ChakraProvider` and `CacheProvi
 import { CacheProvider } from '@chakra-ui/next-js'
 import { ChakraProvider } from '@chakra-ui/react'
 
-export function Providers({ 
-    children 
-  }: { 
-  children: React.ReactNode 
-  }) {
+export function Providers({ children }: { children: React.ReactNode }) {
   return (
     <CacheProvider>
-      <ChakraProvider>
-        {children}
-      </ChakraProvider>
+      <ChakraProvider>{children}</ChakraProvider>
     </CacheProvider>
   )
 }
 ```
 
-Now, you can import and render `<Providers />` directly within your root. With the providers rendered at the root, all the components and hooks from Chakra UI will work as expected within your own Client Components.
+Now, you can import and render `<Providers />` directly within your root. With
+the providers rendered at the root, all the components and hooks from Chakra UI
+will work as expected within your own Client Components.
 
 ```jsx live=false
 // app/layout.tsx
-import { Providers } from "./providers";
+import { Providers } from './providers'
 
 export default function RootLayout({
   children,
 }: {
-  children: React.ReactNode;
+  children: React.ReactNode,
 }) {
   return (
-    <html lang="en">
-      <body>
-        <Providers>
-          {children}
-        </Providers>
-      </body>
+    <html lang='en'>
+      <Providers>{children}</Providers>
     </html>
-  );
+  )
 }
 ```
 
@@ -224,20 +217,21 @@ export default function Page() {
 }
 ```
 
-### Chakra UI with next/font 
+### Chakra UI with next/font
 
-With Next.js 13, you can optimize your fonts (including custom fonts) and remove external network requests for improved privacy and performance.
+With Next.js 13, you can optimize your fonts (including custom fonts) and remove
+external network requests for improved privacy and performance.
 
 To use the new `next/font` with Chakra UI globally;
 
 ```jsx live=false
 /* pages/_app.tsx */
-import { Rubik } from 'next/font/google';
+import { Rubik } from 'next/font/google'
 
-const rubik = Rubik({ subsets: ['latin'] });
+const rubik = Rubik({ subsets: ['latin'] })
 
 const App = ({ Component, pageProps }: AppProps) => {
-  <>
+  ;<>
     <style jsx global>
       {`
         :root {
@@ -249,8 +243,9 @@ const App = ({ Component, pageProps }: AppProps) => {
       <Component {...pageProps} />
     </ChakraProvider>
   </>
-};
+}
 ```
+
 Now you can use the optimized font with your custom theme file across the app.
 
 ```jsx live=false


### PR DESCRIPTION
## 📝 Description

When we use Providers in the `<body>` tag, many components experience errors and problems. Until this situation reaches a better solution, it makes the most sense to keep the `body` tag inside the `children` in the `provider`.

## ⛳️ Current behavior (updates)

> App directory content in Nextjs getting started page

## 🚀 New behavior

> Since I deleted the body tag that encapsulates the Provider, most of the problems with the components were solved for a while.

## 📝 Additional Information

Nextjs13 brought many innovations with it. This solution may not be very long term as it will take time to adapt to it. Nevertheless, we can prevent problems that may arise in the components of people who create a project from scratch (I encountered a few issues in the chakra-ui repository about this, 
an example: [#7817](https://github.com/chakra-ui/chakra-ui/issues/7817#issue-1782118623)) .
