### PR TITLE
fix : increase nav bar z index

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -151,7 +151,7 @@ function Header(props: HTMLChakraProps<'header'>) {
       transition='box-shadow 0.2s, background-color 0.2s'
       pos='sticky'
       top='0'
-      zIndex='3'
+      zIndex='11'
       bg='white'
       _dark={{ bg: 'gray.800' }}
       left='0'


### PR DESCRIPTION
Increase nav bar z index to avoid it getting covered by popover

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

> Popover's z index is higher than the nav bar's, and it blocked the nav bar when it is opened.

## ⛳️ Current behavior (updates)

>  Popover's z index is higher than the nav bar's, and it blocked the nav bar when it is opened.

## 🚀 New behavior

> Nav bar has a higher z index now, it would not get blocked when popover is opened.

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

No

## 📝 Additional Information
