### PR TITLE
Update nextjs-app-guide.mdx to add the cssVarsRoot to the provider

### DIFF
--- a/content/getting-started/nextjs-app-guide.mdx
+++ b/content/getting-started/nextjs-app-guide.mdx
@@ -38,7 +38,7 @@ experience when using Chakra UI in the app directory.
 import { ChakraProvider } from '@chakra-ui/react'
 
 export function Providers({ children }: { children: React.ReactNode }) {
-  return <ChakraProvider>{children}</ChakraProvider>
+  return <ChakraProvider cssVarsRoot>{children}</ChakraProvider>
 }
 ```
 


### PR DESCRIPTION
Without it there'll be a typescript error in my NextJs layout.tsx in my app directory:

Property 'cssVarsRoot' is missing in type '{ children: ReactNode; }' but required in type 'ChakraProviderProps'

and adding cssVarsRoot to the provider fixed the issue.