### PR TITLE
docs: fixed some React typos in Link usage.mdx

### DIFF
--- a/content/docs/components/link/usage.mdx
+++ b/content/docs/components/link/usage.mdx
@@ -40,9 +40,9 @@ import { ExternalLinkIcon } from '@chakra-ui/icons'
 
 ## Usage with Routing Library
 
-To use the `Link` with a routing library like Reach Router or React Router, all
+To use the `Link` with a routing library like React Router or React Router, all
 you need to do is pass the `as` prop. It'll replace the rendered `a` tag with
-Reach's `Link`.
+React's `Link`.
 
 ```jsx live=false
 import { Link as ReactRouterLink } from 'react-router-dom'


### PR DESCRIPTION
Fixed a few typos in the Link / React usage docs
