### PR TITLE
Correct link for drawer docs

### DIFF
--- a/content/docs/components/drawer/usage.mdx
+++ b/content/docs/components/drawer/usage.mdx
@@ -2,7 +2,7 @@
 id: drawer
 category: overlay
 title: Drawer
-package: '@chakra-ui/modal'
+package: '@chakra-ui/drawer'
 description:
   The Drawer component is a panel that slides out from the edge of the screen.
   It can be useful when you need users to complete a task or view some details


### PR DESCRIPTION
## 📝 Description

the doc's link to the wrong source files. I'm assuming its because the package is set to modal and not to drawer.


## ⛳️ Current behavior (updates)

When clicking the doc link to the theme source of drawer it goes to modal.

## 🚀 New behavior

When clicking the doc link to the theme source of drawer it goes to drawer.


## 💣 Is this a breaking change (Yes/No):

no
