### PR TITLE
docs(Toast): Clarified when to use ToastContainer with createStandaloneToast

### DIFF
--- a/content/docs/components/toast/usage.mdx
+++ b/content/docs/components/toast/usage.mdx
@@ -341,7 +341,8 @@ Besides the `defaultOptions`, you can also pass the following options:
 ## Standalone Toasts
 
 Use `createStandaloneToast` to create toasts from outside of your React
-Components.
+Components. Both `ChakraProvider` and `ToastContainer` will render a `ToastProvider`,
+so only include `<ToastContainer />` to create toasts outside `ChakraProvider `.
 
 > 🚨 If you're using a custom theme, you **must** pass it in the arguments to
 > `createStandaloneToast`. If you don't, the default theme will be applied,

--- a/content/docs/components/toast/usage.mdx
+++ b/content/docs/components/toast/usage.mdx
@@ -342,7 +342,7 @@ Besides the `defaultOptions`, you can also pass the following options:
 
 Use `createStandaloneToast` to create toasts from outside of your React
 Components. Both `ChakraProvider` and `ToastContainer` will render a `ToastProvider`,
-so only include `<ToastContainer />` to create toasts outside `ChakraProvider `.
+so only include `<ToastContainer />` to create toasts from outside `ChakraProvider`.
 
 > 🚨 If you're using a custom theme, you **must** pass it in the arguments to
 > `createStandaloneToast`. If you don't, the default theme will be applied,


### PR DESCRIPTION
Resolves confusion found in #7547

## 📝 Description
Currently, the docs don't accurately describe how to use `ToastContainer`: it sounds like you need to include `ToastContainer` in order to create toasts from outside React, but really, you only need to include it to create toasts outside of `ChakraProvider`.

## ⛳️ Current behavior (updates)
Docs for `createStandaloneToast` are incomplete.

## 🚀 New behavior
Updated the wording of the `createStandaloneToast` docs.

## 💣 Is this a breaking change (Yes/No):
No