### PR TITLE
Update Input Component docs to not pass children as props, but as nodes

### DIFF
--- a/content/docs/components/input/usage.mdx
+++ b/content/docs/components/input/usage.mdx
@@ -71,15 +71,21 @@ component. Chakra UI exports `InputGroup`, `InputLeftAddon`, and
 ```jsx
 <Stack spacing={4}>
   <InputGroup>
-    <InputLeftAddon children='+234' />
+    <InputLeftAddon>
+      +234
+    </InputLeftAddon>
     <Input type='tel' placeholder='phone number' />
   </InputGroup>
 
   {/* If you add the size prop to `InputGroup`, it'll pass it to all its children. */}
   <InputGroup size='sm'>
-    <InputLeftAddon children='https://' />
+    <InputLeftAddon>
+      https://
+    </InputLeftAddon>
     <Input placeholder='mysite' />
-    <InputRightAddon children='.com' />
+    <InputRightAddon>
+      .com
+    </InputRightAddon>
   </InputGroup>
 </Stack>
 ```
@@ -108,8 +114,9 @@ focused the input.
       pointerEvents='none'
       color='gray.300'
       fontSize='1.2em'
-      children='$'
-    />
+    >
+      $
+    </InputLeftElement>
     <Input placeholder='Enter amount' />
     <InputRightElement>
       <CheckIcon color='green.500' />


### PR DESCRIPTION
## 📝 Description

Update usage.mdx ([https://chakra-ui.com/docs/components/input](https://chakra-ui.com/docs/components/input)) to not use the children prop, but express the children as child node.

## ⛳️ Current behavior (updates)

In the examples, some string children are defined through a prop.

## 🚀 New behavior

In this proposal, the string children are passed as child nodes in the dom tree for improved clarity, instead of being passed as a prop.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

[https://chakra-ui.com/docs/components/input](https://chakra-ui.com/docs/components/input)
