### PR TITLE
docs: Fix font usage in Next.js (App)

### DIFF
--- a/content/getting-started/nextjs-app-guide.mdx
+++ b/content/getting-started/nextjs-app-guide.mdx
@@ -119,7 +119,7 @@ export default function RootLayout({
   children: React.ReactNode,
 }) {
   return (
-    <html lang='en' className={fonts.rubik.className}>
+    <html lang='en' className={fonts.rubik.variable}>
       <body>
         <Providers>{children}</Providers>
       </body>


### PR DESCRIPTION
## 📝 Description

In the "Next.js (App)" section, change `fonts.rubik.className` to `fonts.rubik.variable` so that it works as expected.

## ⛳️ Current behavior (updates)

The current documentation uses `fonts.rubik.className` this makes the font apply to the entire site. This way, if we import more than one font, the entire website will be seen with the last imported font.

```html
<html lang='en' className={fonts.rubik.className}>
``` 

## 🚀 New behavior

After merging this PR, the code example in the documentation will be fixed by changing to `fonts.rubik.variable`, this allows us to have control in `theme.ts` of the font that is used as shown in the documentation example.

```html
<html lang='en' className={fonts.rubik.variable}>
``` 

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

This change is a minor fix to the documentation and does not affect the functionality of the Chakra UI. Ensures that the example works as expected.