### PR TITLE
Update vpn-apps link to correct page

### DIFF
--- a/.all-sponsorsrc
+++ b/.all-sponsorsrc
@@ -2771,7 +2771,7 @@
       "email": null,
       "twitter": null,
       "github": null,
-      "website": "https://veepn.com/"
+      "website": "https://veepn.com/vpn-apps/download-vpn-for-pc/"
     },
     {
       "MemberId": 435567,


### PR DESCRIPTION
Note that on the Open Collective side, https://opencollective.com/veepn-vpn the link to this app is https://veepn.com/vpn-apps/download-vpn-for-pc/ and the user requested us that this link be updated on the Chakra UI docs as well.