### PR TITLE
docs: Remove unnecessary line of code

### DIFF
--- a/content/docs/components/slider/usage.mdx
+++ b/content/docs/components/slider/usage.mdx
@@ -98,7 +98,6 @@ accomplished using the `step` prop.
 ```jsx
 <Slider defaultValue={60} min={0} max={300} step={30}>
   <SliderTrack bg='red.100'>
-    <Box position='relative' right={10} />
     <SliderFilledTrack bg='tomato' />
   </SliderTrack>
   <SliderThumb boxSize={6} />


### PR DESCRIPTION
## 📝 Description

Remove unnecessary line of code from `slider` documentation

## ⛳️ Current behavior (updates)

We have a working slider, but it contains a line that does not affect its operation and is unnecessary

## 🚀 New behavior

We have a working slider without unnecessary code

## 💣 Is this a breaking change (Yes/No):

No
