### PR TITLE
docs: add docs for usage of collapse

### DIFF
--- a/configs/search-meta.json
+++ b/configs/search-meta.json
@@ -56274,6 +56274,17 @@
     }
   },
   {
+    "content": "Changing transitions manually using motion props",
+    "id": "//docs/components/transitions/usage",
+    "type": "lvl4",
+    "url": "/docs/components/transitions/usage#changing-transitions-manually-using-motion-props",
+    "hierarchy": {
+      "lvl1": "Transitions",
+      "lvl2": "Changing the startingHeight",
+      "lvl3": null
+    }
+  },
+  {
     "id": "//docs/components/visually-hidden/props",
     "type": "lvl1",
     "url": "/docs/components/visually-hidden/props",

--- a/content/docs/components/transitions/usage.mdx
+++ b/content/docs/components/transitions/usage.mdx
@@ -182,3 +182,29 @@ function Example() {
   )
 }
 ```
+
+#### Changing transitions manually using motion props
+
+```jsx
+function CollapseEx() {
+  const { isOpen, onToggle } = useDisclosure()
+
+  return (
+    <>
+      <Button onClick={onToggle}>Click Me</Button>
+      <Collapse in={isOpen}  transition={{exit: {delay: 1}, enter: {duration: 0.5}}}>
+        <Box
+          p='40px'
+          color='white'
+          mt='4'
+          bg='teal.500'
+          rounded='md'
+          shadow='md'
+        >
+          <Lorem count={1} />
+        </Box>
+      </Collapse>
+    </>
+  )
+}
+```


### PR DESCRIPTION
## 📝 Description

Adds to the existing Collapse documentation. Adds the use of transition when trying to use motionProps on any elements using Collapse. The docs were not clear on what should I use to change the existing transition behavior.

## ⛳️ Current behavior (updates)

I searched a long time on  how to change the animation of *AccordionPanel*. Must be easy, it accepts motionProps. Let's see whats it's using under the hood. Bam, found *Collapse*. Now *Collapse* is supposed to support all motionProps. But it doesn't. Or it does it in a way that is not useful to me (or any otheer user stuck on it).

## 🚀 New behavior

> User can find the usage of transition to no longer be searching left and right.

## 📝 Additional Information

[Link to original answer](https://github.com/chakra-ui/chakra-ui/issues/1017)