### PR TITLE
fix: VersionSwitcher focus indicator

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -63,6 +63,7 @@ function HeaderContent() {
             width='auto'
             flexShrink={0}
             display={{ base: 'none', md: 'flex' }}
+            marginRight='var(--chakra-space-5)'
           />
           <HStack spacing='5' display={{ base: 'none', md: 'flex' }}>
             <Link

--- a/src/components/version-switcher.tsx
+++ b/src/components/version-switcher.tsx
@@ -21,7 +21,7 @@ function VersionSwitcher(props: SelectProps) {
   return (
     <Select
       marginEnd='0rem'
-      variant='unstyled'
+      variant='outline'
       fontWeight='semibold'
       color='gray.600'
       _dark={{ color: 'whiteAlpha.600' }}


### PR DESCRIPTION
Closes #1667 

## 📝 Description

The `VersionSwitcher` component was missing a focus indicator with keyboard navigation.

## ⛳️ Current behavior (updates)

- `VersionSwitcher` does not show an outline
- `VersionSwitcher` has no visible focus indicator when focused
- `VersionSwitcher` has no horizontal space after it

## 🚀 New behavior

- `VersionSwitcher` always shows an outline
- `VersionSwitcher` shows a visible focus indicator when focused
- `VersionSwitcher` has horizontal space after it

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

This change helps fix a violation of [WCAG 2.1 Success Criterion 2.4.7 Focus Visible (Level AA)](https://www.w3.org/TR/WCAG21/#focus-visible): "Any keyboard operable user interface has a mode of operation where the keyboard focus indicator is visible."