### PR TITLE
refactor: regenerate search meta with v2.8.2 changelog

### DIFF
--- a/configs/search-meta.json
+++ b/configs/search-meta.json
@@ -49028,6 +49028,508 @@
     }
   },
   {
+    "content": "Version 2.8.2",
+    "id": "//changelog/v2.8.2",
+    "type": "lvl1",
+    "url": "/changelog/v2.8.2",
+    "hierarchy": { "lvl1": "Version 2.8.2" }
+  },
+  {
+    "content": "@chakra-ui/form-control@2.2.0",
+    "id": "//changelog/v2.8.2",
+    "type": "lvl2",
+    "url": "/changelog/v2.8.2#chakra-uiform-control220",
+    "hierarchy": {
+      "lvl1": "Version 2.8.2",
+      "lvl2": "@chakra-ui/form-control@2.2.0",
+      "lvl3": null
+    }
+  },
+  {
+    "content": "Minor Changes",
+    "id": "//changelog/v2.8.2",
+    "type": "lvl3",
+    "url": "/changelog/v2.8.2#minor-changes",
+    "hierarchy": {
+      "lvl1": "Version 2.8.2",
+      "lvl2": "@chakra-ui/form-control@2.2.0",
+      "lvl3": "Minor Changes"
+    }
+  },
+  {
+    "content": "Patch Changes",
+    "id": "//changelog/v2.8.2",
+    "type": "lvl3",
+    "url": "/changelog/v2.8.2#patch-changes",
+    "hierarchy": {
+      "lvl1": "Version 2.8.2",
+      "lvl2": "Minor Changes",
+      "lvl3": "Patch Changes"
+    }
+  },
+  {
+    "content": "@chakra-ui/next-js@2.2.0",
+    "id": "//changelog/v2.8.2",
+    "type": "lvl2",
+    "url": "/changelog/v2.8.2#chakra-uinext-js220",
+    "hierarchy": {
+      "lvl1": "Version 2.8.2",
+      "lvl2": "@chakra-ui/next-js@2.2.0",
+      "lvl3": null
+    }
+  },
+  {
+    "content": "Minor Changes",
+    "id": "//changelog/v2.8.2",
+    "type": "lvl3",
+    "url": "/changelog/v2.8.2#minor-changes-1",
+    "hierarchy": {
+      "lvl1": "Version 2.8.2",
+      "lvl2": "@chakra-ui/next-js@2.2.0",
+      "lvl3": "Minor Changes"
+    }
+  },
+  {
+    "content": "@chakra-ui/storybook-addon@5.1.0",
+    "id": "//changelog/v2.8.2",
+    "type": "lvl2",
+    "url": "/changelog/v2.8.2#chakra-uistorybook-addon510",
+    "hierarchy": {
+      "lvl1": "Version 2.8.2",
+      "lvl2": "@chakra-ui/storybook-addon@5.1.0",
+      "lvl3": null
+    }
+  },
+  {
+    "content": "Minor Changes",
+    "id": "//changelog/v2.8.2",
+    "type": "lvl3",
+    "url": "/changelog/v2.8.2#minor-changes-2",
+    "hierarchy": {
+      "lvl1": "Version 2.8.2",
+      "lvl2": "@chakra-ui/storybook-addon@5.1.0",
+      "lvl3": "Minor Changes"
+    }
+  },
+  {
+    "content": "@chakra-ui/alert@2.2.2",
+    "id": "//changelog/v2.8.2",
+    "type": "lvl2",
+    "url": "/changelog/v2.8.2#chakra-uialert222",
+    "hierarchy": {
+      "lvl1": "Version 2.8.2",
+      "lvl2": "@chakra-ui/alert@2.2.2",
+      "lvl3": null
+    }
+  },
+  {
+    "content": "Patch Changes",
+    "id": "//changelog/v2.8.2",
+    "type": "lvl3",
+    "url": "/changelog/v2.8.2#patch-changes-1",
+    "hierarchy": {
+      "lvl1": "Version 2.8.2",
+      "lvl2": "@chakra-ui/alert@2.2.2",
+      "lvl3": "Patch Changes"
+    }
+  },
+  {
+    "content": "@chakra-ui/anatomy@2.2.2",
+    "id": "//changelog/v2.8.2",
+    "type": "lvl2",
+    "url": "/changelog/v2.8.2#chakra-uianatomy222",
+    "hierarchy": {
+      "lvl1": "Version 2.8.2",
+      "lvl2": "@chakra-ui/anatomy@2.2.2",
+      "lvl3": null
+    }
+  },
+  {
+    "content": "Patch Changes",
+    "id": "//changelog/v2.8.2",
+    "type": "lvl3",
+    "url": "/changelog/v2.8.2#patch-changes-2",
+    "hierarchy": {
+      "lvl1": "Version 2.8.2",
+      "lvl2": "@chakra-ui/anatomy@2.2.2",
+      "lvl3": "Patch Changes"
+    }
+  },
+  {
+    "content": "@chakra-ui/checkbox@2.3.2",
+    "id": "//changelog/v2.8.2",
+    "type": "lvl2",
+    "url": "/changelog/v2.8.2#chakra-uicheckbox232",
+    "hierarchy": {
+      "lvl1": "Version 2.8.2",
+      "lvl2": "@chakra-ui/checkbox@2.3.2",
+      "lvl3": null
+    }
+  },
+  {
+    "content": "Patch Changes",
+    "id": "//changelog/v2.8.2",
+    "type": "lvl3",
+    "url": "/changelog/v2.8.2#patch-changes-3",
+    "hierarchy": {
+      "lvl1": "Version 2.8.2",
+      "lvl2": "@chakra-ui/checkbox@2.3.2",
+      "lvl3": "Patch Changes"
+    }
+  },
+  {
+    "content": "@chakra-ui/input@2.1.2",
+    "id": "//changelog/v2.8.2",
+    "type": "lvl2",
+    "url": "/changelog/v2.8.2#chakra-uiinput212",
+    "hierarchy": {
+      "lvl1": "Version 2.8.2",
+      "lvl2": "@chakra-ui/input@2.1.2",
+      "lvl3": null
+    }
+  },
+  {
+    "content": "Patch Changes",
+    "id": "//changelog/v2.8.2",
+    "type": "lvl3",
+    "url": "/changelog/v2.8.2#patch-changes-4",
+    "hierarchy": {
+      "lvl1": "Version 2.8.2",
+      "lvl2": "@chakra-ui/input@2.1.2",
+      "lvl3": "Patch Changes"
+    }
+  },
+  {
+    "content": "@chakra-ui/number-input@2.1.2",
+    "id": "//changelog/v2.8.2",
+    "type": "lvl2",
+    "url": "/changelog/v2.8.2#chakra-uinumber-input212",
+    "hierarchy": {
+      "lvl1": "Version 2.8.2",
+      "lvl2": "@chakra-ui/number-input@2.1.2",
+      "lvl3": null
+    }
+  },
+  {
+    "content": "Patch Changes",
+    "id": "//changelog/v2.8.2",
+    "type": "lvl3",
+    "url": "/changelog/v2.8.2#patch-changes-5",
+    "hierarchy": {
+      "lvl1": "Version 2.8.2",
+      "lvl2": "@chakra-ui/number-input@2.1.2",
+      "lvl3": "Patch Changes"
+    }
+  },
+  {
+    "content": "@chakra-ui/provider@2.4.2",
+    "id": "//changelog/v2.8.2",
+    "type": "lvl2",
+    "url": "/changelog/v2.8.2#chakra-uiprovider242",
+    "hierarchy": {
+      "lvl1": "Version 2.8.2",
+      "lvl2": "@chakra-ui/provider@2.4.2",
+      "lvl3": null
+    }
+  },
+  {
+    "content": "Patch Changes",
+    "id": "//changelog/v2.8.2",
+    "type": "lvl3",
+    "url": "/changelog/v2.8.2#patch-changes-6",
+    "hierarchy": {
+      "lvl1": "Version 2.8.2",
+      "lvl2": "@chakra-ui/provider@2.4.2",
+      "lvl3": "Patch Changes"
+    }
+  },
+  {
+    "content": "@chakra-ui/radio@2.1.2",
+    "id": "//changelog/v2.8.2",
+    "type": "lvl2",
+    "url": "/changelog/v2.8.2#chakra-uiradio212",
+    "hierarchy": {
+      "lvl1": "Version 2.8.2",
+      "lvl2": "@chakra-ui/radio@2.1.2",
+      "lvl3": null
+    }
+  },
+  {
+    "content": "Patch Changes",
+    "id": "//changelog/v2.8.2",
+    "type": "lvl3",
+    "url": "/changelog/v2.8.2#patch-changes-7",
+    "hierarchy": {
+      "lvl1": "Version 2.8.2",
+      "lvl2": "@chakra-ui/radio@2.1.2",
+      "lvl3": "Patch Changes"
+    }
+  },
+  {
+    "content": "@chakra-ui/react@2.8.2",
+    "id": "//changelog/v2.8.2",
+    "type": "lvl2",
+    "url": "/changelog/v2.8.2#chakra-uireact282",
+    "hierarchy": {
+      "lvl1": "Version 2.8.2",
+      "lvl2": "@chakra-ui/react@2.8.2",
+      "lvl3": null
+    }
+  },
+  {
+    "content": "Patch Changes",
+    "id": "//changelog/v2.8.2",
+    "type": "lvl3",
+    "url": "/changelog/v2.8.2#patch-changes-8",
+    "hierarchy": {
+      "lvl1": "Version 2.8.2",
+      "lvl2": "@chakra-ui/react@2.8.2",
+      "lvl3": "Patch Changes"
+    }
+  },
+  {
+    "content": "@chakra-ui/select@2.1.2",
+    "id": "//changelog/v2.8.2",
+    "type": "lvl2",
+    "url": "/changelog/v2.8.2#chakra-uiselect212",
+    "hierarchy": {
+      "lvl1": "Version 2.8.2",
+      "lvl2": "@chakra-ui/select@2.1.2",
+      "lvl3": null
+    }
+  },
+  {
+    "content": "Patch Changes",
+    "id": "//changelog/v2.8.2",
+    "type": "lvl3",
+    "url": "/changelog/v2.8.2#patch-changes-9",
+    "hierarchy": {
+      "lvl1": "Version 2.8.2",
+      "lvl2": "@chakra-ui/select@2.1.2",
+      "lvl3": "Patch Changes"
+    }
+  },
+  {
+    "content": "@chakra-ui/switch@2.1.2",
+    "id": "//changelog/v2.8.2",
+    "type": "lvl2",
+    "url": "/changelog/v2.8.2#chakra-uiswitch212",
+    "hierarchy": {
+      "lvl1": "Version 2.8.2",
+      "lvl2": "@chakra-ui/switch@2.1.2",
+      "lvl3": null
+    }
+  },
+  {
+    "content": "Patch Changes",
+    "id": "//changelog/v2.8.2",
+    "type": "lvl3",
+    "url": "/changelog/v2.8.2#patch-changes-10",
+    "hierarchy": {
+      "lvl1": "Version 2.8.2",
+      "lvl2": "@chakra-ui/switch@2.1.2",
+      "lvl3": "Patch Changes"
+    }
+  },
+  {
+    "content": "@chakra-ui/textarea@2.1.2",
+    "id": "//changelog/v2.8.2",
+    "type": "lvl2",
+    "url": "/changelog/v2.8.2#chakra-uitextarea212",
+    "hierarchy": {
+      "lvl1": "Version 2.8.2",
+      "lvl2": "@chakra-ui/textarea@2.1.2",
+      "lvl3": null
+    }
+  },
+  {
+    "content": "Patch Changes",
+    "id": "//changelog/v2.8.2",
+    "type": "lvl3",
+    "url": "/changelog/v2.8.2#patch-changes-11",
+    "hierarchy": {
+      "lvl1": "Version 2.8.2",
+      "lvl2": "@chakra-ui/textarea@2.1.2",
+      "lvl3": "Patch Changes"
+    }
+  },
+  {
+    "content": "@chakra-ui/theme@3.3.1",
+    "id": "//changelog/v2.8.2",
+    "type": "lvl2",
+    "url": "/changelog/v2.8.2#chakra-uitheme331",
+    "hierarchy": {
+      "lvl1": "Version 2.8.2",
+      "lvl2": "@chakra-ui/theme@3.3.1",
+      "lvl3": null
+    }
+  },
+  {
+    "content": "Patch Changes",
+    "id": "//changelog/v2.8.2",
+    "type": "lvl3",
+    "url": "/changelog/v2.8.2#patch-changes-12",
+    "hierarchy": {
+      "lvl1": "Version 2.8.2",
+      "lvl2": "@chakra-ui/theme@3.3.1",
+      "lvl3": "Patch Changes"
+    }
+  },
+  {
+    "content": "@chakra-ui/theme-tools@2.1.2",
+    "id": "//changelog/v2.8.2",
+    "type": "lvl2",
+    "url": "/changelog/v2.8.2#chakra-uitheme-tools212",
+    "hierarchy": {
+      "lvl1": "Version 2.8.2",
+      "lvl2": "@chakra-ui/theme-tools@2.1.2",
+      "lvl3": null
+    }
+  },
+  {
+    "content": "Patch Changes",
+    "id": "//changelog/v2.8.2",
+    "type": "lvl3",
+    "url": "/changelog/v2.8.2#patch-changes-13",
+    "hierarchy": {
+      "lvl1": "Version 2.8.2",
+      "lvl2": "@chakra-ui/theme-tools@2.1.2",
+      "lvl3": "Patch Changes"
+    }
+  },
+  {
+    "content": "@chakra-ui/toast@7.0.2",
+    "id": "//changelog/v2.8.2",
+    "type": "lvl2",
+    "url": "/changelog/v2.8.2#chakra-uitoast702",
+    "hierarchy": {
+      "lvl1": "Version 2.8.2",
+      "lvl2": "@chakra-ui/toast@7.0.2",
+      "lvl3": null
+    }
+  },
+  {
+    "content": "Patch Changes",
+    "id": "//changelog/v2.8.2",
+    "type": "lvl3",
+    "url": "/changelog/v2.8.2#patch-changes-14",
+    "hierarchy": {
+      "lvl1": "Version 2.8.2",
+      "lvl2": "@chakra-ui/toast@7.0.2",
+      "lvl3": "Patch Changes"
+    }
+  },
+  {
+    "content": "@chakra-ui/tooltip@2.3.1",
+    "id": "//changelog/v2.8.2",
+    "type": "lvl2",
+    "url": "/changelog/v2.8.2#chakra-uitooltip231",
+    "hierarchy": {
+      "lvl1": "Version 2.8.2",
+      "lvl2": "@chakra-ui/tooltip@2.3.1",
+      "lvl3": null
+    }
+  },
+  {
+    "content": "Patch Changes",
+    "id": "//changelog/v2.8.2",
+    "type": "lvl3",
+    "url": "/changelog/v2.8.2#patch-changes-15",
+    "hierarchy": {
+      "lvl1": "Version 2.8.2",
+      "lvl2": "@chakra-ui/tooltip@2.3.1",
+      "lvl3": "Patch Changes"
+    }
+  },
+  {
+    "content": "@chakra-ui/styled-system@2.9.2",
+    "id": "//changelog/v2.8.2",
+    "type": "lvl2",
+    "url": "/changelog/v2.8.2#chakra-uistyled-system292",
+    "hierarchy": {
+      "lvl1": "Version 2.8.2",
+      "lvl2": "@chakra-ui/styled-system@2.9.2",
+      "lvl3": null
+    }
+  },
+  {
+    "content": "Patch Changes",
+    "id": "//changelog/v2.8.2",
+    "type": "lvl3",
+    "url": "/changelog/v2.8.2#patch-changes-16",
+    "hierarchy": {
+      "lvl1": "Version 2.8.2",
+      "lvl2": "@chakra-ui/styled-system@2.9.2",
+      "lvl3": "Patch Changes"
+    }
+  },
+  {
+    "content": "@chakra-ui/system@2.6.2",
+    "id": "//changelog/v2.8.2",
+    "type": "lvl2",
+    "url": "/changelog/v2.8.2#chakra-uisystem262",
+    "hierarchy": {
+      "lvl1": "Version 2.8.2",
+      "lvl2": "@chakra-ui/system@2.6.2",
+      "lvl3": null
+    }
+  },
+  {
+    "content": "Patch Changes",
+    "id": "//changelog/v2.8.2",
+    "type": "lvl3",
+    "url": "/changelog/v2.8.2#patch-changes-17",
+    "hierarchy": {
+      "lvl1": "Version 2.8.2",
+      "lvl2": "@chakra-ui/system@2.6.2",
+      "lvl3": "Patch Changes"
+    }
+  },
+  {
+    "content": "@chakra-ui/theme-utils@2.0.21",
+    "id": "//changelog/v2.8.2",
+    "type": "lvl2",
+    "url": "/changelog/v2.8.2#chakra-uitheme-utils2021",
+    "hierarchy": {
+      "lvl1": "Version 2.8.2",
+      "lvl2": "@chakra-ui/theme-utils@2.0.21",
+      "lvl3": null
+    }
+  },
+  {
+    "content": "Patch Changes",
+    "id": "//changelog/v2.8.2",
+    "type": "lvl3",
+    "url": "/changelog/v2.8.2#patch-changes-18",
+    "hierarchy": {
+      "lvl1": "Version 2.8.2",
+      "lvl2": "@chakra-ui/theme-utils@2.0.21",
+      "lvl3": "Patch Changes"
+    }
+  },
+  {
+    "content": "@chakra-ui/test-utils@2.0.45",
+    "id": "//changelog/v2.8.2",
+    "type": "lvl2",
+    "url": "/changelog/v2.8.2#chakra-uitest-utils2045",
+    "hierarchy": {
+      "lvl1": "Version 2.8.2",
+      "lvl2": "@chakra-ui/test-utils@2.0.45",
+      "lvl3": null
+    }
+  },
+  {
+    "content": "Patch Changes",
+    "id": "//changelog/v2.8.2",
+    "type": "lvl3",
+    "url": "/changelog/v2.8.2#patch-changes-19",
+    "hierarchy": {
+      "lvl1": "Version 2.8.2",
+      "lvl2": "@chakra-ui/test-utils@2.0.45",
+      "lvl3": "Patch Changes"
+    }
+  },
+  {
     "content": "Advanced Formik integration",
     "id": "//community/recipes/advanced-formik-integration",
     "type": "lvl1",


### PR DESCRIPTION
Regenerate the search meta to includes links to the changelog for `v2.8.2` which is currently not present in prod when using the search bar.