### PR TITLE
Fix typo in color-mode.mdx

### DIFF
--- a/content/docs/styled-system/color-mode.mdx
+++ b/content/docs/styled-system/color-mode.mdx
@@ -436,4 +436,4 @@ In some cases, when you switch to dark mode and refresh the page, you might
 experience a quick flash of light mode before it switches correctly.
 
 This is a known issue and we're looking to fix it. If you have some ideas, feel
-free to share with us on Discord or Github.
+free to share with us on Discord or GitHub.


### PR DESCRIPTION
## 📝 Description

Changes "Github" to "GitHub"

## 💣 Is this a breaking change (Yes/No):

No
